### PR TITLE
T21 — SwiftPM package for the helper + Linux CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,26 @@ on:
   pull_request:
 
 jobs:
-  core-linux:
+  linux:
     runs-on: ubuntu-24.04-arm
     container: swift:6.1
     steps:
       - uses: actions/checkout@v4
+      # Root package = the headless side (helper executable + Core by path).
+      # A Linux-only compile error in Helper/ or Core/ fails here.
+      - name: Build helper (root SwiftPM package)
+        run: swift build
+      - name: Run root package tests
+        run: swift test
+      - name: Helper lists all subcommands
+        run: |
+          OUT=$(.build/debug/restic-station-helper --help)
+          echo "$OUT"
+          for sub in tick run-set init-secondary restore probe-repo unlock fda-check version; do
+            echo "$OUT" | grep -qE "^  $sub( |$)" || { echo "missing subcommand: $sub"; exit 1; }
+          done
+      # SwiftPM does not run a path dependency's test targets, so Core's
+      # suite still needs its own invocation.
       - name: Run Core unit tests
         run: swift test --package-path Core
 

--- a/Helper/Tests/HelperTests/SubcommandRegistrationTests.swift
+++ b/Helper/Tests/HelperTests/SubcommandRegistrationTests.swift
@@ -1,0 +1,32 @@
+import Testing
+
+@testable import restic_station_helper
+
+/// The root SwiftPM package's test target exists so `swift test` at the repo
+/// root has something to run (T21) — SwiftPM does not run a path
+/// dependency's test targets, so Core's suite is still invoked separately
+/// via `swift test --package-path Core`.
+///
+/// This asserts the verification the T21 issue asks for — "the helper lists
+/// all subcommands" — off the command tree rather than by shelling out to
+/// the built binary, so it behaves identically on macOS and Linux.
+@Test func exposesEverySubcommand() {
+    // Spelled as an explicit closure with an explicit result type: the
+    // key-path form `map(\.configuration.commandName)` over an existential
+    // metatype crashes SILGen in Swift 6.3.3.
+    let names: [String?] = HelperMain.configuration.subcommands.map { subcommand in
+        subcommand.configuration.commandName
+    }
+    #expect(
+        names == [
+            "tick",
+            "run-set",
+            "init-secondary",
+            "restore",
+            "probe-repo",
+            "unlock",
+            "fda-check",
+            "version",
+        ]
+    )
+}

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "b824a4624afd85215c14bb629b6f152dbe4e89bc944ddb5f8b7f0df17286b530",
+  "pins" : [
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,47 @@
+// swift-tools-version:6.0
+import PackageDescription
+
+// Root SwiftPM package for the headless side of Restic Station.
+//
+// It exists so `restic-station-helper` can be built and tested with plain
+// `swift build` / `swift test` on Linux (M5). It deliberately does NOT
+// absorb `Core/Package.swift`: `Core` stays its own package so the existing
+// `swift test --package-path Core` invocation and the `project.yml`
+// XcodeGen package reference (`ResticStationCore: path: Core`) keep working
+// byte-for-byte. No source file moves for the same reason — the helper
+// target points straight at `Helper/Sources`, the same directory the
+// XcodeGen `restic-station-helper` tool target uses.
+//
+// `Restic Station.app` (`App/Sources`, SwiftUI) is macOS-only and is
+// intentionally absent from this package.
+let package = Package(
+    name: "restic-station",
+    // Apple-platform minimum deployment target only; SwiftPM ignores this
+    // entirely on Linux. It must match `Core/Package.swift` (and
+    // `project.yml`'s `deploymentTarget.macOS: "14.0"`), otherwise SwiftPM
+    // refuses to link a macOS 10.13 executable against a macOS 14 library.
+    platforms: [
+        .macOS(.v14)
+    ],
+    dependencies: [
+        .package(path: "Core"),
+        // Same lower bound as `project.yml` pins, so the Xcode build and the
+        // SwiftPM build resolve to the same argument-parser version.
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "restic-station-helper",
+            dependencies: [
+                .product(name: "ResticStationCore", package: "Core"),
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            ],
+            path: "Helper/Sources"
+        ),
+        .testTarget(
+            name: "HelperTests",
+            dependencies: ["restic-station-helper"],
+            path: "Helper/Tests/HelperTests"
+        ),
+    ]
+)


### PR DESCRIPTION
## What changed

`Helper/` was not a SwiftPM target — it existed only as an XcodeGen `tool` target in `project.yml`, so there was no way to `swift build` the helper at all. This adds the missing build system entry point and proves it on Linux in CI.

- **`Package.swift` (new, repo root)** — declares `.package(path: "Core")` and `apple/swift-argument-parser` `from: "1.3.0"` (the same bound `project.yml` pins), plus an executable target `restic-station-helper` with `path: "Helper/Sources"`. No source files moved. `Core/Package.swift` and `project.yml` are untouched, so `swift test --package-path Core` and the XcodeGen/Xcode app build keep working byte-for-byte.
- **`Package.resolved` (new)** — committed so CI resolves the same argument-parser revision.
- **`Helper/Tests/HelperTests/SubcommandRegistrationTests.swift` (new)** — one test asserting the helper's subcommand list. Needed because SwiftPM does **not** run a path dependency's test targets: without a test target of its own, root `swift test` fails outright with `error: no tests found; create a target in the 'Tests' directory`. This also encodes the issue's stated verification ("`--help` lists all subcommands") in a form that runs identically on macOS and Linux.
- **`.github/workflows/ci.yml`** — the existing `core-linux` job is renamed `linux` and extended. It already ran on `ubuntu-24.04-arm` / `container: swift:6.1`, and Core already built and tested on Linux there; that container and the Core step are kept as-is (**not** downgraded to `swift:6.0` as the issue text suggested). It now additionally runs `swift build`, `swift test`, and a `--help` subcommand check for the root package. The `macos` job is untouched.
- **`.gitignore`** — no change needed, `.build/` was already present.

### One deliberate departure from the issue text

The issue says to add a *new* job with `runs-on: ubuntu-latest`, `container: swift:6.0`. `.github/workflows/ci.yml` already had a `core-linux` job on `ubuntu-24.04-arm` / `swift:6.1`. Adding a second, older, x86 Linux job would have been redundant, so the existing job was extended instead. Same effect, one job.

## `#if os(...)` gates added

**None.** The issue anticipated needing to gate ten test files; that turned out to be unnecessary, and I did not add gates for their own sake.

- Core's Linux support already landed: `FileLock`, `StateStore`, `RunStore`, `LogWriter`, `ConfigStore` and `ProcessRunning` carry `#if canImport(Darwin) / #elseif canImport(Glibc)` shims, `AppPathsTests` and `RunStoreTests` carry the matching test-side shims, and `DefaultProcessRunnerTests` already has an `#if os(macOS)` around its SIGINT-timing assertion. The `core-linux` job has been green on `main`, i.e. all 308 Core tests already pass on Linux.
- The other files the issue listed do not need gating on inspection: `KeychainClientTests` never executes `/usr/bin/security` (it asserts argv against `FakeProcessRunner`); `KeychainSmokeTests` is already `.enabled(if: RESTIC_STATION_KEYCHAIN_SMOKE == "1")` and does not run in CI; `ConfigDiffTests`/`ModelsTests` use `/opt/homebrew/bin/restic` only as an opaque config *string*, never as a path to execute; `BackupEngineTests`/`ReachabilityTests`/`ResticRunnerTests` run against fakes.
- `Helper/` needed no gates either — it imports only `ArgumentParser`, `Foundation` and `ResticStationCore`.

The only new conditional-ish thing in the diff is a comment, not a gate: the test spells its `map` as an explicit closure because the key-path form `map(\.configuration.commandName)` over an existential metatype crashes SILGen in Swift 6.3.3.

## Left wrong-but-compiling on Linux (per the issue's "Out of scope")

`AppPaths.default()` still returns `~/Library/Application Support/ResticStation` on Linux, and `AppPathsTests` still asserts that suffix on Linux. That is T22's decision to make, not this task's. `KeychainClient` still shells out to `/usr/bin/security` unconditionally — T23. Neither is touched here.

## Acceptance criteria

| Criterion | Status |
|---|---|
| Root `Package.swift` builds `restic-station-helper` via `swift build` on macOS | **Verified locally** (Apple Swift 6.3.3) |
| …and on Linux | **Verified in CI** (`linux` job) |
| `swift test` green on Ubuntu; no test deleted, gates name their removing task | **Verified in CI** — no gates added, no tests deleted or disabled |
| Existing Xcode app + helper build unchanged | **Verified locally**: `./scripts/bootstrap.sh && xcodebuild -scheme "Restic Station" build CODE_SIGNING_ALLOWED=NO` succeeds; `project.yml` has zero diff. Also **verified in CI** by the untouched `macos` job |
| `swift test --package-path Core` does not regress | **Verified locally** (308 tests, 52 suites) and **in CI** |
| CI has a Linux job that fails on a Linux-only compile error | **Verified in CI** — `swift build` at root now compiles `Helper/Sources` on Linux, which nothing did before |
| `.build/debug/restic-station-helper --help` lists all subcommands on Linux | **Verified in CI** — explicit grep step over all eight subcommands |

Not verified: nothing was run against a real Linux toolchain locally (this is a macOS machine with no container runtime), so every Linux claim above rests on the CI run attached to this PR rather than on a local reproduction.

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)
