### PR TITLE
T22 — Portable AppPaths (XDG on Linux)

### DIFF
--- a/Core/Sources/ResticStationCore/Config/AppPaths.swift
+++ b/Core/Sources/ResticStationCore/Config/AppPaths.swift
@@ -3,9 +3,18 @@ import Foundation
 /// Single source of truth for every runtime path Restic Station reads or
 /// writes. Never hard-code a path elsewhere — go through `AppPaths`.
 ///
-/// `root` defaults to `~/Library/Application Support/ResticStation` and is
-/// overridable via `init(root:)` and via the `RESTIC_STATION_DATA_DIR`
-/// environment variable (used by tests and `scripts/integration-test.sh`).
+/// `root` is platform-dependent:
+/// - macOS: `~/Library/Application Support/ResticStation`
+/// - Linux: `$XDG_STATE_HOME/restic-station`, falling back to
+///   `~/.local/state/restic-station`
+///
+/// It is overridable via `init(root:)` and via the `RESTIC_STATION_DATA_DIR`
+/// environment variable (used by tests and `scripts/integration-test.sh`),
+/// which takes precedence on both platforms.
+///
+/// **Everything below `root` is byte-identical across platforms** — only
+/// `root` and `resticCacheDir` branch on the OS. `config export`/`import`
+/// and rsync-ing a data directory between hosts depend on this.
 ///
 /// See `docs/architecture.md` §AppPaths for the full table this mirrors.
 public struct AppPaths: Equatable, Sendable {
@@ -16,17 +25,45 @@ public struct AppPaths: Equatable, Sendable {
     }
 
     /// Resolves the root from `RESTIC_STATION_DATA_DIR` if set (non-empty),
-    /// else `~/Library/Application Support/ResticStation`.
+    /// else the platform default: `~/Library/Application Support/ResticStation`
+    /// on macOS, `$XDG_STATE_HOME/restic-station` (or
+    /// `~/.local/state/restic-station`) on Linux.
     public static func `default`() -> AppPaths {
         if let override = ProcessInfo.processInfo.environment["RESTIC_STATION_DATA_DIR"], !override.isEmpty {
             return AppPaths(root: URL(fileURLWithPath: override, isDirectory: true))
         }
+        #if os(Linux)
+        return AppPaths(root: xdgBaseDirectory(
+            variable: "XDG_STATE_HOME",
+            fallbackHomeRelativeComponents: [".local", "state"]
+        ).appendingPathComponent("restic-station", isDirectory: true))
+        #else
         let appSupport = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent("Library", isDirectory: true)
             .appendingPathComponent("Application Support", isDirectory: true)
             .appendingPathComponent("ResticStation", isDirectory: true)
         return AppPaths(root: appSupport)
+        #endif
     }
+
+    #if os(Linux)
+    /// Resolves an XDG base directory per the XDG Base Directory Specification:
+    /// the environment variable is honoured only when set, non-empty, **and**
+    /// an absolute path; anything else falls back to the home-relative default
+    /// as if the variable were unset.
+    static func xdgBaseDirectory(variable: String, fallbackHomeRelativeComponents: [String]) -> URL {
+        if let value = ProcessInfo.processInfo.environment[variable],
+           !value.isEmpty,
+           value.hasPrefix("/") {
+            return URL(fileURLWithPath: value, isDirectory: true)
+        }
+        var url = FileManager.default.homeDirectoryForCurrentUser
+        for component in fallbackHomeRelativeComponents {
+            url = url.appendingPathComponent(component, isDirectory: true)
+        }
+        return url
+    }
+    #endif
 
     // MARK: - config.json
 
@@ -105,6 +142,11 @@ public struct AppPaths: Equatable, Sendable {
     // MARK: - mounts/ (docs/restic-cli.md §mount)
 
     /// `mounts/<destId>/` — `restic mount` mountpoint for browsing a repo.
+    ///
+    /// The path is defined on every platform (it is `root`-relative like all
+    /// the others), but mounting is macOS-only in practice: `restic mount`
+    /// needs macFUSE there and FUSE on Linux, which a headless host generally
+    /// does not have.
     public func mountsDir(destId: UUID) -> URL {
         root.appendingPathComponent("mounts", isDirectory: true)
             .appendingPathComponent(destId.uuidString, isDirectory: true)
@@ -112,16 +154,25 @@ public struct AppPaths: Equatable, Sendable {
 
     // MARK: - restic cache
 
-    /// restic's cache, redirected via `RESTIC_CACHE_DIR`. Fixed at
-    /// `~/Library/Caches/net.herila.ResticStation/restic` per
-    /// `docs/architecture.md` and `docs/restic-cli.md` — independent of
-    /// `root`, since it is a regenerable cache, not app state.
+    /// restic's cache, redirected via `RESTIC_CACHE_DIR`. Per
+    /// `docs/architecture.md` and `docs/restic-cli.md` this is deliberately
+    /// **independent of `root`**, since it is a regenerable cache, not app
+    /// state:
+    /// - macOS: `~/Library/Caches/net.herila.ResticStation/restic`
+    /// - Linux: `$XDG_CACHE_HOME/restic-station/restic`, falling back to
+    ///   `~/.cache/restic-station/restic`
     public var resticCacheDir: URL {
+        #if os(Linux)
+        Self.xdgBaseDirectory(variable: "XDG_CACHE_HOME", fallbackHomeRelativeComponents: [".cache"])
+            .appendingPathComponent("restic-station", isDirectory: true)
+            .appendingPathComponent("restic", isDirectory: true)
+        #else
         FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent("Library", isDirectory: true)
             .appendingPathComponent("Caches", isDirectory: true)
             .appendingPathComponent("net.herila.ResticStation", isDirectory: true)
             .appendingPathComponent("restic", isDirectory: true)
+        #endif
     }
 
     // MARK: - Directory creation

--- a/Core/Tests/ResticStationCoreTests/Config/AppPathsTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Config/AppPathsTests.swift
@@ -8,50 +8,191 @@ import Darwin
 import Glibc
 #endif
 
-/// Tests that mutate the `RESTIC_STATION_DATA_DIR` process environment
-/// variable must not run concurrently with each other (or with anything
-/// else reading it), hence `.serialized`.
-@Suite(.serialized)
-struct AppPathsEnvTests {
-    @Test func envOverrideRespected() throws {
-        let originalValue = ProcessInfo.processInfo.environment["RESTIC_STATION_DATA_DIR"]
-        defer { Self.restore(originalValue) }
-
-        let overrideDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("restic-station-test-\(UUID().uuidString)")
-        setenv("RESTIC_STATION_DATA_DIR", overrideDir.path, 1)
-
-        let paths = AppPaths.default()
-        #expect(paths.root.path == overrideDir.path)
-    }
-
-    @Test func emptyEnvOverrideFallsBackToDefault() throws {
-        let originalValue = ProcessInfo.processInfo.environment["RESTIC_STATION_DATA_DIR"]
-        defer { Self.restore(originalValue) }
-
-        setenv("RESTIC_STATION_DATA_DIR", "", 1)
-
-        let paths = AppPaths.default()
-        #expect(paths.root.path.hasSuffix("Library/Application Support/ResticStation"))
-    }
-
-    @Test func noEnvOverrideFallsBackToApplicationSupport() throws {
-        let originalValue = ProcessInfo.processInfo.environment["RESTIC_STATION_DATA_DIR"]
-        defer { Self.restore(originalValue) }
-
-        unsetenv("RESTIC_STATION_DATA_DIR")
-
-        let paths = AppPaths.default()
-        #expect(paths.root.path.hasSuffix("Library/Application Support/ResticStation"))
-    }
-
-    private static func restore(_ originalValue: String?) {
-        if let originalValue {
-            setenv("RESTIC_STATION_DATA_DIR", originalValue, 1)
+/// Sets `variable` to `value` (or unsets it when `value` is nil) for the
+/// duration of `body`, restoring the previous value afterwards — including on
+/// throw — so environment mutations can never leak into other tests.
+private func withEnvironment<T>(
+    _ variable: String,
+    _ value: String?,
+    _ body: () throws -> T
+) rethrows -> T {
+    let original = ProcessInfo.processInfo.environment[variable]
+    func apply(_ newValue: String?) {
+        if let newValue {
+            setenv(variable, newValue, 1)
         } else {
-            unsetenv("RESTIC_STATION_DATA_DIR")
+            unsetenv(variable)
         }
     }
+    apply(value)
+    defer { apply(original) }
+    return try body()
+}
+
+/// The platform default `root`, expressed independently of `AppPaths` so the
+/// tests assert against the specification rather than against the
+/// implementation.
+private var expectedDefaultRootSuffix: String {
+    #if os(Linux)
+    "/.local/state/restic-station"
+    #else
+    "/Library/Application Support/ResticStation"
+    #endif
+}
+
+private var expectedResticCacheSuffix: String {
+    #if os(Linux)
+    "/.cache/restic-station/restic"
+    #else
+    "/Library/Caches/net.herila.ResticStation/restic"
+    #endif
+}
+
+/// Tests that mutate the process environment (`RESTIC_STATION_DATA_DIR`,
+/// `XDG_*`) must not run concurrently with each other (or with anything else
+/// reading those variables), hence `.serialized`.
+@Suite(.serialized)
+struct AppPathsEnvTests {
+    // MARK: - RESTIC_STATION_DATA_DIR (both platforms)
+
+    @Test func envOverrideRespected() {
+        let overrideDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("restic-station-test-\(UUID().uuidString)")
+        withEnvironment("RESTIC_STATION_DATA_DIR", overrideDir.path) {
+            #expect(AppPaths.default().root.path == overrideDir.path)
+        }
+    }
+
+    @Test func emptyEnvOverrideFallsBackToDefault() {
+        withEnvironment("RESTIC_STATION_DATA_DIR", "") {
+            #expect(AppPaths.default().root.path.hasSuffix(expectedDefaultRootSuffix))
+        }
+    }
+
+    @Test func noEnvOverrideFallsBackToPlatformDefault() {
+        withEnvironment("RESTIC_STATION_DATA_DIR", nil) {
+            #expect(AppPaths.default().root.path.hasSuffix(expectedDefaultRootSuffix))
+        }
+    }
+
+    /// The data-dir override wins over the XDG variables on Linux too.
+    @Test func envOverrideBeatsXDG() {
+        let overrideDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("restic-station-test-\(UUID().uuidString)")
+        withEnvironment("XDG_STATE_HOME", "/xdg-state-should-be-ignored") {
+            withEnvironment("RESTIC_STATION_DATA_DIR", overrideDir.path) {
+                #expect(AppPaths.default().root.path == overrideDir.path)
+            }
+        }
+    }
+
+    /// Lives in the serialized suite because on Linux `resticCacheDir` reads
+    /// `XDG_CACHE_HOME`, which the tests below mutate.
+    @Test func resticCacheDirIsIndependentOfRoot() {
+        let paths = AppPaths(root: URL(fileURLWithPath: "/tmp/rs-a", isDirectory: true))
+        let other = AppPaths(root: URL(fileURLWithPath: "/var/lib/somewhere-else", isDirectory: true))
+        withEnvironment("XDG_CACHE_HOME", nil) {
+            #expect(paths.resticCacheDir == other.resticCacheDir)
+            #expect(paths.resticCacheDir.path.hasSuffix(expectedResticCacheSuffix))
+        }
+    }
+
+    // MARK: - macOS resolution (must be byte-identical to pre-T22 behaviour)
+
+    #if os(macOS)
+    /// Pins the exact macOS strings. `~/Library/Application Support/ResticStation`
+    /// and `~/Library/Caches/net.herila.ResticStation/restic` are what shipped
+    /// before portable paths landed; any drift breaks existing installs.
+    @Test func macOSDefaultRootIsUnchanged() {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        withEnvironment("RESTIC_STATION_DATA_DIR", nil) {
+            #expect(AppPaths.default().root.path == "\(home)/Library/Application Support/ResticStation")
+        }
+    }
+
+    @Test func macOSResticCacheDirIsUnchanged() {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let paths = AppPaths(root: URL(fileURLWithPath: "/tmp/anything", isDirectory: true))
+        #expect(paths.resticCacheDir.path == "\(home)/Library/Caches/net.herila.ResticStation/restic")
+    }
+
+    /// XDG variables must have no effect whatsoever on macOS.
+    @Test func macOSIgnoresXDGVariables() {
+        withEnvironment("RESTIC_STATION_DATA_DIR", nil) {
+            withEnvironment("XDG_STATE_HOME", "/xdg/state") {
+                withEnvironment("XDG_CACHE_HOME", "/xdg/cache") {
+                    let home = FileManager.default.homeDirectoryForCurrentUser.path
+                    let paths = AppPaths.default()
+                    #expect(paths.root.path == "\(home)/Library/Application Support/ResticStation")
+                    #expect(paths.resticCacheDir.path == "\(home)/Library/Caches/net.herila.ResticStation/restic")
+                }
+            }
+        }
+    }
+    #endif
+
+    // MARK: - Linux XDG resolution
+
+    #if os(Linux)
+    @Test func linuxUsesXDGStateHomeWhenAbsolute() {
+        withEnvironment("RESTIC_STATION_DATA_DIR", nil) {
+            withEnvironment("XDG_STATE_HOME", "/var/lib/xdg-state") {
+                #expect(AppPaths.default().root.path == "/var/lib/xdg-state/restic-station")
+            }
+        }
+    }
+
+    @Test func linuxFallsBackToLocalStateWhenXDGStateHomeUnset() {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        withEnvironment("RESTIC_STATION_DATA_DIR", nil) {
+            withEnvironment("XDG_STATE_HOME", nil) {
+                #expect(AppPaths.default().root.path == "\(home)/.local/state/restic-station")
+            }
+        }
+    }
+
+    @Test func linuxFallsBackWhenXDGStateHomeIsEmpty() {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        withEnvironment("RESTIC_STATION_DATA_DIR", nil) {
+            withEnvironment("XDG_STATE_HOME", "") {
+                #expect(AppPaths.default().root.path == "\(home)/.local/state/restic-station")
+            }
+        }
+    }
+
+    /// Per the XDG spec a relative value is invalid and must be treated as unset.
+    @Test func linuxIgnoresRelativeXDGStateHome() {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        withEnvironment("RESTIC_STATION_DATA_DIR", nil) {
+            withEnvironment("XDG_STATE_HOME", "relative/state") {
+                #expect(AppPaths.default().root.path == "\(home)/.local/state/restic-station")
+            }
+        }
+    }
+
+    @Test func linuxUsesXDGCacheHomeWhenAbsolute() {
+        let paths = AppPaths(root: URL(fileURLWithPath: "/tmp/anything", isDirectory: true))
+        withEnvironment("XDG_CACHE_HOME", "/var/cache/xdg") {
+            #expect(paths.resticCacheDir.path == "/var/cache/xdg/restic-station/restic")
+        }
+    }
+
+    @Test func linuxFallsBackToDotCacheWhenXDGCacheHomeUnset() {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let paths = AppPaths(root: URL(fileURLWithPath: "/tmp/anything", isDirectory: true))
+        withEnvironment("XDG_CACHE_HOME", nil) {
+            #expect(paths.resticCacheDir.path == "\(home)/.cache/restic-station/restic")
+        }
+    }
+
+    @Test func linuxIgnoresRelativeXDGCacheHome() {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let paths = AppPaths(root: URL(fileURLWithPath: "/tmp/anything", isDirectory: true))
+        withEnvironment("XDG_CACHE_HOME", "relative/cache") {
+            #expect(paths.resticCacheDir.path == "\(home)/.cache/restic-station/restic")
+        }
+    }
+    #endif
 }
 
 @Suite struct AppPathsLayoutTests {
@@ -61,6 +202,8 @@ struct AppPathsEnvTests {
         return (AppPaths(root: root), root)
     }
 
+    /// Runs on every platform: the layout below `root` is the cross-platform
+    /// contract (`config export`/`import`, rsync between hosts).
     @Test func computedPathsMatchArchitectureTable() {
         let (paths, root) = makeTempPaths()
         let setId = UUID()
@@ -68,21 +211,80 @@ struct AppPathsEnvTests {
 
         let rootPath = root.path
         #expect(paths.configFile.path == "\(rootPath)/config.json")
+        #expect(paths.runsDir.path == "\(rootPath)/runs")
         #expect(paths.runsIndexFile.path == "\(rootPath)/runs/index.jsonl")
+        #expect(paths.runDir(runId: "r1").path == "\(rootPath)/runs/r1")
         #expect(paths.runMetadataFile(runId: "r1").path == "\(rootPath)/runs/r1/metadata.json")
         #expect(paths.runLogFile(runId: "r1").path == "\(rootPath)/runs/r1/log.txt")
+        #expect(paths.stateDir.path == "\(rootPath)/state")
         #expect(paths.scheduleStateFile.path == "\(rootPath)/state/schedule-state.json")
         #expect(paths.currentRunFile(setId: setId).path == "\(rootPath)/state/current-run-\(setId.uuidString).json")
         #expect(paths.repoStatusFile(destId: destId).path == "\(rootPath)/state/repo-status-\(destId.uuidString).json")
         #expect(paths.fdaCheckFile.path == "\(rootPath)/state/fda-check.json")
+        #expect(paths.locksDir.path == "\(rootPath)/locks")
         #expect(paths.tickLockFile.path == "\(rootPath)/locks/tick.lock")
         #expect(paths.setLockFile(setId: setId).path == "\(rootPath)/locks/set-\(setId.uuidString).lock")
         #expect(paths.mountsDir(destId: destId).path == "\(rootPath)/mounts/\(destId.uuidString)")
     }
 
-    @Test func resticCacheDirIsFixedRegardlessOfRoot() {
-        let (paths, _) = makeTempPaths()
-        #expect(paths.resticCacheDir.path.hasSuffix("Library/Caches/net.herila.ResticStation/restic"))
+    /// Guards requirement 3 against future drift: every member other than
+    /// `root` itself must be a pure function of `root`, so two roots yield the
+    /// same relative sub-paths. Written as literal relative strings so a
+    /// platform branch sneaking into any member below `root` fails here.
+    @Test func subPathsAreRelativeToRootAndPlatformIndependent() {
+        let setId = UUID()
+        let destId = UUID()
+        let rootA = URL(fileURLWithPath: "/tmp/rs-a", isDirectory: true)
+        let rootB = URL(fileURLWithPath: "/var/lib/rs-b", isDirectory: true)
+        let a = AppPaths(root: rootA)
+        let b = AppPaths(root: rootB)
+
+        func relative(_ path: String, to root: URL) -> String {
+            let prefix = root.path + "/"
+            #expect(path.hasPrefix(prefix))
+            return String(path.dropFirst(prefix.count))
+        }
+
+        func members(_ paths: AppPaths) -> [String] {
+            [
+                paths.configFile.path,
+                paths.runsDir.path,
+                paths.runsIndexFile.path,
+                paths.runDir(runId: "r1").path,
+                paths.runMetadataFile(runId: "r1").path,
+                paths.runLogFile(runId: "r1").path,
+                paths.stateDir.path,
+                paths.scheduleStateFile.path,
+                paths.currentRunFile(setId: setId).path,
+                paths.repoStatusFile(destId: destId).path,
+                paths.fdaCheckFile.path,
+                paths.locksDir.path,
+                paths.tickLockFile.path,
+                paths.setLockFile(setId: setId).path,
+                paths.mountsDir(destId: destId).path,
+            ]
+        }
+
+        let relativeA = members(a).map { relative($0, to: rootA) }
+        let relativeB = members(b).map { relative($0, to: rootB) }
+        #expect(relativeA == relativeB)
+        #expect(relativeA == [
+            "config.json",
+            "runs",
+            "runs/index.jsonl",
+            "runs/r1",
+            "runs/r1/metadata.json",
+            "runs/r1/log.txt",
+            "state",
+            "state/schedule-state.json",
+            "state/current-run-\(setId.uuidString).json",
+            "state/repo-status-\(destId.uuidString).json",
+            "state/fda-check.json",
+            "locks",
+            "locks/tick.lock",
+            "locks/set-\(setId.uuidString).lock",
+            "mounts/\(destId.uuidString)",
+        ])
     }
 
     @Test func ensureDirectoriesCreatesRootRunsStateLocks() throws {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -81,9 +81,18 @@ restic exit code mapping (verified against restic 0.18.1 — see `restic-cli.md`
 
 ## AppPaths
 
-All runtime paths come from one type, `AppPaths` (in `Config/`), never hard-coded elsewhere. Root defaults to `~/Library/Application Support/ResticStation` and is overridable via init parameter and via the environment variable `RESTIC_STATION_DATA_DIR` (used by tests and the integration script).
+All runtime paths come from one type, `AppPaths` (in `Config/`), never hard-coded elsewhere. `root` is overridable via init parameter and via the environment variable `RESTIC_STATION_DATA_DIR` (used by tests and the integration script), which takes precedence on every platform. Otherwise it resolves per-platform:
 
-| Path | Contents |
+| | macOS | Linux |
+|---|---|---|
+| `root` | `~/Library/Application Support/ResticStation` | `$XDG_STATE_HOME/restic-station`, else `~/.local/state/restic-station` |
+| restic cache | `~/Library/Caches/net.herila.ResticStation/restic` | `$XDG_CACHE_HOME/restic-station/restic`, else `~/.cache/restic-station/restic` |
+
+State — not config — is the right XDG base dir for `root`: `config.json` is the smallest part of it, and the directory is dominated by `runs/`, `state/`, and `locks/`. Per the XDG Base Directory Specification an `XDG_*` value that is not an absolute path is ignored and the fallback applies as if it were unset.
+
+**`root` and the restic cache are the only platform-dependent members.** Everything below `root` is byte-identical across platforms — `config export`/`import` and rsync-ing a data directory between hosts depend on this, and a test asserts it.
+
+| Path (relative to `root`) | Contents |
 |---|---|
 | `config.json` | `AppConfig` (see `data-model.md`) |
 | `runs/<runId>/metadata.json` | one `RunMetadata` per run |
@@ -94,8 +103,11 @@ All runtime paths come from one type, `AppPaths` (in `Config/`), never hard-code
 | `state/repo-status-<destId>.json` | reachability + last-synced info per destination |
 | `state/fda-check.json` | result of the helper's Full Disk Access probe |
 | `locks/tick.lock`, `locks/set-<setId>.lock` | flock files (see `scheduling.md`) |
+| `mounts/<destId>/` | `restic mount` mountpoint (see `restic-cli.md` §mount) |
 
-restic's cache is redirected via `RESTIC_CACHE_DIR` to `~/Library/Caches/net.herila.ResticStation/restic`.
+restic's cache is redirected via `RESTIC_CACHE_DIR` to the location in the table above. It is deliberately independent of `root` — it is a regenerable cache, not app state.
+
+`mounts/<destId>/` is defined on both platforms but is macOS-only in practice: `restic mount` requires macFUSE on macOS and FUSE on Linux, which a headless Linux host generally does not have.
 
 `runId` format: `<ISO8601 basic UTC>-<kind>-<first 8 chars of set UUID>`, e.g. `20260726T205704Z-backup-a1b2c3d4`.
 


### PR DESCRIPTION
## What changed

`AppPaths` is now portable. Only two members branch on the OS; everything else is untouched.

**`Core/Sources/ResticStationCore/Config/AppPaths.swift`**

- `default()` resolution order, checked in this order on both platforms:
  1. `RESTIC_STATION_DATA_DIR` if set and non-empty (unchanged).
  2. Linux: `$XDG_STATE_HOME/restic-station`, falling back to `~/.local/state/restic-station`.
  3. macOS: `~/Library/Application Support/ResticStation` (unchanged).
- `resticCacheDir`: Linux `$XDG_CACHE_HOME/restic-station/restic` → `~/.cache/restic-station/restic`; macOS keeps `~/Library/Caches/net.herila.ResticStation/restic`. Still deliberately independent of `root`.
- New internal `xdgBaseDirectory(variable:fallbackHomeRelativeComponents:)` (Linux-only), which honours an `XDG_*` value only when it is set, non-empty **and** absolute — a relative value is ignored and the fallback applies, per the XDG Base Directory Specification.
- `configFile`, `runsDir`, `stateDir`, `locksDir`, `mountsDir`, and every per-id helper are unchanged and remain purely `root`-relative.
- Doc comments no longer claim an unconditional `~/Library` path; `mountsDir` gained a note that it is macOS-only in practice (macFUSE / FUSE) though the path stays defined on both.

**`Core/Tests/ResticStationCoreTests/Config/AppPathsTests.swift`** — restructured:

- A `withEnvironment(_:_:_:)` helper sets and restores (via `defer`, so also on throw) any env var it touches, so nothing leaks between tests. All env-touching tests live in the `.serialized` `AppPathsEnvTests` suite — `resticCacheDirIsIndependentOfRoot` moved there because on Linux it now reads `XDG_CACHE_HOME`.
- Cross-platform: `RESTIC_STATION_DATA_DIR` honoured; set-but-empty falls through to the platform default; the override beats `XDG_STATE_HOME`.
- Cross-platform layout: `computedPathsMatchArchitectureTable` now also covers `runsDir`/`runDir`/`stateDir`/`locksDir`. New `subPathsAreRelativeToRootAndPlatformIndependent` builds `AppPaths` from two different roots, strips each root prefix, asserts the two relative lists are equal **and** equal to a literal expected list — so a platform branch sneaking in below `root` fails the test on both OSes.
- macOS-gated (`#if os(macOS)`): `macOSDefaultRootIsUnchanged` and `macOSResticCacheDirIsUnchanged` pin the exact pre-change absolute strings, and `macOSIgnoresXDGVariables` asserts `XDG_STATE_HOME`/`XDG_CACHE_HOME` have no effect on macOS.
- Linux-gated (`#if os(Linux)`): `XDG_STATE_HOME` absolute → used; unset → `~/.local/state/restic-station`; empty → fallback; relative → ignored, fallback. Same four-way coverage for `XDG_CACHE_HOME` (absolute / unset / relative).

**`docs/architecture.md` §AppPaths** — replaced the single-platform sentence with a two-column macOS/Linux table for `root` and the restic cache, the rationale for choosing the *state* XDG base dir over *config*, the absolute-path rule for `XDG_*`, an explicit statement that everything below `root` is byte-identical across platforms (with a test guaranteeing it), and a `mounts/<destId>/` row plus the macFUSE/FUSE caveat.

## How verified

Locally on macOS (Apple Swift 6.3.3):

- `swift build` — clean
- `swift test` (root package) — pass
- `swift test --package-path Core` — 313 tests in 52 suites pass
- `./scripts/bootstrap.sh && xcodebuild -scheme "Restic Station" build CODE_SIGNING_ALLOWED=NO -quiet` — exit 0

Linux verification is CI-only (`ubuntu-24.04-arm`, container `swift:6.1`) — no local Linux toolchain available in this environment.

## Acceptance criteria

- [x] `swift test` green on macOS (verified locally) and on Linux (verified in CI — see the `linux` job). Note: the issue's premise that T21 gated `AppPathsTests` for Linux was wrong; T21 added no `#if os(...)` gates, so there was no gate to remove. The old assertions passed on Linux only because the pre-change implementation was unconditionally `~/Library/...` on every platform.
- [x] macOS resolution byte-identical to before — verified by test, not inspection (`macOSDefaultRootIsUnchanged`, `macOSResticCacheDirIsUnchanged`, `macOSIgnoresXDGVariables` pin the literal strings).
- [x] Everything below `root` identical across platforms — verified by `subPathsAreRelativeToRootAndPlatformIndependent`, which runs on both platforms and asserts against literal relative paths.
- [x] `docs/architecture.md` §AppPaths documents both platforms; `AppPaths.swift` doc comments no longer claim an unconditional `~/Library` path.

## Deferred / out of scope

- `docs/restic-cli.md` still states `RESTIC_CACHE_DIR=~/Library/Caches/net.herila.ResticStation/restic` and the `mount` mountpoint as unconditional macOS paths. Left alone deliberately: the issue names only `docs/architecture.md`, and that file is being edited concurrently by the restic-discovery task (#27). Worth a one-line follow-up once that lands.
- The XDG runtime dir is not used for `locks/`. `locks/` stays under `root` because the lock files are part of the byte-identical-below-`root` contract; revisit only if lock semantics change.

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)
