### PR TITLE
T25 — Platform-conditional helper: FDA probe, restic discovery in Core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,63 @@ jobs:
       - name: Run Core unit tests
         run: swift test --package-path Core
 
+      # T25 acceptance criteria that only a real Linux run can show.
+      - name: fda-check is a no-op on Linux
+        run: |
+          export RESTIC_STATION_DATA_DIR=$(mktemp -d)
+          OUT=$(.build/debug/restic-station-helper fda-check)
+          echo "$OUT"
+          echo "$OUT" | grep -q "not applicable on this platform"
+          # A fake "granted" record would make the file's meaning
+          # platform-dependent — nothing may be written at all.
+          test ! -e "$RESTIC_STATION_DATA_DIR/state/fda-check.json"
+
+      - name: restic discovery resolves the helper's binary on Linux
+        run: |
+          export RESTIC_STATION_DATA_DIR=$(mktemp -d)
+          mkdir -p "$RESTIC_STATION_DATA_DIR"
+          # No resticPath configured and no sets: enough to exercise
+          # HelperContext.make()'s resolution, which runs before anything else.
+          echo '{"version":1,"resticPath":null,"showMenuBarIcon":true,"sets":[]}' \
+            > "$RESTIC_STATION_DATA_DIR/config.json"
+          UUID=00000000-0000-0000-0000-000000000001
+
+          # 1. Nothing installed anywhere: an actionable message, not "open
+          #    Restic Station".
+          OUT=$(env PATH=/nonexistent .build/debug/restic-station-helper \
+            probe-repo --set $UUID --dest $UUID 2>&1 || true)
+          echo "$OUT"
+          echo "$OUT" | grep -q "restic not found"
+          echo "$OUT" | grep -q "/usr/bin/restic"
+          echo "$OUT" | grep -q "$RESTIC_STATION_DATA_DIR/config.json"
+          # "open Restic Station" is impossible advice on a headless host.
+          ! echo "$OUT" | grep -q "open Restic Station"
+
+          # 2. A restic on PATH is discovered and used, with no configuration
+          #    at all — the "headless host" acceptance criterion. Note it is
+          #    only "found" because it *runs*: an inert +x file would not do.
+          FAKEBIN=$(mktemp -d)
+          cat > "$FAKEBIN/restic" <<'SH'
+          #!/bin/sh
+          if [ "$1" = "version" ]; then
+            echo '{"version":"0.18.1","go_version":"go1.22.0","go_os":"linux","go_arch":"arm64"}'
+            exit 0
+          fi
+          exit 1
+          SH
+          chmod +x "$FAKEBIN/restic"
+          OUT=$(env PATH="$FAKEBIN" .build/debug/restic-station-helper \
+            probe-repo --set $UUID --dest $UUID 2>&1 || true)
+          echo "$OUT"
+          echo "$OUT" | grep -q "discovered $FAKEBIN/restic"
+          # Got past restic resolution and on to the real (absent) set.
+          echo "$OUT" | grep -q "no backup set with id"
+
+          # 3. tick still exits 0 on a host with nothing configured.
+          #    (tick resolves restic through the same `resolveResticPath`
+          #    that step 2 exercises, via `makeTolerant`.)
+          env PATH="$FAKEBIN" .build/debug/restic-station-helper tick
+
   macos:
     runs-on: macos-15
     steps:

--- a/App/Sources/Support/ResticStatusMapping.swift
+++ b/App/Sources/Support/ResticStatusMapping.swift
@@ -1,0 +1,45 @@
+import Foundation
+import ResticStationCore
+
+/// `ResticDiscovery`, `ResticProbe` and `ResticDiscoveryResult` live in Core
+/// (`Core/Sources/ResticStationCore/Restic/ResticDiscovery.swift`) since T25 —
+/// the helper needs them too, and `App/` is never compiled on Linux.
+///
+/// What stays here is only the *UI vocabulary*: the translation from a probe
+/// outcome into `ResticStatus`, the enum the Settings chip and the menu-bar
+/// health derivation speak. Core has no business knowing about it, and the
+/// mapping is the one part of the old file that was genuinely app-side.
+extension ResticProbe {
+    /// Maps a probe onto the status vocabulary the Settings chip and the
+    /// menu-bar health derivation already speak (`AppModel.resticStatus`).
+    var status: ResticStatus {
+        switch outcome {
+        case .ok(let version):
+            return .ok(path: path, version: version)
+        case .tooOld(let version):
+            return .tooOld(path: path, version: version, minimum: ResticDiscovery.minimumVersion)
+        case .unusable(let reason):
+            return .unavailable(path: path, reason: reason)
+        }
+    }
+}
+
+extension ResticDiscoveryResult {
+    /// The best thing we can say about this search, in the vocabulary of the
+    /// Settings chip: a working binary, else the first too-old one we found
+    /// (candidates are probed in preference order, so this is the binary the
+    /// user is most likely to think of as "their" restic), else the first
+    /// unusable candidate, else "nothing on this Mac".
+    var status: ResticStatus {
+        if let chosen {
+            return chosen.status
+        }
+        if let firstTooOld {
+            return firstTooOld.status
+        }
+        if let firstUnusable = rejected.first {
+            return firstUnusable.status
+        }
+        return .notConfigured
+    }
+}

--- a/App/Sources/ViewModels/AppModel.swift
+++ b/App/Sources/ViewModels/AppModel.swift
@@ -232,10 +232,11 @@ final class AppModel: ObservableObject {
             setHealths: setHealths,
             anyRunInFlight: !stateWatcher.currentRuns.isEmpty,
             // Only a *definite* denial is a warning: a missing
-            // `fda-check.json` means the probe has never run, which the
-            // Permissions pane reports as "unknown" (T18) rather than as a
-            // problem.
-            fullDiskAccessDenied: stateWatcher.fdaCheck.map { !$0.hasFullDiskAccess } ?? false,
+            // `fda-check.json` means the probe has never run (or does not
+            // apply on this platform), which the Permissions pane reports as
+            // "unknown" (T18) rather than as a problem. The rule lives in
+            // Core so the Linux build is held to it too (T25).
+            fullDiskAccessDenied: HealthDerivation.fullDiskAccessDenied(from: stateWatcher.fdaCheck),
             backgroundAgentEnabled: launchd.isEnabled
         )
     }

--- a/Core/Sources/ResticStationCore/Restic/ResticDiscovery.swift
+++ b/Core/Sources/ResticStationCore/Restic/ResticDiscovery.swift
@@ -1,42 +1,68 @@
 import Foundation
-import ResticStationCore
 
 /// Finds a usable `restic` binary (`docs/architecture.md` §restic discovery,
-/// `docs/restic-cli.md` §version): probe the three package-manager locations
-/// first, then whatever the app's inherited `PATH` offers, and validate each
+/// `docs/restic-cli.md` §version): probe the package-manager locations for
+/// this platform first, then whatever `PATH` offers, and validate each
 /// candidate by actually running `restic version --json` and comparing the
 /// reported version against the documented minimum.
+///
+/// Lives in Core (moved out of `App/` in T25) because the *helper* needs it
+/// too: on a headless Linux host there is no app to open, so
+/// `HelperContext.make()` discovers restic itself rather than telling the
+/// user to launch a GUI that isn't there.
 ///
 /// Three rules this type exists to enforce:
 ///
 /// 1. **A candidate is only "found" if it ran.** Existence and the +x bit are
 ///    a filter, never the answer: a Homebrew shim for an uninstalled formula,
-///    an x86 binary on an Apple-silicon Mac with no Rosetta, or a broken
-///    symlink all pass `isExecutableFile` and fail to execute. Everything the
-///    UI shows comes from a real `version --json` round trip.
-/// 2. **Only absolute paths are ever persisted.** `config.resticPath` is
-///    consumed by the *helper*, running from launchd with a minimal
+///    an x86 binary on an Apple-silicon Mac with no Rosetta, a distro
+///    wrapper script for an uninstalled package, or a broken symlink all pass
+///    `isExecutableFile` and fail to execute. Everything the UI shows — and
+///    everything the helper acts on — comes from a real `version --json`
+///    round trip.
+/// 2. **Only absolute paths are ever persisted.** A resolved path is consumed
+///    by the *helper*, running from launchd/systemd with a minimal
 ///    environment and an unrelated working directory — a relative path from
 ///    a `PATH` entry like `.` or `bin` would resolve differently (or
 ///    dangerously) there, so such entries are skipped outright.
 /// 3. **No environment is passed to the probe.** `restic version` needs
-///    none, and inheriting the app's environment keeps the probe faithful to
-///    how a user would run the binary in a shell.
+///    none, and inheriting the caller's environment keeps the probe faithful
+///    to how a user would run the binary in a shell.
 ///
 /// Deliberately free of SwiftUI/AppKit imports: the type is plain
 /// `Foundation` + Core so it can be exercised (and was, during T18) by a
 /// throwaway command-line probe compiled against the real Homebrew restic.
-struct ResticDiscovery: Sendable {
+public struct ResticDiscovery: Sendable {
 
     // MARK: - Configuration
 
-    /// Package-manager install locations, in preference order: Homebrew on
-    /// Apple silicon, Homebrew on Intel, MacPorts.
-    static let wellKnownPaths = [
+    /// Package-manager install locations on macOS, in preference order:
+    /// Homebrew on Apple silicon, Homebrew on Intel, MacPorts.
+    public static let macOSWellKnownPaths = [
         "/opt/homebrew/bin/restic",
         "/usr/local/bin/restic",
         "/opt/local/bin/restic"
     ]
+
+    /// Package-manager install locations on Linux, in preference order:
+    /// distro package (`apt`/`dnf`/`pacman` all land in `/usr/bin`), a
+    /// locally installed release tarball, and the `/opt` convention some
+    /// images use for hand-placed tooling.
+    public static let linuxWellKnownPaths = [
+        "/usr/bin/restic",
+        "/usr/local/bin/restic",
+        "/opt/restic/bin/restic"
+    ]
+
+    /// The well-known list for the platform this binary was built for.
+    /// `PATH` scanning happens on both platforms and is not affected.
+    public static var wellKnownPaths: [String] {
+        #if os(macOS)
+        return macOSWellKnownPaths
+        #else
+        return linuxWellKnownPaths
+        #endif
+    }
 
     /// The minimum restic the docs require — the first version with the
     /// current exit-code contract (`docs/restic-cli.md` §version).
@@ -47,21 +73,26 @@ struct ResticDiscovery: Sendable {
     /// `AppModel.discoverResticBinary()`, so a future edit to one without
     /// the other trips in debug builds instead of quietly disagreeing about
     /// which binaries are acceptable.
-    static let minimumVersion = "0.17.0"
+    public static let minimumVersion = "0.17.0"
 
     /// Per-candidate probe timeout. Short on purpose: this runs while the
     /// user waits on a Settings pane or the onboarding sheet, and a hung
     /// candidate (a binary on an unresponsive network mount) must not stall
     /// the whole search. `DefaultProcessRunner` SIGINTs, then SIGKILLs.
-    static let probeTimeout: TimeInterval = 5
+    public static let probeTimeout: TimeInterval = 5
 
     /// Upper bound on how many candidates are executed in one search, so a
     /// pathological `PATH` (hundreds of entries, e.g. a misconfigured shell
     /// profile) cannot turn discovery into a minute-long stall.
-    static let maxCandidates = 24
+    public static let maxCandidates = 24
 
-    /// `PATH` as the app inherited it. Injectable so the candidate list can
-    /// be reasoned about without depending on the developer's shell.
+    /// The well-known locations searched ahead of `PATH`. Injectable so the
+    /// candidate list can be reasoned about in tests without depending on
+    /// what happens to be installed on the machine running them.
+    private let wellKnownPaths: [String]
+
+    /// `PATH` as the process inherited it. Injectable so the candidate list
+    /// can be reasoned about without depending on the developer's shell.
     private let environment: [String: String]
     private let runner: any ProcessRunning
 
@@ -70,19 +101,27 @@ struct ResticDiscovery: Sendable {
     /// detached probe task from the main actor.
     private var fileManager: FileManager { .default }
 
-    init(
+    public init(
+        wellKnownPaths: [String] = ResticDiscovery.wellKnownPaths,
         environment: [String: String] = ProcessInfo.processInfo.environment,
         runner: any ProcessRunning = DefaultProcessRunner()
     ) {
+        self.wellKnownPaths = wellKnownPaths
         self.environment = environment
         self.runner = runner
     }
 
+    /// A human-readable list of what a failed search looked at, for the
+    /// "restic not found" message the helper prints on a headless host.
+    public var searchedDescription: String {
+        wellKnownPaths.joined(separator: ", ") + ", and every directory on PATH"
+    }
+
     // MARK: - Candidates
 
-    /// The ordered, de-duplicated list of paths worth executing: the three
-    /// well-known locations first (so a Homebrew restic wins over whatever a
-    /// user's shell profile happens to shadow it with), then one
+    /// The ordered, de-duplicated list of paths worth executing: the
+    /// well-known locations first (so a package-manager restic wins over
+    /// whatever a user's shell profile happens to shadow it with), then one
     /// `<dir>/restic` per `PATH` entry.
     ///
     /// Filtering is intentionally conservative — relative `PATH` entries are
@@ -91,7 +130,7 @@ struct ResticDiscovery: Sendable {
     /// and a `~/bin/restic` symlink pointing at it are the same binary, and
     /// probing both would double the wait for no new information. The
     /// *reported* path stays the one the user would recognize.
-    func candidatePaths() -> [String] {
+    public func candidatePaths() -> [String] {
         var ordered: [String] = []
         var seenResolved = Set<String>()
 
@@ -110,7 +149,7 @@ struct ResticDiscovery: Sendable {
             ordered.append(path)
         }
 
-        for path in Self.wellKnownPaths {
+        for path in wellKnownPaths {
             consider(path)
         }
         for directory in pathEntries() {
@@ -141,7 +180,7 @@ struct ResticDiscovery: Sendable {
     /// Runs `<path> version --json` and classifies the result. Used both by
     /// `discover()` and by "Locate manually…", so a hand-picked binary is
     /// held to exactly the same standard as a discovered one.
-    func probe(path: String) async -> ResticProbe {
+    public func probe(path: String) async -> ResticProbe {
         guard path.hasPrefix("/") else {
             return ResticProbe(path: path, outcome: .unusable(
                 reason: "Restic Station needs the full path to the restic binary (starting with “/”)."
@@ -209,7 +248,7 @@ struct ResticDiscovery: Sendable {
     /// rather than a bare "not found", and a newer restic further down `PATH`
     /// should still win. Same for unusable candidates, which are reported so
     /// the "found something, couldn't run it" case is never silent.
-    func discover() async -> ResticDiscoveryResult {
+    public func discover() async -> ResticDiscoveryResult {
         var rejected: [ResticProbe] = []
         for path in candidatePaths() {
             let probe = await probe(path: path)
@@ -227,11 +266,11 @@ struct ResticDiscovery: Sendable {
 // MARK: - ResticProbe
 
 /// One candidate binary and what running it proved.
-struct ResticProbe: Equatable, Sendable {
-    let path: String
-    let outcome: Outcome
+public struct ResticProbe: Equatable, Sendable {
+    public let path: String
+    public let outcome: Outcome
 
-    enum Outcome: Equatable, Sendable {
+    public enum Outcome: Equatable, Sendable {
         /// Ran, reported a version, and meets the minimum.
         case ok(version: String)
         /// Ran and reported a version below `ResticDiscovery.minimumVersion`.
@@ -240,60 +279,45 @@ struct ResticProbe: Equatable, Sendable {
         case unusable(reason: String)
     }
 
-    var version: String? {
+    public init(path: String, outcome: Outcome) {
+        self.path = path
+        self.outcome = outcome
+    }
+
+    public var version: String? {
         switch outcome {
         case .ok(let version), .tooOld(let version): return version
         case .unusable: return nil
         }
     }
 
-    var isUsable: Bool {
+    public var isUsable: Bool {
         if case .ok = outcome { return true }
         return false
-    }
-
-    /// Maps a probe onto the status vocabulary the Settings chip and the
-    /// menu-bar health derivation already speak (`AppModel.resticStatus`).
-    var status: ResticStatus {
-        switch outcome {
-        case .ok(let version):
-            return .ok(path: path, version: version)
-        case .tooOld(let version):
-            return .tooOld(path: path, version: version, minimum: ResticDiscovery.minimumVersion)
-        case .unusable(let reason):
-            return .unavailable(path: path, reason: reason)
-        }
     }
 }
 
 // MARK: - ResticDiscoveryResult
 
-struct ResticDiscoveryResult: Equatable, Sendable {
+public struct ResticDiscoveryResult: Equatable, Sendable {
     /// The first candidate that ran and met the minimum version, if any.
-    let chosen: ResticProbe?
+    public let chosen: ResticProbe?
     /// Candidates that were found and executed but rejected, in probe order
     /// — the raw material for "0.16.4 found, 0.17.0+ required".
-    let rejected: [ResticProbe]
+    public let rejected: [ResticProbe]
 
-    /// The best thing we can say about this search, in the vocabulary of the
-    /// Settings chip: a working binary, else the first too-old one we found
-    /// (candidates are probed in preference order, so this is the binary the
-    /// user is most likely to think of as "their" restic), else the first
-    /// unusable candidate, else "nothing on this Mac".
-    var status: ResticStatus {
-        if let chosen {
-            return chosen.status
-        }
-        let firstTooOld = rejected.first {
+    public init(chosen: ResticProbe?, rejected: [ResticProbe]) {
+        self.chosen = chosen
+        self.rejected = rejected
+    }
+
+    /// The first rejected candidate that at least *ran* but was too old —
+    /// candidates are probed in preference order, so this is the binary the
+    /// user is most likely to think of as "their" restic.
+    public var firstTooOld: ResticProbe? {
+        rejected.first {
             if case .tooOld = $0.outcome { return true }
             return false
         }
-        if let firstTooOld {
-            return firstTooOld.status
-        }
-        if let firstUnusable = rejected.first {
-            return firstUnusable.status
-        }
-        return .notConfigured
     }
 }

--- a/Core/Sources/ResticStationCore/Support/HealthDerivation.swift
+++ b/Core/Sources/ResticStationCore/Support/HealthDerivation.swift
@@ -234,15 +234,36 @@ public enum HealthDerivation {
 
     // MARK: Global
 
+    /// Interprets `state/fda-check.json` for `appHealth(…)`'s
+    /// `fullDiskAccessDenied` parameter — the one place the absent-file
+    /// semantics are defined.
+    ///
+    /// **Absent means "not applicable", never "denied".** The file is absent
+    /// in two situations and neither is a problem:
+    ///
+    /// - macOS, before the first `fda-check` has run (fresh install).
+    /// - Linux, always: there is no TCC, so `fda-check` deliberately writes
+    ///   nothing (T25). A fake "granted" record would make the file's
+    ///   meaning platform-dependent, so the helper writes no record at all
+    ///   and readers must not infer a denial from its absence.
+    ///
+    /// Only a record that explicitly says `hasFullDiskAccess == false` is a
+    /// denial.
+    public static func fullDiskAccessDenied(from record: FdaCheckResult?) -> Bool {
+        guard let record else { return false }
+        return !record.hasFullDiskAccess
+    }
+
     /// The menu bar icon's state.
     ///
     /// - Parameters:
     ///   - anyRunInFlight: `true` when *any* `current-run-*.json` exists,
     ///     including one belonging to a set that is no longer in the config
     ///     (a run started before the set was deleted is still running).
-    ///   - fullDiskAccessDenied: from `state/fda-check.json`. Pass `false`
-    ///     when the probe has never run — "not yet known" must not paint the
-    ///     icon yellow, only a definite `hasFullDiskAccess == false` does.
+    ///   - fullDiskAccessDenied: from `state/fda-check.json`, via
+    ///     `fullDiskAccessDenied(from:)` — "not yet known" (or "not
+    ///     applicable on this platform") must not paint the icon yellow,
+    ///     only a definite `hasFullDiskAccess == false` does.
     ///   - backgroundAgentEnabled: `SMAppService.Status == .enabled`.
     ///     Anything else means scheduled backups are not running.
     public static func appHealth(

--- a/Core/Tests/ResticStationCoreTests/Restic/ResticDiscoveryTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Restic/ResticDiscoveryTests.swift
@@ -1,0 +1,458 @@
+import Foundation
+import Testing
+
+@testable import ResticStationCore
+
+/// `ResticDiscovery` moved from `App/` to Core in T25 so the helper can use
+/// it on Linux. These tests exist to make sure nothing was lost in the move:
+/// the probe-by-running rule, the per-candidate timeout, and the candidate
+/// cap are all load-bearing.
+///
+/// Everything here runs on **both** platforms: the well-known list is
+/// injected and the "binaries" are real files in a temp directory that the
+/// fake runner decides the fate of, so macOS CI genuinely exercises the code
+/// path Linux takes.
+@Suite struct ResticDiscoveryTests {
+
+    // MARK: - Test doubles
+
+    /// A `ProcessRunning` keyed by executable path (unlike the sequential
+    /// `FakeProcessRunner`, discovery's whole point is *which* candidate got
+    /// run, and in what order). Records every argv and the timeout it was
+    /// handed.
+    final class ProbeRunner: ProcessRunning, @unchecked Sendable {
+        enum Behaviour {
+            /// Ran and printed a `version --json` object.
+            case reports(version: String)
+            /// Ran and exited nonzero (a Homebrew shim for an uninstalled
+            /// formula does this).
+            case exits(code: Int32, stderr: String)
+            /// Ran and printed something that is not restic's version JSON.
+            case printsGarbage(String)
+            /// Could not be launched at all (bad architecture, broken
+            /// interpreter line, dangling symlink target).
+            case failsToLaunch
+            /// Hung past the deadline.
+            case timesOut
+        }
+
+        private let lock = NSLock()
+        private var behaviours: [String: Behaviour]
+        private var _calls: [(argv: [String], timeout: TimeInterval?)] = []
+
+        init(_ behaviours: [String: Behaviour]) {
+            self.behaviours = behaviours
+        }
+
+        /// Scoped rather than bare `lock()`/`unlock()` calls: the latter are
+        /// unavailable from an async context.
+        private func withLock<T>(_ body: () -> T) -> T {
+            lock.lock()
+            defer { lock.unlock() }
+            return body()
+        }
+
+        var calls: [(argv: [String], timeout: TimeInterval?)] {
+            withLock { _calls }
+        }
+
+        var probedPaths: [String] {
+            calls.compactMap { call in call.argv.first }
+        }
+
+        func run(
+            _ argv: [String],
+            env: [String: String]?,
+            currentDirectory: String?,
+            onStdoutLine: (@Sendable (String) -> Void)?,
+            onStderrLine: (@Sendable (String) -> Void)?,
+            timeout: TimeInterval?
+        ) async throws -> ProcessResult {
+            let behaviour = withLock { () -> Behaviour in
+                _calls.append((argv, timeout))
+                return behaviours[argv.first ?? ""] ?? .failsToLaunch
+            }
+
+            #expect(env == nil, "the probe must not pass an environment (rule 3)")
+
+            switch behaviour {
+            case .reports(let version):
+                let json = """
+                    {"version":"\(version)","go_version":"go1.22.0","go_os":"linux","go_arch":"arm64"}
+                    """
+                return ProcessResult(exitCode: 0, stdout: Data(json.utf8), stderr: Data())
+            case .exits(let code, let stderr):
+                return ProcessResult(exitCode: code, stdout: Data(), stderr: Data(stderr.utf8))
+            case .printsGarbage(let text):
+                return ProcessResult(exitCode: 0, stdout: Data(text.utf8), stderr: Data())
+            case .failsToLaunch:
+                throw ProcessRunnerError.launchFailed("Bad CPU type in executable")
+            case .timesOut:
+                throw ProcessRunnerError.timeout
+            }
+        }
+    }
+
+    /// A temp directory of real, executable, entirely inert files — enough
+    /// to satisfy `fileExists` + `isExecutableFile`, which is exactly the
+    /// filter the probe-by-running rule refuses to trust on its own.
+    final class FakeBinaries {
+        let root: URL
+
+        init() throws {
+            root = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+                .appendingPathComponent("restic-discovery-\(UUID().uuidString)", isDirectory: true)
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        }
+
+        /// Explicit rather than a `deinit`: the test only holds the
+        /// directory alive through a local `let`, and ARC is free to release
+        /// that before the test body ends.
+        func cleanup() {
+            try? FileManager.default.removeItem(at: root)
+        }
+
+        /// Creates an executable file and returns its absolute path.
+        @discardableResult
+        func makeExecutable(_ relativePath: String) throws -> String {
+            let url = root.appendingPathComponent(relativePath)
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try Data("#!/bin/sh\nexit 0\n".utf8).write(to: url)
+            try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+            return url.path
+        }
+
+        /// Creates a non-executable regular file and returns its path.
+        @discardableResult
+        func makeNonExecutable(_ relativePath: String) throws -> String {
+            let path = try makeExecutable(relativePath)
+            try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: path)
+            return path
+        }
+
+        func directory(_ relativePath: String) throws -> String {
+            let url = root.appendingPathComponent(relativePath, isDirectory: true)
+            try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+            return url.path
+        }
+    }
+
+    // MARK: - Platform-conditional well-known lists
+
+    @Test("the documented per-platform well-known lists")
+    func wellKnownListsAreTheDocumentedOnes() {
+        #expect(ResticDiscovery.macOSWellKnownPaths == [
+            "/opt/homebrew/bin/restic",
+            "/usr/local/bin/restic",
+            "/opt/local/bin/restic",
+        ])
+        #expect(ResticDiscovery.linuxWellKnownPaths == [
+            "/usr/bin/restic",
+            "/usr/local/bin/restic",
+            "/opt/restic/bin/restic",
+        ])
+    }
+
+    @Test("the default list is the one for the platform this build targets")
+    func defaultWellKnownListIsPlatformConditional() {
+        #if os(macOS)
+        #expect(ResticDiscovery.wellKnownPaths == ResticDiscovery.macOSWellKnownPaths)
+        #expect(!ResticDiscovery.wellKnownPaths.contains("/usr/bin/restic"))
+        #else
+        #expect(ResticDiscovery.wellKnownPaths == ResticDiscovery.linuxWellKnownPaths)
+        #expect(!ResticDiscovery.wellKnownPaths.contains("/opt/homebrew/bin/restic"))
+        #endif
+    }
+
+    // MARK: - Candidate list
+
+    @Test("well-known locations are searched before PATH")
+    func wellKnownComesFirst() throws {
+        let binaries = try FakeBinaries()
+        defer { binaries.cleanup() }
+        let wellKnown = try binaries.makeExecutable("opt/restic")
+        let pathDir = try binaries.directory("pathbin")
+        try binaries.makeExecutable("pathbin/restic")
+
+        let discovery = ResticDiscovery(
+            wellKnownPaths: [wellKnown],
+            environment: ["PATH": pathDir],
+            runner: ProbeRunner([:])
+        )
+        #expect(discovery.candidatePaths() == [wellKnown, pathDir + "/restic"])
+    }
+
+    @Test("relative PATH entries are dropped, absolute ones are normalized")
+    func relativePathEntriesAreDropped() throws {
+        let binaries = try FakeBinaries()
+        defer { binaries.cleanup() }
+        let pathDir = try binaries.directory("bin")
+        let candidate = try binaries.makeExecutable("bin/restic")
+
+        let discovery = ResticDiscovery(
+            wellKnownPaths: [],
+            // Leading colon (= cwd), a relative entry, and a trailing slash.
+            environment: ["PATH": ":relative/bin:\(pathDir)/"],
+            runner: ProbeRunner([:])
+        )
+        #expect(discovery.candidatePaths() == [candidate])
+    }
+
+    @Test("non-executable files and directories are never candidates")
+    func onlyExecutableRegularFilesAreCandidates() throws {
+        let binaries = try FakeBinaries()
+        defer { binaries.cleanup() }
+        let notExecutable = try binaries.makeNonExecutable("a/restic")
+        let directoryNamedRestic = try binaries.directory("b/restic")
+        let good = try binaries.makeExecutable("c/restic")
+
+        let discovery = ResticDiscovery(
+            wellKnownPaths: [notExecutable, directoryNamedRestic, good],
+            environment: [:],
+            runner: ProbeRunner([:])
+        )
+        #expect(discovery.candidatePaths() == [good])
+    }
+
+    @Test("a symlink to an already-seen binary is not probed twice")
+    func symlinksAreDeduplicated() throws {
+        let binaries = try FakeBinaries()
+        defer { binaries.cleanup() }
+        let real = try binaries.makeExecutable("real/restic")
+        let linkDir = try binaries.directory("link")
+        let link = linkDir + "/restic"
+        try FileManager.default.createSymbolicLink(atPath: link, withDestinationPath: real)
+
+        let discovery = ResticDiscovery(
+            wellKnownPaths: [real, link],
+            environment: [:],
+            runner: ProbeRunner([:])
+        )
+        #expect(discovery.candidatePaths() == [real])
+    }
+
+    @Test("a pathological PATH cannot exceed the candidate cap")
+    func candidateCountIsCapped() throws {
+        let binaries = try FakeBinaries()
+        defer { binaries.cleanup() }
+        var directories: [String] = []
+        for index in 0..<(ResticDiscovery.maxCandidates + 10) {
+            directories.append(try binaries.directory("bin\(index)"))
+            try binaries.makeExecutable("bin\(index)/restic")
+        }
+
+        let discovery = ResticDiscovery(
+            wellKnownPaths: [],
+            environment: ["PATH": directories.joined(separator: ":")],
+            runner: ProbeRunner([:])
+        )
+        #expect(discovery.candidatePaths().count == ResticDiscovery.maxCandidates)
+    }
+
+    @Test("the cap bounds how many candidates are actually executed")
+    func discoveryExecutesNoMoreThanTheCap() async throws {
+        let binaries = try FakeBinaries()
+        defer { binaries.cleanup() }
+        var directories: [String] = []
+        for index in 0..<(ResticDiscovery.maxCandidates + 10) {
+            directories.append(try binaries.directory("bin\(index)"))
+            try binaries.makeExecutable("bin\(index)/restic")
+        }
+
+        // Every candidate exists and is +x, and none of them run: the worst
+        // case, where only the cap stops the search.
+        let runner = ProbeRunner([:])
+        let discovery = ResticDiscovery(
+            wellKnownPaths: [],
+            environment: ["PATH": directories.joined(separator: ":")],
+            runner: runner
+        )
+        let result = await discovery.discover()
+        #expect(result.chosen == nil)
+        #expect(runner.calls.count == ResticDiscovery.maxCandidates)
+    }
+
+    // MARK: - The probe-by-running rule
+
+    @Test("a candidate that exists and is +x but fails to run is NOT found")
+    func executableThatCannotRunIsRejected() async throws {
+        let binaries = try FakeBinaries()
+        defer { binaries.cleanup() }
+        let shim = try binaries.makeExecutable("opt/homebrew/bin/restic")
+
+        // The filesystem says yes to both questions discovery is allowed to
+        // ask cheaply…
+        #expect(FileManager.default.fileExists(atPath: shim))
+        #expect(FileManager.default.isExecutableFile(atPath: shim))
+
+        let runner = ProbeRunner([shim: .failsToLaunch])
+        let discovery = ResticDiscovery(wellKnownPaths: [shim], environment: [:], runner: runner)
+
+        let result = await discovery.discover()
+        // …and it is still not a find, because it never ran.
+        #expect(result.chosen == nil)
+        #expect(result.rejected.count == 1)
+        #expect(result.rejected[0].path == shim)
+        #expect(result.rejected[0].isUsable == false)
+        if case .unusable = result.rejected[0].outcome {} else {
+            Issue.record("expected .unusable, got \(result.rejected[0].outcome)")
+        }
+        // And it was rejected by *running* it, not by inspecting it.
+        #expect(runner.probedPaths == [shim])
+        #expect(runner.calls[0].argv == [shim, "version", "--json"])
+    }
+
+    @Test("a candidate that runs but is not restic is NOT found")
+    func executableThatIsNotResticIsRejected() async throws {
+        let binaries = try FakeBinaries()
+        defer { binaries.cleanup() }
+        let impostor = try binaries.makeExecutable("bin/restic")
+
+        let runner = ProbeRunner([impostor: .printsGarbage("restic 0.18.1 compiled with go1.22\n")])
+        let discovery = ResticDiscovery(wellKnownPaths: [impostor], environment: [:], runner: runner)
+
+        let result = await discovery.discover()
+        #expect(result.chosen == nil)
+        #expect(result.rejected.first?.version == nil)
+    }
+
+    @Test("a candidate that runs and exits nonzero is NOT found")
+    func executableThatExitsNonzeroIsRejected() async throws {
+        let binaries = try FakeBinaries()
+        defer { binaries.cleanup() }
+        let broken = try binaries.makeExecutable("bin/restic")
+
+        let runner = ProbeRunner([
+            broken: .exits(code: 127, stderr: "Error: restic is not installed"),
+        ])
+        let discovery = ResticDiscovery(wellKnownPaths: [broken], environment: [:], runner: runner)
+
+        let result = await discovery.discover()
+        #expect(result.chosen == nil)
+        if case .unusable(let reason) = result.rejected.first?.outcome {
+            #expect(reason.contains("127"))
+            #expect(reason.contains("restic is not installed"))
+        } else {
+            Issue.record("expected .unusable with the exit code and stderr")
+        }
+    }
+
+    @Test("probing never inherits an environment and always carries the timeout")
+    func everyProbeIsBoundedAndEnvironmentFree() async throws {
+        let binaries = try FakeBinaries()
+        defer { binaries.cleanup() }
+        let hung = try binaries.makeExecutable("a/restic")
+        let good = try binaries.makeExecutable("b/restic")
+
+        let runner = ProbeRunner([hung: .timesOut, good: .reports(version: "0.18.1")])
+        let discovery = ResticDiscovery(
+            wellKnownPaths: [hung, good],
+            environment: [:],
+            runner: runner
+        )
+
+        let result = await discovery.discover()
+        #expect(result.chosen?.path == good)
+        // A hung candidate is bounded and does not abort the search.
+        #expect(runner.calls.count == 2)
+        for call in runner.calls {
+            #expect(call.timeout == ResticDiscovery.probeTimeout)
+        }
+        if case .unusable(let reason) = result.rejected.first?.outcome {
+            #expect(reason.contains("did not respond"))
+        } else {
+            Issue.record("expected the timed-out candidate to be reported as unusable")
+        }
+    }
+
+    // MARK: - Version gating and ordering
+
+    @Test("the first candidate meeting the minimum wins and stops the search")
+    func firstUsableCandidateWins() async throws {
+        let binaries = try FakeBinaries()
+        defer { binaries.cleanup() }
+        let first = try binaries.makeExecutable("a/restic")
+        let second = try binaries.makeExecutable("b/restic")
+
+        let runner = ProbeRunner([
+            first: .reports(version: "0.18.1"),
+            second: .reports(version: "0.19.0"),
+        ])
+        let discovery = ResticDiscovery(
+            wellKnownPaths: [first, second],
+            environment: [:],
+            runner: runner
+        )
+
+        let result = await discovery.discover()
+        #expect(result.chosen?.path == first)
+        #expect(result.chosen?.version == "0.18.1")
+        #expect(runner.probedPaths == [first], "the search must stop at the first usable candidate")
+    }
+
+    @Test("a too-old binary is remembered but does not end the search")
+    func tooOldIsRememberedAndOvertaken() async throws {
+        let binaries = try FakeBinaries()
+        defer { binaries.cleanup() }
+        let old = try binaries.makeExecutable("a/restic")
+        let new = try binaries.makeExecutable("b/restic")
+
+        let runner = ProbeRunner([
+            old: .reports(version: "0.16.4"),
+            new: .reports(version: "0.18.1"),
+        ])
+        let discovery = ResticDiscovery(
+            wellKnownPaths: [old, new],
+            environment: [:],
+            runner: runner
+        )
+
+        let result = await discovery.discover()
+        #expect(result.chosen?.path == new)
+        #expect(result.firstTooOld?.path == old)
+        #expect(result.firstTooOld?.version == "0.16.4")
+    }
+
+    @Test("the minimum version is the documented one")
+    func minimumVersionIsDocumented() {
+        #expect(ResticDiscovery.minimumVersion == "0.17.0")
+    }
+
+    // MARK: - probe(path:)
+
+    @Test("a relative path is refused without running anything")
+    func relativePathIsRefused() async {
+        let runner = ProbeRunner([:])
+        let discovery = ResticDiscovery(wellKnownPaths: [], environment: [:], runner: runner)
+        let probe = await discovery.probe(path: "restic")
+        #expect(probe.isUsable == false)
+        #expect(runner.calls.isEmpty)
+    }
+
+    @Test("a nonexistent path is refused without running anything")
+    func missingPathIsRefused() async throws {
+        let binaries = try FakeBinaries()
+        defer { binaries.cleanup() }
+        let runner = ProbeRunner([:])
+        let discovery = ResticDiscovery(wellKnownPaths: [], environment: [:], runner: runner)
+        let probe = await discovery.probe(path: binaries.root.appendingPathComponent("nope").path)
+        #expect(probe.isUsable == false)
+        #expect(runner.calls.isEmpty)
+    }
+
+    // MARK: - searchedDescription
+
+    @Test("the failure message names what was searched")
+    func searchedDescriptionNamesTheList() {
+        let discovery = ResticDiscovery(
+            wellKnownPaths: ResticDiscovery.linuxWellKnownPaths,
+            environment: [:],
+            runner: ProbeRunner([:])
+        )
+        #expect(discovery.searchedDescription
+            == "/usr/bin/restic, /usr/local/bin/restic, /opt/restic/bin/restic, and every directory on PATH")
+    }
+}

--- a/Core/Tests/ResticStationCoreTests/Support/HealthDerivationTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Support/HealthDerivationTests.swift
@@ -500,6 +500,39 @@ private func currentRun(percentDone: Double, phase: String = "backing-up-primary
         ) == .warning)
     }
 
+    // MARK: fda-check.json absent-file semantics (T25)
+
+    @Test("an absent fda-check.json is 'not applicable', never 'denied'")
+    func absentFdaCheckIsNotADenial() {
+        // Absent on Linux always (no TCC, so `fda-check` writes nothing) and
+        // on macOS until the first probe runs.
+        #expect(HealthDerivation.fullDiskAccessDenied(from: nil) == false)
+        #expect(HealthDerivation.appHealth(
+            setHealths: [health()],
+            anyRunInFlight: false,
+            fullDiskAccessDenied: HealthDerivation.fullDiskAccessDenied(from: nil),
+            backgroundAgentEnabled: true
+        ) == .idle)
+    }
+
+    @Test("only an explicit hasFullDiskAccess == false is a denial")
+    func onlyAnExplicitDenialCounts() {
+        let granted = FdaCheckResult(
+            checkedAt: Date(timeIntervalSince1970: 1_800_000_000),
+            hasFullDiskAccess: true,
+            probedPath: "~/Library/Safari",
+            context: "launchd"
+        )
+        let denied = FdaCheckResult(
+            checkedAt: Date(timeIntervalSince1970: 1_800_000_000),
+            hasFullDiskAccess: false,
+            probedPath: "~/Library/Safari",
+            context: "launchd"
+        )
+        #expect(HealthDerivation.fullDiskAccessDenied(from: granted) == false)
+        #expect(HealthDerivation.fullDiskAccessDenied(from: denied) == true)
+    }
+
     @Test func disabledBackgroundAgentIsAWarning() {
         #expect(HealthDerivation.appHealth(
             setHealths: [health()],

--- a/Helper/Sources/Commands/FdaCheck.swift
+++ b/Helper/Sources/Commands/FdaCheck.swift
@@ -9,20 +9,37 @@ import ResticStationCore
 /// result to `state/fda-check.json` so both "App" and "Background agent"
 /// badges in onboarding can be shown.
 ///
+/// **macOS-only behaviour, present on every platform.** Full Disk Access is
+/// a macOS TCC concept; on Linux ordinary file permissions govern access and
+/// there is nothing to probe. The subcommand still exists there — so scripts
+/// and docs are uniform — but reports "not applicable" and, crucially, does
+/// **not** write `state/fda-check.json`. Writing a fake "granted" record
+/// would make the file's meaning platform-dependent; an absent file already
+/// means "the probe has never run", which every reader treats as *unknown*,
+/// never as *denied* (`HealthDerivation.fullDiskAccessDenied(from:)`).
+///
 /// Does not go through `HelperContext.make()`: no restic path is needed to
 /// probe FDA, and this command must succeed even before restic is
 /// configured (it's part of onboarding, which runs before that).
 struct FdaCheck: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "fda-check",
-        abstract: "Probe Full Disk Access and record the result to state/fda-check.json. Always exits 0."
+        abstract: "Probe Full Disk Access and record the result to state/fda-check.json "
+            + "(macOS only; a no-op elsewhere). Always exits 0."
     )
 
     @Option(name: .long, help: "Which process context ran the probe: \"launchd\" or \"app\".")
     var context: String = "launchd"
 
     func run() async throws {
-        let result = Self.probeAndRecord(context: context, stateStore: StateStore(paths: AppPaths.default()))
+        guard let result = Self.probeAndRecord(
+            context: context,
+            stateStore: StateStore(paths: AppPaths.default())
+        ) else {
+            print("full disk access: not applicable on this platform (no TCC outside macOS); "
+                + "state/fda-check.json not written.")
+            return
+        }
         print("full disk access: \(result.hasFullDiskAccess ? "granted" : "not granted") (probed \(result.probedPath), context: \(context))")
     }
 
@@ -30,8 +47,11 @@ struct FdaCheck: AsyncParsableCommand {
     /// so the "Background agent" badge always has fresh launchd-context
     /// evidence (docs/keychain-and-fda.md §2 — the app deliberately never
     /// writes this file itself).
+    ///
+    /// Returns `nil` on non-macOS platforms, having written nothing.
     @discardableResult
-    static func probeAndRecord(context: String, stateStore: StateStore) -> FdaCheckResult {
+    static func probeAndRecord(context: String, stateStore: StateStore) -> FdaCheckResult? {
+        #if os(macOS)
         let home = FileManager.default.homeDirectoryForCurrentUser
         let safari = home.appendingPathComponent("Library/Safari", isDirectory: true)
         let mail = home.appendingPathComponent("Library/Mail", isDirectory: true)
@@ -53,5 +73,10 @@ struct FdaCheck: AsyncParsableCommand {
             FileHandle.standardError.write(Data("fda-check: could not write state: \(error)\n".utf8))
         }
         return result
+        #else
+        _ = context
+        _ = stateStore
+        return nil
+        #endif
     }
 }

--- a/Helper/Sources/Commands/InitSecondary.swift
+++ b/Helper/Sources/Commands/InitSecondary.swift
@@ -17,7 +17,7 @@ struct InitSecondary: AsyncParsableCommand {
     var dest: UUID
 
     func run() async throws {
-        let context = HelperContext.make()
+        let context = await HelperContext.make()
         guard let backupSet = context.config.sets.first(where: { $0.id == set }) else {
             HelperExit.fail("no backup set with id \(set)")
         }

--- a/Helper/Sources/Commands/ProbeRepo.swift
+++ b/Helper/Sources/Commands/ProbeRepo.swift
@@ -19,7 +19,7 @@ struct ProbeRepo: AsyncParsableCommand {
     var dest: UUID
 
     func run() async throws {
-        let context = HelperContext.make()
+        let context = await HelperContext.make()
         guard let backupSet = context.config.sets.first(where: { $0.id == set }) else {
             HelperExit.fail("no backup set with id \(set)")
         }

--- a/Helper/Sources/Commands/Restore.swift
+++ b/Helper/Sources/Commands/Restore.swift
@@ -39,7 +39,7 @@ struct Restore: AsyncParsableCommand {
     var overwrite: ResticCommand.OverwriteMode?
 
     func run() async throws {
-        let context = HelperContext.make()
+        let context = await HelperContext.make()
         guard let backupSet = context.config.sets.first(where: { $0.id == set }) else {
             HelperExit.fail("no backup set with id \(set)")
         }

--- a/Helper/Sources/Commands/RunSet.swift
+++ b/Helper/Sources/Commands/RunSet.swift
@@ -25,7 +25,7 @@ struct RunSet: AsyncParsableCommand {
     var kind: Kind = .backup
 
     func run() async throws {
-        let context = HelperContext.make()
+        let context = await HelperContext.make()
         guard let backupSet = context.config.sets.first(where: { $0.id == set }) else {
             HelperExit.fail("no backup set with id \(set)")
         }

--- a/Helper/Sources/Commands/Tick.swift
+++ b/Helper/Sources/Commands/Tick.swift
@@ -42,10 +42,15 @@ struct Tick: AsyncParsableCommand {
             print("no backup sets")
             return
         }
-        guard let context = HelperContext.makeTolerant(paths: paths, config: config, configStore: configStore) else {
-            // RunAtLoad tolerance: nothing usable configured yet (no restic
-            // path) — not a hard error, tick just has nothing to do.
-            print("restic not configured — open Restic Station")
+        guard let context = await HelperContext.makeTolerant(
+            paths: paths,
+            config: config,
+            configStore: configStore
+        ) else {
+            // RunAtLoad tolerance: nothing usable configured yet, and
+            // discovery found no restic either — not a hard error, tick just
+            // has nothing to do.
+            print(HelperContext.resticNotFoundMessage(paths: paths))
             return
         }
 

--- a/Helper/Sources/Commands/Unlock.swift
+++ b/Helper/Sources/Commands/Unlock.swift
@@ -52,7 +52,7 @@ struct Unlock: AsyncParsableCommand {
     var dest: UUID
 
     func run() async throws {
-        let context = HelperContext.make()
+        let context = await HelperContext.make()
         guard let backupSet = context.config.sets.first(where: { $0.id == set }) else {
             HelperExit.fail("no backup set with id \(set)")
         }

--- a/Helper/Sources/HelperContext.swift
+++ b/Helper/Sources/HelperContext.swift
@@ -48,9 +48,9 @@ struct HelperContext {
 
     /// The strict entry point used by every subcommand except `tick`:
     /// loads config from disk (a hard I/O/decode/version error → exit 1),
-    /// then requires a configured restic path (missing → exit 1, "restic
-    /// not configured — open Restic Station" per the T10 task file).
-    static func make() -> HelperContext {
+    /// then resolves a restic path (unresolvable → exit 1 with
+    /// `resticNotFoundMessage`).
+    static func make() async -> HelperContext {
         let paths = AppPaths.default()
         let configStore = ConfigStore(paths: paths)
         let config: AppConfig
@@ -59,18 +59,18 @@ struct HelperContext {
         } catch {
             HelperExit.fail("could not load configuration: \(error)")
         }
-        guard let context = makeTolerant(paths: paths, config: config, configStore: configStore) else {
-            HelperExit.fail("restic not configured — open Restic Station")
+        guard let context = await makeTolerant(paths: paths, config: config, configStore: configStore) else {
+            HelperExit.fail(resticNotFoundMessage(paths: paths))
         }
         return context
     }
 
     /// The lenient constructor `tick` uses: `tick`'s own contract is "exit 0
     /// always, except a hard config-load error" (`docs/scheduling.md`
-    /// §Tick algorithm) — a missing restic path must not be treated as a
-    /// hard error there, so this returns `nil` instead of exiting.
-    static func makeTolerant(paths: AppPaths, config: AppConfig, configStore: ConfigStore) -> HelperContext? {
-        guard let resticPath = config.resticPath, !resticPath.isEmpty else {
+    /// §Tick algorithm) — an unresolvable restic path must not be treated as
+    /// a hard error there, so this returns `nil` instead of exiting.
+    static func makeTolerant(paths: AppPaths, config: AppConfig, configStore: ConfigStore) async -> HelperContext? {
+        guard let resticPath = await resolveResticPath(config: config) else {
             return nil
         }
         let processRunner = DefaultProcessRunner()

--- a/Helper/Sources/ResticPathResolution.swift
+++ b/Helper/Sources/ResticPathResolution.swift
@@ -1,0 +1,84 @@
+import Foundation
+import ResticStationCore
+
+/// How the helper decides *which* restic binary to run (T25).
+///
+/// Kept out of `HelperContext.swift` so the wiring there stays a single
+/// `await resolveResticPath(config:)` line.
+extension HelperContext {
+
+    /// Resolves the restic binary this invocation should use.
+    ///
+    /// Order:
+    ///
+    /// 1. **`machine.json` `resticPath`** — the per-machine override. Not
+    ///    implemented yet; see the `TODO(#26)` below.
+    /// 2. **`AppConfig.resticPath`** — deprecated. `config.json` is shared
+    ///    across machines (it is the file a user syncs), so a path that is
+    ///    correct on one host is wrong on the next. Still honoured because
+    ///    every existing macOS install has it set.
+    /// 3. **Discovery** — probe the platform's well-known locations and
+    ///    `PATH`, running each candidate (`ResticDiscovery`). This is what
+    ///    makes a headless Linux host work with no configuration at all.
+    ///
+    /// A discovered path is deliberately **not** written back into
+    /// `config.json`: that file is shared across machines, and persisting
+    /// one host's `/usr/bin/restic` there would break the next one. It is
+    /// logged once instead, so `journalctl`/`log show` can answer "which
+    /// restic did it actually run?".
+    static func resolveResticPath(
+        config: AppConfig,
+        discovery: ResticDiscovery = ResticDiscovery(),
+        log: @Sendable (String) -> Void = { HelperLog.info($0) }
+    ) async -> String? {
+        // TODO(#26): machine.json `resticPath` is checked here, ahead of the
+        // deprecated config.json fallback below. One line:
+        //     if let machinePath = machine.resticPath, !machinePath.isEmpty { return machinePath }
+
+        if let configured = config.resticPath, !configured.isEmpty {
+            return configured
+        }
+
+        let result = await discovery.discover()
+        guard let chosen = result.chosen else {
+            return nil
+        }
+        log("restic not configured; discovered \(chosen.path) (version \(chosen.version ?? "unknown"))")
+        return chosen.path
+    }
+
+    /// What to print when nothing resolved.
+    ///
+    /// On macOS this stays the T10 wording verbatim — there *is* an app to
+    /// open, and onboarding walks the user through picking a binary.
+    /// On Linux that advice is impossible to follow on a headless host, so
+    /// the message names what was searched and how to fix it.
+    static func resticNotFoundMessage(
+        paths: AppPaths,
+        discovery: ResticDiscovery = ResticDiscovery()
+    ) -> String {
+        #if os(macOS)
+        return "restic not configured — open Restic Station"
+        #else
+        // TODO(#26): once machine.json exists, point at
+        // `paths.machineFile.path` rather than config.json — a per-machine
+        // override is the right place for a per-machine binary path.
+        return """
+            restic not found. Searched \(discovery.searchedDescription).
+            Install restic (for example `apt install restic` or \
+            `dnf install restic`), or set "resticPath" in \(paths.configFile.path).
+            """
+        #endif
+    }
+}
+
+// MARK: - HelperLog
+
+/// The helper's one-line logging surface. stderr rather than stdout: stdout
+/// is each subcommand's result channel (scripts parse it), and launchd /
+/// systemd capture both streams anyway.
+enum HelperLog {
+    static func info(_ message: String) {
+        FileHandle.standardError.write(Data("info: \(message)\n".utf8))
+    }
+}

--- a/Helper/Tests/HelperTests/PlatformConditionalTests.swift
+++ b/Helper/Tests/HelperTests/PlatformConditionalTests.swift
@@ -1,0 +1,221 @@
+import Foundation
+import Testing
+
+import ResticStationCore
+@testable import restic_station_helper
+
+/// T25: the two macOS-specific behaviours the helper used to assume were
+/// universal — the Full Disk Access probe and "the app will configure restic
+/// for you" — are now platform-conditional. These tests run on both
+/// platforms and assert whichever half applies.
+
+// MARK: - fda-check
+
+@Suite struct FdaCheckPlatformTests {
+
+    /// A temp `AppPaths` so the probe (on macOS) writes somewhere disposable
+    /// rather than into the developer's real Application Support directory.
+    private func makeTempPaths() throws -> (AppPaths, () -> Void) {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("fda-check-\(UUID().uuidString)", isDirectory: true)
+        let paths = AppPaths(root: root)
+        try paths.ensureDirectories()
+        return (paths, { try? FileManager.default.removeItem(at: root) })
+    }
+
+    @Test("fda-check writes state/fda-check.json on macOS and nothing elsewhere")
+    func probeAndRecordIsPlatformConditional() throws {
+        let (paths, cleanup) = try makeTempPaths()
+        defer { cleanup() }
+
+        let result = FdaCheck.probeAndRecord(context: "unit-test", stateStore: StateStore(paths: paths))
+        let fileExists = FileManager.default.fileExists(atPath: paths.fdaCheckFile.path)
+
+        #if os(macOS)
+        // Unchanged behaviour: a record is produced and written, whatever the
+        // verdict (a test process usually has no FDA, which is fine — the
+        // schema and the write are what matter here).
+        #expect(result != nil)
+        #expect(result?.context == "unit-test")
+        #expect(result?.probedPath == "~/Library/Safari" || result?.probedPath == "~/Library/Mail")
+        #expect(fileExists)
+        // Field-wise, not whole-struct: `checkedAt` round-trips through the
+        // documented second-precision ISO-8601 encoding.
+        let reread = StateStore(paths: paths).readFdaCheck()
+        #expect(reread?.hasFullDiskAccess == result?.hasFullDiskAccess)
+        #expect(reread?.probedPath == result?.probedPath)
+        #expect(reread?.context == "unit-test")
+        #else
+        // On Linux there is no TCC. Writing a fake "granted" record would
+        // make the file's meaning platform-dependent, so nothing is written
+        // at all.
+        #expect(result == nil)
+        #expect(fileExists == false)
+        #endif
+    }
+
+    @Test("fda-check stays registered on every platform, so scripts are uniform")
+    func fdaCheckIsStillASubcommand() {
+        let names: [String?] = HelperMain.configuration.subcommands.map { subcommand in
+            subcommand.configuration.commandName
+        }
+        #expect(names.contains("fda-check"))
+    }
+}
+
+// MARK: - restic path resolution
+
+@Suite struct ResticPathResolutionTests {
+
+    /// `ProcessRunning` double that reports a usable restic for one specific
+    /// path and refuses to launch anything else.
+    private final class OneGoodBinary: ProcessRunning, @unchecked Sendable {
+        let goodPath: String
+        init(goodPath: String) { self.goodPath = goodPath }
+
+        func run(
+            _ argv: [String],
+            env: [String: String]?,
+            currentDirectory: String?,
+            onStdoutLine: (@Sendable (String) -> Void)?,
+            onStderrLine: (@Sendable (String) -> Void)?,
+            timeout: TimeInterval?
+        ) async throws -> ProcessResult {
+            guard argv.first == goodPath else {
+                throw ProcessRunnerError.launchFailed("not restic")
+            }
+            let json = #"{"version":"0.18.1","go_version":"go1.22.0","go_os":"linux","go_arch":"arm64"}"#
+            return ProcessResult(exitCode: 0, stdout: Data(json.utf8), stderr: Data())
+        }
+    }
+
+    private func makeFakeRestic() throws -> (path: String, cleanup: () -> Void) {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("restic-resolve-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let binary = dir.appendingPathComponent("restic")
+        try Data("#!/bin/sh\nexit 0\n".utf8).write(to: binary)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: binary.path)
+        return (binary.path, { try? FileManager.default.removeItem(at: dir) })
+    }
+
+    @Test("a configured resticPath wins without running discovery at all")
+    func configuredPathWins() async throws {
+        let fake = try makeFakeRestic()
+        defer { fake.cleanup() }
+
+        // Discovery is pointed at a binary that *would* be found, to prove
+        // the configured value short-circuits it.
+        let discovery = ResticDiscovery(
+            wellKnownPaths: [fake.path],
+            environment: [:],
+            runner: OneGoodBinary(goodPath: fake.path)
+        )
+        let resolved = await HelperContext.resolveResticPath(
+            config: AppConfig(resticPath: "/configured/restic"),
+            discovery: discovery,
+            log: { _ in Issue.record("nothing should be logged when config already has a path") }
+        )
+        #expect(resolved == "/configured/restic")
+    }
+
+    @Test("with nothing configured, a discoverable binary is used and logged once")
+    func discoveryFillsInForAnUnconfiguredHost() async throws {
+        let fake = try makeFakeRestic()
+        defer { fake.cleanup() }
+
+        let discovery = ResticDiscovery(
+            wellKnownPaths: [fake.path],
+            environment: [:],
+            runner: OneGoodBinary(goodPath: fake.path)
+        )
+        let logged = LogSink()
+        let resolved = await HelperContext.resolveResticPath(
+            config: AppConfig(resticPath: nil),
+            discovery: discovery,
+            log: { logged.append($0) }
+        )
+        #expect(resolved == fake.path)
+        #expect(logged.messages.count == 1)
+        #expect(logged.messages.first?.contains(fake.path) == true)
+    }
+
+    @Test("an empty configured path is treated as unset")
+    func emptyConfiguredPathFallsThroughToDiscovery() async throws {
+        let fake = try makeFakeRestic()
+        defer { fake.cleanup() }
+
+        let discovery = ResticDiscovery(
+            wellKnownPaths: [fake.path],
+            environment: [:],
+            runner: OneGoodBinary(goodPath: fake.path)
+        )
+        let resolved = await HelperContext.resolveResticPath(
+            config: AppConfig(resticPath: ""),
+            discovery: discovery,
+            log: { _ in }
+        )
+        #expect(resolved == fake.path)
+    }
+
+    @Test("nothing configured and nothing discoverable resolves to nil")
+    func nothingAnywhereResolvesToNil() async throws {
+        let fake = try makeFakeRestic()
+        defer { fake.cleanup() }
+
+        // The candidate exists and is +x, but does not run.
+        let discovery = ResticDiscovery(
+            wellKnownPaths: [fake.path],
+            environment: [:],
+            runner: OneGoodBinary(goodPath: "/nowhere/restic")
+        )
+        let resolved = await HelperContext.resolveResticPath(
+            config: AppConfig(resticPath: nil),
+            discovery: discovery,
+            log: { _ in Issue.record("nothing should be logged when nothing was found") }
+        )
+        #expect(resolved == nil)
+    }
+
+    @Test("the not-found message is actionable on the platform it is printed on")
+    func notFoundMessageIsPlatformAppropriate() {
+        let paths = AppPaths(root: URL(fileURLWithPath: "/tmp/restic-station-test", isDirectory: true))
+        let discovery = ResticDiscovery(
+            wellKnownPaths: ResticDiscovery.wellKnownPaths,
+            environment: [:],
+            runner: OneGoodBinary(goodPath: "")
+        )
+        let message = HelperContext.resticNotFoundMessage(paths: paths, discovery: discovery)
+
+        #if os(macOS)
+        // The T10 wording, verbatim — on macOS there really is an app to open.
+        #expect(message == "restic not configured — open Restic Station")
+        #else
+        // Headless: name what was searched and how to fix it.
+        #expect(message.contains("/usr/bin/restic"))
+        #expect(message.contains("/opt/restic/bin/restic"))
+        #expect(message.contains("every directory on PATH"))
+        #expect(message.contains("install restic") || message.contains("Install restic"))
+        #expect(message.contains(paths.configFile.path))
+        #expect(!message.contains("open Restic Station"))
+        #endif
+    }
+}
+
+/// Collects the info-level lines `resolveResticPath` emits.
+private final class LogSink: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _messages: [String] = []
+
+    func append(_ message: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        _messages.append(message)
+    }
+
+    var messages: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return _messages
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,7 +17,7 @@ Shared state on disk: ~/Library/Application Support/ResticStation/
 Secrets: macOS login Keychain (service "restic-station")
 ```
 
-1. **`ResticStationCore`** — local Swift package at `Core/`. Contains **all** logic: config model + store, keychain client, restic runner + command builders + parsers, schedule math, run store, file locking, backup engine, reachability, state store. No UI. Depends only on Foundation (+ swift-argument-parser is *not* here; it's a Helper dependency). `Package.swift` declares `platforms: [.macOS(.v14)]` so `swift test --package-path Core` works standalone.
+1. **`ResticStationCore`** — local Swift package at `Core/`. Contains **all** logic: config model + store, keychain client, restic runner + command builders + parsers, restic discovery, schedule math, run store, file locking, backup engine, reachability, state store. No UI. Depends only on Foundation (+ swift-argument-parser is *not* here; it's a Helper dependency). `Package.swift` declares `platforms: [.macOS(.v14)]` so `swift test --package-path Core` works standalone.
 2. **`restic-station-helper`** — command-line executable target, embedded in the app bundle at `Contents/MacOS/restic-station-helper`. Uses swift-argument-parser. Subcommands: `tick`, `run-set`, `init-secondary`, `probe-repo`, `restore`, `fda-check`, `version`. Each invocation does its work and **exits** — it never daemonizes. launchd re-fires it via `StartInterval`.
 3. **`Restic Station.app`** — SwiftUI app. Regular app (Dock icon + windows) plus a `MenuBarExtra`. Registers the helper's LaunchAgent via `SMAppService`.
 
@@ -62,6 +62,31 @@ public protocol ProcessRunning: Sendable {
 ```
 
 The production implementation (`DefaultProcessRunner`) wraps `Process` + pipes. Tests inject `FakeProcessRunner` (see `testing.md`). `KeychainClient`, `ResticRunner`, and `Reachability` all take a `ProcessRunning` in their initializers.
+
+## restic discovery
+
+`ResticDiscovery` (`Core/Sources/ResticStationCore/Restic/ResticDiscovery.swift`) finds a usable restic binary. It lives in **Core**, not `App/`: the helper needs it too, and `App/` is macOS-only.
+
+Search order: the platform's well-known package-manager locations first, then one `<dir>/restic` per `PATH` entry.
+
+| Platform | Well-known locations (in order) |
+| --- | --- |
+| macOS | `/opt/homebrew/bin/restic`, `/usr/local/bin/restic`, `/opt/local/bin/restic` |
+| Linux | `/usr/bin/restic`, `/usr/local/bin/restic`, `/opt/restic/bin/restic` |
+
+Three rules, all load-bearing:
+
+1. **A candidate is "found" only if it *ran*.** Existence plus the `+x` bit is a filter, never the answer — a Homebrew shim for an uninstalled formula, an x86 binary with no Rosetta, a distro wrapper for an uninstalled package, and a dangling symlink all pass `isExecutableFile` and fail to execute. Every reported version comes from a real `restic version --json` round trip, compared against the documented minimum (0.17.0, `restic-cli.md` §version).
+2. **Per-candidate timeout** (5 s) so a binary on an unresponsive network mount cannot stall onboarding, and a **cap of 24 candidates executed per search** so a pathological `PATH` cannot either.
+3. **Only absolute paths.** Relative `PATH` entries (including the empty entry POSIX shells read as the current directory) are dropped: the resolved path is consumed by a helper running headless with an unrelated working directory.
+
+**Who resolves what.** The app persists a user-chosen or discovered path into `config.json`'s `resticPath` and shows the rejected candidates in Settings. The helper resolves independently, in this order:
+
+1. `machine.json` `resticPath` — the per-machine override (T24; not implemented yet, see the `TODO(#26)` in `Helper/Sources/ResticPathResolution.swift`).
+2. `config.json` `resticPath` — deprecated. `config.json` is shared across machines, so a path correct on one host is wrong on the next.
+3. Discovery.
+
+A discovered path is logged once at info level and deliberately **not** written back into `config.json`. When nothing resolves, macOS prints the T10 wording ("restic not configured — open Restic Station"); Linux, where there is no app to open, prints what was searched and how to fix it.
 
 ## Error taxonomy
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -199,6 +199,8 @@ Superset of the index line, plus: `pid`, `resticExitCode`, `argvRedacted` (argv 
 { "checkedAt": "2026-07-26T20:57:00Z", "hasFullDiskAccess": true, "probedPath": "~/Library/Safari", "context": "launchd" }
 ```
 
+**macOS only, and absence is meaningful.** The file is written only by the macOS `fda-check` probe; on other platforms the subcommand writes nothing at all. An absent file means "not applicable / not yet known", **never** "denied" — see `keychain-and-fda.md` §2 for the normative rule and `HealthDerivation.fullDiskAccessDenied(from:)` for its single implementation.
+
 ## Versioning & migration
 
 `AppConfig.version` starts at 1. Loader behavior: version > current → refuse with clear error ("config written by a newer Restic Station"); version < current → run in-code migration chain then save. State/run files carry no version field — they are regenerable caches/history; on decode failure, skip the record and log, never crash.

--- a/docs/keychain-and-fda.md
+++ b/docs/keychain-and-fda.md
@@ -35,11 +35,31 @@ A `RunAtLoad` tick can fire before the login keychain is unlocked; `find-generic
 
 ## 2. Full Disk Access (TCC)
 
+**macOS only.** TCC is a macOS mechanism; on Linux there is no equivalent and ordinary file permissions govern access to everything. Everything in this section applies to the macOS build alone.
+
 - Reading `~/Library/Mail`, `~/Library/Safari`, Messages, etc. requires FDA. **There is no prompt and no request API** — the user must add the app in System Settings → Privacy & Security → Full Disk Access. Deep link: `x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles`.
 - **Attribution:** processes launched by launchd are normally self-responsible for TCC. But an SMAppService agent whose plist uses `BundleProgram` runs with the containing app as the responsible bundle — so granting FDA to **Restic Station.app** is expected to cover the embedded helper. This is the designed behavior on macOS 14/15, but it has real-world edge cases (unsigned dev builds, app relocated after registration), so we verify empirically instead of assuming:
 - **Verification protocol:** the helper has an `fda-check` subcommand: attempt `FileManager.contentsOfDirectory` on `~/Library/Safari` (fall back to `~/Library/Mail` if Safari dir absent); write `{hasFullDiskAccess, probedPath, checkedAt, context:"launchd"}` to `state/fda-check.json`. The app (a) runs the same probe in-process (`context:"app"`), and (b) triggers a real launchd-context probe via `launchctl kickstart -k gui/<uid>/net.herila.ResticStation.helper` and reads the state file. Onboarding shows BOTH results as separate badges — "App" and "Background agent" — because they can genuinely differ.
 - **Troubleshooting fallback (docs + onboarding help text):** if the app has FDA but the launchd probe still reports denied, add the helper binary itself via the "+" button in the FDA pane: `Restic Station.app/Contents/MacOS/restic-station-helper` (⌘⇧G to type the path).
 - Sources the user picks via `NSOpenPanel` are readable without FDA only by the app process (powerbox), NOT by the helper — so FDA is effectively required for any real backup of user data. Onboarding must treat FDA as a required step, not optional polish.
+
+### `fda-check` on non-macOS platforms
+
+The `fda-check` subcommand exists on **every** platform, so scripts, docs and the launchd/systemd unit stay uniform. Off macOS it prints "not applicable on this platform" and exits 0 **without writing `state/fda-check.json`**.
+
+Writing a synthetic `{"hasFullDiskAccess": true}` record was rejected deliberately: it would make the file's meaning platform-dependent and put a claim about a privacy mechanism that does not exist into a file other code reads.
+
+### Absent-file semantics (normative)
+
+**An absent `state/fda-check.json` means "not applicable / not yet known" — never "denied".** It is absent in two legitimate situations:
+
+- macOS, before the first `fda-check` has run (a fresh install, up to the first tick).
+- Linux, always.
+
+Every reader must honour this:
+
+- `HealthDerivation.fullDiskAccessDenied(from:)` (Core) is the single definition — `nil` → `false`; only an explicit `hasFullDiskAccess == false` is a denial. `AppModel` feeds `appHealth(…)` through it, so an absent file never paints the menu bar icon yellow and never degrades a set's health.
+- The Permissions pane reports an absent record as **unknown**, with its own staleness rule (evidence older than an hour is not evidence — FDA is revocable at any time).
 
 ## 3. SMAppService
 


### PR DESCRIPTION
## What changed

### 1. `ResticDiscovery` moved to Core
- `App/Sources/Support/ResticDiscovery.swift` → `Core/Sources/ResticStationCore/Restic/ResticDiscovery.swift`, made `public`. Git records it as a rename (70% similarity).
- **All three safety properties survive unchanged**, and each now has an explicit test:
  - *probe-by-running*: a candidate counts as found only if `restic version --json` actually ran and parsed. Existence + `+x` is a filter, never the answer.
  - *per-candidate timeout* (5 s), asserted on every recorded call.
  - *candidate cap* (24), asserted both on the candidate list and on how many were actually executed.
- Well-known locations are platform-conditional and injectable:

  | Platform | List |
  | --- | --- |
  | macOS | `/opt/homebrew/bin/restic`, `/usr/local/bin/restic`, `/opt/local/bin/restic` |
  | Linux | `/usr/bin/restic`, `/usr/local/bin/restic`, `/opt/restic/bin/restic` |

  `PATH` scanning is unchanged on both. `ResticDiscovery.wellKnownPaths` (which `ResticSettings` uses to seed the open panel) still resolves to the current platform's list, so the app is unaffected.
- `App/` keeps only the *UI vocabulary*: `App/Sources/Support/ResticStatusMapping.swift` holds the `ResticProbe.status` / `ResticDiscoveryResult.status` → `ResticStatus` mapping as extensions on the Core types. `ResticStatus` stays in `AppModel.swift` — Core has no business knowing about it. This is a move, not a redesign; onboarding behaviour is unchanged.
- `ResticDiscoveryResult.status` used an inline `first { if case .tooOld … }`; that predicate is now `firstTooOld` on the Core type so the App extension stays a pure mapping. Same result.

### 2. Helper resolves restic itself
`Helper/Sources/ResticPathResolution.swift` (new; kept out of `HelperContext.swift` so that file's diff stays a two-line change — see the seam note below).

Resolution order today: **`AppConfig.resticPath` (deprecated) → discovery.** A discovered path is logged once at info level to stderr and deliberately **not** written back into `config.json`, which is shared across machines.

`HelperContext.make()` / `makeTolerant(…)` became `async` (every call site was already in an `async` command body).

When nothing resolves:
- macOS: the T10 wording verbatim — `restic not configured — open Restic Station`.
- Linux: names what was searched and how to fix it, e.g.
  ```
  restic not found. Searched /usr/bin/restic, /usr/local/bin/restic, /opt/restic/bin/restic, and every directory on PATH.
  Install restic (for example `apt install restic` or `dnf install restic`), or set "resticPath" in <root>/config.json.
  ```

### 3. `fda-check` is platform-aware
- macOS: byte-identical. Same probe (`~/Library/Safari` → `~/Library/Mail`), same `state/fda-check.json` schema, same `--context` flag, same always-exit-0 contract. Verified by running the built helper and comparing the written file against `docs/data-model.md`.
- Linux: still registered as a subcommand (scripts and docs stay uniform), reports "not applicable on this platform", exits 0, and **writes nothing**. `probeAndRecord` now returns `FdaCheckResult?` — `nil` off macOS.
- Absent-file semantics are now a Core rule rather than an App comment: `HealthDerivation.fullDiskAccessDenied(from:)` — `nil` → `false`; only an explicit `hasFullDiskAccess == false` is a denial. `AppModel` feeds `appHealth(…)` through it. Tested in Core, so the Linux suite holds the rule too.

### 4. Docs
- `docs/architecture.md`: new **§restic discovery** (the section the source already cited but which did not exist) with the per-platform table, the three rules, and the app-vs-helper resolution split; Core's component blurb now lists restic discovery.
- `docs/keychain-and-fda.md` §2: states FDA is macOS-only, documents `fda-check`'s Linux no-op and why a synthetic "granted" record was rejected, and adds a normative **Absent-file semantics** subsection.
- `docs/data-model.md` §state/fda-check.json: absence is meaningful; points at the normative rule.

## How verified

**Locally (macOS, Swift 6.3.3):**
- `swift build` — clean.
- `swift test` (root) — 8 tests, green.
- `swift test --package-path Core` — 328 tests in 53 suites, green.
- `./scripts/bootstrap.sh && xcodebuild -scheme "Restic Station" build CODE_SIGNING_ALLOWED=NO -quiet` — green (a type moved out of `App/`, so this was the load-bearing check).
- Ran the built helper: `fda-check --context smoke` writes the unchanged 4-key schema; `probe-repo` with `PATH=/nonexistent` and `resticPath: null` logs `info: restic not configured; discovered /opt/homebrew/bin/restic (version 0.18.1)` and proceeds past resolution.

**In CI (Linux, the only Linux available — no local toolchain, no container runtime):** three new steps in the `linux` job:
1. `fda-check` prints "not applicable on this platform" and `state/fda-check.json` does not exist afterwards.
2. With no restic anywhere, `probe-repo` fails with the actionable message naming `/usr/bin/restic` and the config path, and *not* "open Restic Station". With a `restic` on `PATH` that answers `version --json`, the same command logs `discovered <path>` and gets through to "no backup set with id …" — i.e. an unconfigured headless host resolves restic on its own.
3. `tick` exits 0.

The new `ResticDiscovery` tests inject both the well-known list and `PATH`, and use real `+x` files in a temp directory whose fate a path-keyed fake `ProcessRunning` decides — so **macOS CI genuinely exercises the Linux code path**, and no test depends on what is installed on the runner.

### The probe-by-running rule
This is the property the issue flags as most likely to be lost in a move, so it is asserted directly rather than implied: `executableThatCannotRunIsRejected` first asserts the filesystem answers *yes* to both cheap questions (`fileExists`, `isExecutableFile`), then scripts the runner to fail to launch, then asserts `chosen == nil`, the candidate is `.unusable`, **and** that it was rejected by having been run (`argv == [path, "version", "--json"]`). Sibling tests cover the other two ways a candidate can run and still not count: exits nonzero, and prints something that is not restic's version JSON.

## `TODO(#26)` seam

`machine.json` does not exist yet (#26 / T24 owns it), so the resolution order implemented is `AppConfig.resticPath → discovery`. The `machine.json` step is a one-line insertion at a marked point in `Helper/Sources/ResticPathResolution.swift`:

```swift
// TODO(#26): machine.json `resticPath` is checked here, ahead of the
// deprecated config.json fallback below. One line:
//     if let machinePath = machine.resticPath, !machinePath.isEmpty { return machinePath }
```

A second `TODO(#26)` in `resticNotFoundMessage(paths:discovery:)` marks where the Linux message should point at `machine.json` instead of `config.json` — a per-machine override is the right place for a per-machine binary path, but naming a file that does not exist yet would be misleading advice today.

## Darwin-assumption sweep (reported, not fixed)

Grepped `Core/Sources` and `Helper/Sources` for `os(macOS)`, `canImport(Darwin)`, AppKit/ServiceManagement/Security imports, `~/Library`, `/usr/bin/`, `launchctl`, `NSWorkspace`, `Bundle.main`, `homeDirectoryForCurrentUser`, `DistributedNotification`.

**Confirmed clean:** `Reachability` (Foundation only); `StateStore.swift` ~line 356 (`DistributedNotificationCenter` already `#if os(macOS)`); `ProcessRunning`, `FileLock`, `LogWriter`, `RunStore`, `ConfigStore` (all already `canImport(Darwin)`/`Glibc`-conditional).

**Still Darwin-assuming, owned by other in-flight work — not touched:**
1. `Core/Sources/ResticStationCore/Config/AppPaths.swift` — hardcodes `~/Library/Application Support/ResticStation` and `~/Library/Caches/net.herila.ResticStation/restic`. It compiles and runs on Linux (it is just a path), but the location is wrong there; XDG dirs are the Linux convention. **Owned by #24/T22 right now**, and the task brief explicitly barred editing it.
2. `Core/Sources/ResticStationCore/Secrets/KeychainClient.swift` — hardcodes `/usr/bin/security`, which does not exist on Linux. It compiles, but every secret read fails at runtime, which means no backup can run. This is the single biggest remaining blocker for a working Linux backup. **Owned by #25/T23 (SecretStore) right now**, and likewise barred.

**New finding, unowned:**
3. `Core/Sources/ResticStationCore/Support/HelperCommand.swift` — `LaunchctlCommand.executablePath = "/bin/launchctl"` and the `kickstart` argv builders are compiled into Core on every platform. Harmless today (pure argv construction; only the macOS app ever executes it, and nothing in `Helper/` calls it), but it is macOS-only vocabulary sitting in the portable layer. When a systemd equivalent is needed, this is where the platform split belongs. Flagged rather than fixed — not in this task's scope, and changing Core's public surface would collide with the two branches above.

## Acceptance criteria

- [x] **`swift test` green on macOS** — verified locally (root: 8 tests; Core: 328 tests) and in the `macos` CI job.
- [x] **`swift test` green on Linux** — verified in the `linux` CI job (root `swift build` + `swift test` + `swift test --package-path Core`). This is the only Linux verification available; there is no local Linux toolchain or container runtime.
- [x] **The macOS app builds and its onboarding restic-discovery behaviour is unchanged** — build verified locally and in CI. "Unchanged" is verified structurally (the discovery logic is the same code, the app's call sites are untouched apart from the import boundary, and `ResticDiscovery.wellKnownPaths` still yields the macOS list) plus the moved unit tests. The onboarding *sheet* itself is not exercised by an automated UI test in this repo — that remains manual-checklist territory, as before this PR.
- [x] **A Linux host with `restic` on `PATH` and no `resticPath` configured runs the helper successfully** — verified in CI via the discovery step: with only a `PATH` restic, the helper resolves it, logs it, and proceeds past resolution. Note the CI proof runs through `probe-repo` rather than `tick`, because a `tick` that reaches a *set* would need a valid set and would then hit the `/usr/bin/security` keychain blocker above (finding 2); `tick` shares the identical `resolveResticPath` code path via `makeTolerant`, and CI asserts `tick` exits 0. Full `tick`-with-a-set on Linux is **deferred to T23** for that reason.
- [x] **`docs/keychain-and-fda.md` states FDA is macOS-only and documents the absent-file semantics; `docs/architecture.md` reflects `ResticDiscovery` living in Core** — both updated, plus `docs/data-model.md`.

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)
