### PR TITLE
T23 — SecretStore abstraction + Linux file backend + secret CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,13 +21,29 @@ jobs:
           OUT=$(.build/debug/restic-station-helper --help)
           echo "$OUT"
           # `timer` is Linux-only (T26); the macos job asserts its absence.
-          for sub in tick run-set init-secondary restore probe-repo unlock fda-check timer version; do
+          for sub in tick run-set init-secondary restore probe-repo unlock fda-check secret timer version; do
             echo "$OUT" | grep -qE "^  $sub( |$)" || { echo "missing subcommand: $sub"; exit 1; }
           done
+          # print-password is registered but deliberately hidden: it is the
+          # machinery behind RESTIC_PASSWORD_COMMAND, not a user action.
+          if echo "$OUT" | grep -qE "^  print-password( |$)"; then
+            echo "print-password must not appear in --help"
+            exit 1
+          fi
+          # …hidden, but reachable.
+          .build/debug/restic-station-helper print-password --help >/dev/null
+          .build/debug/restic-station-helper secret --help
       # SwiftPM does not run a path dependency's test targets, so Core's
       # suite still needs its own invocation.
       - name: Run Core unit tests
         run: swift test --package-path Core
+      # The Linux secret backend, end to end against the real binary. restic
+      # is not installed in this container, so the script skips its restic
+      # half (T29 owns the Linux restic matrix) and still asserts the file
+      # modes, the exact print-password bytes, and that `secret list` prints
+      # no secret value.
+      - name: Secret CLI + FileSecretStore end to end
+        run: scripts/secret-cli-test.sh
 
       # T25 acceptance criteria that only a real Linux run can show.
       - name: fda-check is a no-op on Linux
@@ -205,6 +221,12 @@ jobs:
         run: swift test --package-path Core
       - name: Run integration test
         run: scripts/integration-test.sh
+      # Forces the Linux file backend on macOS, where restic IS installed —
+      # so this run also proves the acceptance criterion "restic
+      # authenticates via RESTIC_PASSWORD_COMMAND against FileSecretStore",
+      # against the helper inside the real app bundle.
+      - name: Secret CLI + FileSecretStore end to end (file backend on macOS)
+        run: scripts/secret-cli-test.sh "dd/Build/Products/Debug/Restic Station.app/Contents/MacOS/restic-station-helper"
       - name: Ad-hoc sign and package app artifact
         run: |
           APP="dd/Build/Products/Debug/Restic Station.app"

--- a/App/Sources/ViewModels/AppModel+Maintenance.swift
+++ b/App/Sources/ViewModels/AppModel+Maintenance.swift
@@ -40,7 +40,7 @@ enum MaintenanceLookup {
         return ResticRunner(
             resticPath: resticPath,
             paths: model.paths,
-            secrets: try SecretStoreFactory.make(paths: model.paths, runner: processRunner),
+            secrets: try model.makeSecretStore(),
             runner: processRunner
         )
     }

--- a/App/Sources/ViewModels/AppModel+Maintenance.swift
+++ b/App/Sources/ViewModels/AppModel+Maintenance.swift
@@ -40,7 +40,7 @@ enum MaintenanceLookup {
         return ResticRunner(
             resticPath: resticPath,
             paths: model.paths,
-            keychain: KeychainClient(runner: processRunner),
+            secrets: try SecretStoreFactory.make(paths: model.paths, runner: processRunner),
             runner: processRunner
         )
     }

--- a/App/Sources/ViewModels/AppModel+Restore.swift
+++ b/App/Sources/ViewModels/AppModel+Restore.swift
@@ -72,10 +72,11 @@ extension AppModel {
     func makeBrowsingRunner() -> ResticRunner? {
         guard let path = config.resticPath, !path.isEmpty else { return nil }
         let processRunner = DefaultProcessRunner()
+        guard let secrets = try? SecretStoreFactory.make(paths: paths, runner: processRunner) else { return nil }
         return ResticRunner(
             resticPath: path,
             paths: paths,
-            keychain: KeychainClient(runner: processRunner),
+            secrets: secrets,
             runner: processRunner
         )
     }

--- a/App/Sources/ViewModels/AppModel+Restore.swift
+++ b/App/Sources/ViewModels/AppModel+Restore.swift
@@ -69,14 +69,20 @@ extension AppModel {
     ///
     /// Returns `nil` when no restic binary is configured yet; the caller
     /// renders that as an explained empty state rather than an error.
-    func makeBrowsingRunner() -> ResticRunner? {
+    ///
+    /// **Throws** when secret storage itself is misconfigured (a mistyped
+    /// `RESTIC_STATION_SECRET_BACKEND`). That is deliberately not folded into
+    /// the `nil` case: "restic is not set up yet" is an empty state, while
+    /// "your secret storage setting is wrong" is a real error every other
+    /// flow reports — swallowing it here would leave the Restore pane showing
+    /// a bare "No snapshots" with no hint of the cause.
+    func makeBrowsingRunner() throws -> ResticRunner? {
         guard let path = config.resticPath, !path.isEmpty else { return nil }
         let processRunner = DefaultProcessRunner()
-        guard let secrets = try? SecretStoreFactory.make(paths: paths, runner: processRunner) else { return nil }
         return ResticRunner(
             resticPath: path,
             paths: paths,
-            secrets: secrets,
+            secrets: try makeSecretStore(),
             runner: processRunner
         )
     }
@@ -173,11 +179,19 @@ final class RestoreBrowser: ObservableObject {
 
     /// Points the browser at a repository. Re-configuring with the same
     /// repository is a no-op, so it is safe to call from `onChange`.
-    func configure(repository: RestoreRepository?, runner: ResticRunner?) {
+    ///
+    /// - Parameter unavailableReason: why there is no runner, when the
+    ///   reason is a *misconfiguration* rather than "restic is not set up
+    ///   yet". Surfaced through `snapshotsError`, so the pane explains
+    ///   itself instead of showing a bare "No snapshots".
+    func configure(repository: RestoreRepository?, runner: ResticRunner?, unavailableReason: String? = nil) {
         guard repository?.id != self.repository?.id else {
             // Same repository, but the restic path (and therefore the
             // runner) may have changed in Settings.
             self.runner = runner
+            if let unavailableReason {
+                snapshotsError = unavailableReason
+            }
             return
         }
         snapshotsTask?.cancel()
@@ -185,7 +199,9 @@ final class RestoreBrowser: ObservableObject {
         self.repository = repository
         self.runner = runner
         snapshots = []
-        snapshotsError = nil
+        // Set after the reset, not before: `loadSnapshots` bails out early
+        // without a runner, so this is the only thing that will be showing.
+        snapshotsError = unavailableReason
         isLoadingSnapshots = false
         searchResults = []
         searchState = .idle

--- a/App/Sources/ViewModels/AppModel+Sets.swift
+++ b/App/Sources/ViewModels/AppModel+Sets.swift
@@ -20,11 +20,32 @@ extension AppModel {
     /// keychain by default, or `secrets.json` when
     /// `RESTIC_STATION_SECRET_BACKEND=file`. Cheap to build.
     ///
-    /// `nil` only when the backend override is unrecognised, which the
-    /// callers surface as "the password could not be saved" rather than
-    /// silently writing to the wrong store.
+    /// **The helper path is not this process.** With the file backend the
+    /// store bakes an executable into `RESTIC_PASSWORD_COMMAND`, and restic
+    /// runs it as a child to read the password. Naming the app binary there
+    /// would hand restic a SwiftUI app that cannot print a password and
+    /// would try to open a UI, so every app-side store names the *embedded
+    /// helper* — the same binary `HelperInvoker` and the LaunchAgent use.
+    /// The factory requires this explicitly, so a new app-side call site
+    /// cannot forget it.
+    ///
+    /// Throws only when the `RESTIC_STATION_SECRET_BACKEND` override is
+    /// unrecognised — deliberately a hard error rather than a silent
+    /// fallback to the wrong store.
+    func makeSecretStore() throws -> any SecretStore {
+        try SecretStoreFactory.make(
+            paths: paths,
+            runner: DefaultProcessRunner(),
+            helperExecutablePath: HelperInvoker.helperURL.path
+        )
+    }
+
+    /// `makeSecretStore()` for the call sites that can only degrade (reading
+    /// back a password to pre-fill an editor, deleting a destination's
+    /// secrets). Every site that can *report* the failure calls the throwing
+    /// form instead.
     var secrets: (any SecretStore)? {
-        try? SecretStoreFactory.make(paths: paths, runner: DefaultProcessRunner())
+        try? makeSecretStore()
     }
 
     // MARK: - Sets
@@ -111,7 +132,7 @@ extension AppModel {
         password: String?,
         secretEnv: [String: String]?
     ) async throws {
-        let store = try SecretStoreFactory.make(paths: paths, runner: DefaultProcessRunner())
+        let store = try makeSecretStore()
         if let password, !password.isEmpty {
             try await store.setPassword(password, destId: destId)
         }

--- a/App/Sources/ViewModels/AppModel+Sets.swift
+++ b/App/Sources/ViewModels/AppModel+Sets.swift
@@ -15,11 +15,16 @@ extension AppModel {
 
     // MARK: - Collaborators
 
-    /// A keychain client bound to the same `security(1)` mechanics the helper
-    /// uses (`docs/keychain-and-fda.md` §1). Cheap to build — it is a struct
-    /// wrapping a process runner.
-    var keychain: KeychainClient {
-        KeychainClient(runner: DefaultProcessRunner())
+    /// The secret store this app writes destination passwords into — the
+    /// same one the helper reads (`docs/keychain-and-fda.md`): the login
+    /// keychain by default, or `secrets.json` when
+    /// `RESTIC_STATION_SECRET_BACKEND=file`. Cheap to build.
+    ///
+    /// `nil` only when the backend override is unrecognised, which the
+    /// callers surface as "the password could not be saved" rather than
+    /// silently writing to the wrong store.
+    var secrets: (any SecretStore)? {
+        try? SecretStoreFactory.make(paths: paths, runner: DefaultProcessRunner())
     }
 
     // MARK: - Sets
@@ -106,15 +111,15 @@ extension AppModel {
         password: String?,
         secretEnv: [String: String]?
     ) async throws {
-        let keychain = self.keychain
+        let store = try SecretStoreFactory.make(paths: paths, runner: DefaultProcessRunner())
         if let password, !password.isEmpty {
-            try await keychain.setPassword(password, destId: destId)
+            try await store.setPassword(password, destId: destId)
         }
         if let secretEnv {
             if secretEnv.isEmpty {
-                try await keychain.deleteSecretEnv(destId: destId)
+                try await store.deleteSecretEnv(destId: destId)
             } else {
-                try await keychain.setSecretEnv(secretEnv, destId: destId)
+                try await store.setSecretEnv(secretEnv, destId: destId)
             }
         }
     }
@@ -123,18 +128,18 @@ extension AppModel {
     /// password is not an error here (a destination can exist before its
     /// password was ever stored) — the caller shows "leave blank to keep".
     func loadDestinationSecrets(destId: UUID) async -> (password: String?, secretEnv: [String: String]) {
-        let keychain = self.keychain
-        let password = try? await keychain.password(destId: destId)
-        let env = (try? await keychain.secretEnv(destId: destId)) ?? [:]
+        guard let store = self.secrets else { return (nil, [:]) }
+        let password = try? await store.password(destId: destId)
+        let env = (try? await store.secretEnv(destId: destId)) ?? [:]
         return (password, env)
     }
 
-    /// Both keychain items for a destination, as promised by the remove
-    /// confirmation copy. Deletes are idempotent in `KeychainClient`.
+    /// Both stored secrets for a destination, as promised by the remove
+    /// confirmation copy. Deletes are idempotent in every `SecretStore`.
     func deleteDestinationSecrets(destId: UUID) async {
-        let keychain = self.keychain
-        try? await keychain.deletePassword(destId: destId)
-        try? await keychain.deleteSecretEnv(destId: destId)
+        guard let store = self.secrets else { return }
+        try? await store.deletePassword(destId: destId)
+        try? await store.deleteSecretEnv(destId: destId)
     }
 
     // MARK: - Probe
@@ -233,16 +238,22 @@ extension AppModel {
 
     /// See `initializeRepository(setId:destId:)` for why this bypasses the
     /// helper. Everything else about the invocation is the shared Core path:
-    /// argv from `ResticCommand.initRepo`, env and the keychain pre-flight
+    /// argv from `ResticCommand.initRepo`, env and the secret pre-flight
     /// from `ResticRunner`.
     private func initializePrimaryRepository(_ destination: Destination) async -> DestinationInitOutcome {
         guard let resticPath = config.resticPath, !resticPath.isEmpty else {
             return .failed("No restic binary is configured. Set the restic path in Settings, then try again.")
         }
+        guard let secrets = self.secrets else {
+            return .failed(
+                "Secret storage is misconfigured (check \(SecretBackend.environmentKey)), "
+                    + "so the repository password could not be read."
+            )
+        }
         let runner = ResticRunner(
             resticPath: resticPath,
             paths: paths,
-            keychain: keychain,
+            secrets: secrets,
             runner: DefaultProcessRunner()
         )
         do {

--- a/App/Sources/Views/Restore/MountController.swift
+++ b/App/Sources/Views/Restore/MountController.swift
@@ -312,13 +312,16 @@ final class MountController: ObservableObject {
         environment["PATH"] = "/usr/bin:/bin:/usr/sbin:/sbin"
         environment.merge(destination.nonSecretEnv) { _, new in new }
 
-        let keychain = KeychainClient(runner: DefaultProcessRunner())
-        let secretEnv = try await keychain.secretEnv(destId: destination.id)
+        let secrets = try SecretStoreFactory.make(paths: paths, runner: DefaultProcessRunner())
+        let secretEnv = try await secrets.secretEnv(destId: destination.id)
         environment.merge(secretEnv) { _, new in new }
 
-        // Written last — not overridable by configured env.
+        // Written last — not overridable by configured env. Mirrors
+        // `ResticRunner.environment(for:)`, including the store's own
+        // password-command environment (empty on the keychain backend).
         environment["RESTIC_CACHE_DIR"] = paths.resticCacheDir.path
-        environment["RESTIC_PASSWORD_COMMAND"] = KeychainClient.passwordCommand(destId: destination.id)
+        environment.merge(secrets.passwordCommandEnvironment) { _, new in new }
+        environment["RESTIC_PASSWORD_COMMAND"] = secrets.passwordCommand(destId: destination.id)
         return environment
     }
 

--- a/App/Sources/Views/Restore/MountController.swift
+++ b/App/Sources/Views/Restore/MountController.swift
@@ -312,7 +312,14 @@ final class MountController: ObservableObject {
         environment["PATH"] = "/usr/bin:/bin:/usr/sbin:/sbin"
         environment.merge(destination.nonSecretEnv) { _, new in new }
 
-        let secrets = try SecretStoreFactory.make(paths: paths, runner: DefaultProcessRunner())
+        // The embedded helper, never this process: with the file backend the
+        // store bakes this executable into `RESTIC_PASSWORD_COMMAND`, and
+        // `restic mount` would otherwise be handed the SwiftUI app binary.
+        let secrets = try SecretStoreFactory.make(
+            paths: paths,
+            runner: DefaultProcessRunner(),
+            helperExecutablePath: HelperInvoker.helperURL.path
+        )
         let secretEnv = try await secrets.secretEnv(destId: destination.id)
         environment.merge(secretEnv) { _, new in new }
 

--- a/App/Sources/Views/Restore/RestoreView.swift
+++ b/App/Sources/Views/Restore/RestoreView.swift
@@ -395,7 +395,20 @@ struct RestoreView: View {
     }
 
     private func configureBrowser() {
-        browser.configure(repository: repository, runner: model.makeBrowsingRunner())
+        do {
+            browser.configure(repository: repository, runner: try model.makeBrowsingRunner())
+        } catch {
+            // Secret storage is misconfigured (a mistyped
+            // RESTIC_STATION_SECRET_BACKEND). Say so here rather than letting
+            // the pane fall through to "No snapshots", which would look like
+            // an empty repository.
+            browser.configure(
+                repository: repository,
+                runner: nil,
+                unavailableReason: "Secret storage is misconfigured, so this repository's password "
+                    + "cannot be read: \(error). Fix \(SecretBackend.environmentKey), then try again."
+            )
+        }
         browser.loadSnapshots()
     }
 }

--- a/App/Sources/Views/Sets/SetsBadges.swift
+++ b/App/Sources/Views/Sets/SetsBadges.swift
@@ -90,11 +90,16 @@ enum DestinationStatus: Equatable, Sendable {
     }
 
     /// `Reachability` records environmental failures ("volume not mounted",
-    /// "timed out", "keychain locked") as offline; anything else it recorded
-    /// came from restic itself and needs attention.
+    /// "timed out", "keychain locked", "secret store unavailable") as
+    /// offline; anything else it recorded came from restic itself and needs
+    /// attention. The last of those is what a file-backend host records —
+    /// the app can read a `repo-status` file written by a helper using
+    /// either secret backend.
     private static func offlineOrError(_ lastError: String?) -> DestinationStatus {
         guard let lastError else { return .offline }
-        let environmental = ["volume not mounted", "timed out", "keychain locked", "could not"]
+        let environmental = [
+            "volume not mounted", "timed out", "keychain locked", "secret store unavailable", "could not",
+        ]
         let lowercased = lastError.lowercased()
         return environmental.contains(where: lowercased.contains) ? .offline : .error
     }

--- a/Core/Sources/ResticStationCore/Engine/BackupEngine.swift
+++ b/Core/Sources/ResticStationCore/Engine/BackupEngine.swift
@@ -64,7 +64,7 @@ public struct SetRunChild: Equatable, Sendable {
 /// - ``skipped`` — the set lock was busy; exactly one `.skipped` index
 ///   record was written and nothing else happened (**retryable**).
 /// - ``retryable(reason:)`` — an environmental failure *before* anything was
-///   recorded (keychain locked): NO run record, NO `lastBackupStart` update,
+///   recorded (secret store unreadable): NO run record, NO `lastBackupStart` update,
 ///   NO lock taken, so the next tick simply tries again.
 /// - ``misconfigured(reason:)`` — defensive only: the set has no primary
 ///   destination, which `AppConfig.validate()` rejects on load and save.
@@ -124,7 +124,7 @@ public final class BackupEngine: Sendable {
     private let config: AppConfig
     private let paths: AppPaths
     private let restic: ResticRunner
-    private let keychain: KeychainClient
+    private let secrets: any SecretStore
     private let runStore: RunStore
     private let stateStore: StateStore
     private let reachability: Reachability
@@ -134,7 +134,7 @@ public final class BackupEngine: Sendable {
         config: AppConfig,
         paths: AppPaths,
         restic: ResticRunner,
-        keychain: KeychainClient,
+        secrets: any SecretStore,
         runStore: RunStore,
         stateStore: StateStore,
         reachability: Reachability,
@@ -143,7 +143,7 @@ public final class BackupEngine: Sendable {
         self.config = config
         self.paths = paths
         self.restic = restic
-        self.keychain = keychain
+        self.secrets = secrets
         self.runStore = runStore
         self.stateStore = stateStore
         self.reachability = reachability
@@ -154,7 +154,7 @@ public final class BackupEngine: Sendable {
 
     /// The eight-step set-run sequence from `docs/tasks/T09-backup-engine.md`.
     ///
-    /// 1. keychain pre-flight for the primary — failure returns
+    /// 1. secret-store pre-flight for the primary — failure returns
     ///    ``SetRunOutcome/retryable(reason:)`` leaving *no* trace;
     /// 2. `locks/set-<id>.lock` — busy writes one `.skipped` record and stops;
     /// 3. `lastBackupStart = now()` (attempt semantics, scheduled *and*
@@ -176,15 +176,16 @@ public final class BackupEngine: Sendable {
             return .misconfigured(reason: reason)
         }
 
-        // ── Step 1: keychain pre-flight ─────────────────────────────────
+        // ── Step 1: secret-store pre-flight ─────────────────────────────
         // Deliberately the engine's own read, *before* the lock and before
         // any state mutation: `ResticRunner` performs the same pre-flight,
         // but only once a run record and `lastBackupStart` would already
-        // have been written. A locked keychain must leave no trace at all.
+        // have been written. An unreadable secret store must leave no trace
+        // at all.
         do {
-            _ = try await keychain.password(destId: primary.id)
+            _ = try await secrets.password(destId: primary.id)
         } catch {
-            let reason = "the login keychain could not be read for destination \"\(primary.label)\""
+            let reason = "\(Self.secretStoreDescription) could not be read for destination \"\(primary.label)\""
             logWarning("BackupEngine: \(reason) — skipping this run (retryable, nothing recorded)")
             return .retryable(reason: reason)
         }
@@ -339,7 +340,7 @@ public final class BackupEngine: Sendable {
             logWarning("BackupEngine: backup set \"\(set.name)\" has no primary destination — cannot check")
             return .failed
         }
-        guard await keychainAvailable(for: [primary]) else { return .skipped }
+        guard await secretsAvailable(for: [primary]) else { return .skipped }
 
         let lock = makeSetLock(setId: set.id)
         guard lock.tryAcquire() else {
@@ -439,7 +440,7 @@ public final class BackupEngine: Sendable {
             )
             return .skipped
         }
-        guard await keychainAvailable(for: [primary]) else { return .skipped }
+        guard await secretsAvailable(for: [primary]) else { return .skipped }
 
         let lock = makeSetLock(setId: set.id)
         guard lock.tryAcquire() else {
@@ -507,7 +508,7 @@ public final class BackupEngine: Sendable {
             logWarning("BackupEngine: no configured destination with id \(request.destId) — cannot restore")
             return .failed
         }
-        guard await keychainAvailable(for: [destination]) else { return .skipped }
+        guard await secretsAvailable(for: [destination]) else { return .skipped }
 
         let lock = makeSetLock(setId: set.id)
         guard lock.tryAcquire() else {
@@ -559,7 +560,7 @@ public final class BackupEngine: Sendable {
         }
         // Both repositories' passwords are needed (`RESTIC_PASSWORD_COMMAND`
         // and `RESTIC_FROM_PASSWORD_COMMAND`).
-        guard await keychainAvailable(for: [dest, primary]) else { return .skipped }
+        guard await secretsAvailable(for: [dest, primary]) else { return .skipped }
 
         let lock = makeSetLock(setId: set.id)
         guard lock.tryAcquire() else {
@@ -748,7 +749,7 @@ public final class BackupEngine: Sendable {
     private enum ExecuteResult {
         case ranToCompletion(ResticOutcome)
         /// restic produced no outcome at all (launch failure, timeout,
-        /// keychain read failure mid-run, cancellation).
+        /// secret read failure mid-run, cancellation).
         case didNotRun(reason: String)
 
         var outcome: ResticOutcome? {
@@ -988,16 +989,26 @@ public final class BackupEngine: Sendable {
         }
     }
 
-    /// The engine's own pre-flight for the non-`runSet` entry points: a
-    /// locked keychain is retryable, so those methods return `.skipped`
-    /// without writing a run record (`docs/architecture.md` §Error taxonomy).
-    private func keychainAvailable(for destinations: [Destination]) async -> Bool {
+    /// How the engine names the secret store in its user-visible log lines.
+    /// Platform-split so the macOS wording is byte-for-byte what it was
+    /// before the `SecretStore` abstraction landed.
+    #if os(macOS)
+    static let secretStoreDescription = "the login keychain"
+    #else
+    static let secretStoreDescription = "the secrets file"
+    #endif
+
+    /// The engine's own pre-flight for the non-`runSet` entry points: an
+    /// unreadable secret store is retryable, so those methods return
+    /// `.skipped` without writing a run record (`docs/architecture.md`
+    /// §Error taxonomy).
+    private func secretsAvailable(for destinations: [Destination]) async -> Bool {
         for destination in destinations {
             do {
-                _ = try await keychain.password(destId: destination.id)
+                _ = try await secrets.password(destId: destination.id)
             } catch {
                 logWarning(
-                    "BackupEngine: the login keychain could not be read for destination "
+                    "BackupEngine: \(Self.secretStoreDescription) could not be read for destination "
                         + "\"\(destination.label)\" — skipping (retryable, nothing recorded)"
                 )
                 return false

--- a/Core/Sources/ResticStationCore/Engine/BackupEngine.swift
+++ b/Core/Sources/ResticStationCore/Engine/BackupEngine.swift
@@ -185,7 +185,7 @@ public final class BackupEngine: Sendable {
         do {
             _ = try await secrets.password(destId: primary.id)
         } catch {
-            let reason = "\(Self.secretStoreDescription) could not be read for destination \"\(primary.label)\""
+            let reason = "\(secretStoreDescription) could not be read for destination \"\(primary.label)\""
             logWarning("BackupEngine: \(reason) — skipping this run (retryable, nothing recorded)")
             return .retryable(reason: reason)
         }
@@ -989,14 +989,16 @@ public final class BackupEngine: Sendable {
         }
     }
 
-    /// How the engine names the secret store in its user-visible log lines.
-    /// Platform-split so the macOS wording is byte-for-byte what it was
-    /// before the `SecretStore` abstraction landed.
-    #if os(macOS)
-    static let secretStoreDescription = "the login keychain"
-    #else
-    static let secretStoreDescription = "the secrets file"
-    #endif
+    /// How the engine names the secret store in its user-visible log lines
+    /// and in `.retryable` reasons.
+    ///
+    /// Taken from the store actually in use, not from the host OS: a macOS
+    /// host running `RESTIC_STATION_SECRET_BACKEND=file` must not be told its
+    /// login keychain is the problem. The keychain wording is byte-for-byte
+    /// what it was before the `SecretStore` abstraction landed.
+    private var secretStoreDescription: String {
+        secrets.backend.displayName
+    }
 
     /// The engine's own pre-flight for the non-`runSet` entry points: an
     /// unreadable secret store is retryable, so those methods return
@@ -1008,7 +1010,7 @@ public final class BackupEngine: Sendable {
                 _ = try await secrets.password(destId: destination.id)
             } catch {
                 logWarning(
-                    "BackupEngine: \(Self.secretStoreDescription) could not be read for destination "
+                    "BackupEngine: \(secretStoreDescription) could not be read for destination "
                         + "\"\(destination.label)\" — skipping (retryable, nothing recorded)"
                 )
                 return false

--- a/Core/Sources/ResticStationCore/Engine/Reachability.swift
+++ b/Core/Sources/ResticStationCore/Engine/Reachability.swift
@@ -87,10 +87,17 @@ public struct Reachability: Sendable {
             return .error(outcome.status)
         } catch let error as ResticRunnerError {
             switch error {
-            case .keychainUnavailable:
+            case .secretsUnavailable:
                 // Retryable, not alarming — see docs/architecture.md
-                // §Error taxonomy and ResticRunnerError.keychainUnavailable.
+                // §Error taxonomy and ResticRunnerError.secretsUnavailable.
+                // This string is persisted to `repo-status-<destId>.json` and
+                // matched by the app's badge heuristic (`SetsBadges`), so the
+                // macOS wording stays exactly what it was before T23.
+                #if os(macOS)
                 return .offline(reason: "keychain locked")
+                #else
+                return .offline(reason: "secret store unavailable")
+                #endif
             case .timedOut:
                 return .offline(reason: "timed out")
             case .launchFailed(let reason):

--- a/Core/Sources/ResticStationCore/Engine/Reachability.swift
+++ b/Core/Sources/ResticStationCore/Engine/Reachability.swift
@@ -91,13 +91,11 @@ public struct Reachability: Sendable {
                 // Retryable, not alarming — see docs/architecture.md
                 // §Error taxonomy and ResticRunnerError.secretsUnavailable.
                 // This string is persisted to `repo-status-<destId>.json` and
-                // matched by the app's badge heuristic (`SetsBadges`), so the
-                // macOS wording stays exactly what it was before T23.
-                #if os(macOS)
-                return .offline(reason: "keychain locked")
-                #else
-                return .offline(reason: "secret store unavailable")
-                #endif
+                // matched by the app's badge heuristic (`SetsBadges`). Taken
+                // from the store actually in use, so a macOS host running the
+                // file backend does not record "keychain locked"; the
+                // keychain backend's string is unchanged from before T23.
+                return .offline(reason: restic.secretBackend.unavailableProbeReason)
             case .timedOut:
                 return .offline(reason: "timed out")
             case .launchFailed(let reason):

--- a/Core/Sources/ResticStationCore/Restic/ResticError.swift
+++ b/Core/Sources/ResticStationCore/Restic/ResticError.swift
@@ -178,16 +178,19 @@ public enum ResticRunnerError: Error, Equatable, Sendable, CustomStringConvertib
     public var userFacingMessage: String {
         switch self {
         case .secretsUnavailable:
-            // Platform-split rather than a vague joint sentence, so each host
-            // gets exactly one next step (`docs/ui-spec.md` §Voice). The macOS
-            // wording is unchanged from before the SecretStore abstraction.
-            #if os(macOS)
-            return "The password for this destination could not be read from the keychain. "
-                + "Unlock your login keychain, then run the backup again."
-            #else
-            return "The password for this destination could not be read from secure storage. "
-                + "Check the permissions on the secrets file, then run the backup again."
-            #endif
+            // Worded for the backend actually in use, not for the host OS:
+            // macOS with `RESTIC_STATION_SECRET_BACKEND=file` is supported,
+            // and "unlock your login keychain" is the wrong next step for a
+            // `secrets.json` whose mode was widened.
+            //
+            // This is the one place that reads the *configured* backend
+            // rather than a store's own `backend`: it is a property on an
+            // error value, which has no store to ask. In production the two
+            // always agree — every store is built by `SecretStoreFactory`
+            // from this same environment. Callers that do hold a store
+            // (`BackupEngine`, `Reachability`) use the store's backend.
+            let backend = SecretBackend.configured
+            return "\(backend.unavailableSummary) \(backend.unavailableAdvice)"
         case .launchFailed:
             return "The restic program could not be started. "
                 + "Check the restic path in Settings."

--- a/Core/Sources/ResticStationCore/Restic/ResticError.swift
+++ b/Core/Sources/ResticStationCore/Restic/ResticError.swift
@@ -139,14 +139,15 @@ public enum ResticExitClass: Equatable, Sendable {
 /// Failures that stop `ResticRunner` from producing a `ResticOutcome` at all
 /// — i.e. restic either never ran or did not run to completion.
 public enum ResticRunnerError: Error, Equatable, Sendable, CustomStringConvertible {
-    /// The keychain pre-flight failed for this destination: the repo
+    /// The secret-store pre-flight failed for this destination: the repo
     /// password could not be read, so restic's `RESTIC_PASSWORD_COMMAND`
-    /// would fail too (typically a locked keychain at a pre-login tick).
+    /// would fail too (typically a locked login keychain at a pre-login tick
+    /// on macOS, or a `secrets.json` whose mode has been widened on Linux).
     /// **Retryable** per architecture.md — no `.failed` run record.
     ///
-    /// Deliberately carries only the destination id: the underlying
-    /// `security` output is not embedded anywhere it could reach a log.
-    case keychainUnavailable(destinationId: UUID)
+    /// Deliberately carries only the destination id: the backend's own
+    /// output is not embedded anywhere it could reach a log.
+    case secretsUnavailable(destinationId: UUID)
     /// The restic binary could not be spawned (missing/not executable).
     case launchFailed(String)
     /// The caller's timeout elapsed. `ProcessRunning` has already sent
@@ -155,8 +156,8 @@ public enum ResticRunnerError: Error, Equatable, Sendable, CustomStringConvertib
 
     public var description: String {
         switch self {
-        case .keychainUnavailable(let destinationId):
-            return "keychain unavailable for destination \(destinationId)"
+        case .secretsUnavailable(let destinationId):
+            return "secret store unavailable for destination \(destinationId)"
         case .launchFailed(let reason):
             return "failed to launch restic: \(reason)"
         case .timedOut:
@@ -166,7 +167,7 @@ public enum ResticRunnerError: Error, Equatable, Sendable, CustomStringConvertib
 
     public var category: ResticErrorCategory {
         switch self {
-        case .keychainUnavailable:
+        case .secretsUnavailable:
             return .retryable
         case .launchFailed, .timedOut:
             return .terminal
@@ -176,9 +177,17 @@ public enum ResticRunnerError: Error, Equatable, Sendable, CustomStringConvertib
     /// See ``ResticExitClass/userFacingMessage`` for the "one next step" rule.
     public var userFacingMessage: String {
         switch self {
-        case .keychainUnavailable:
+        case .secretsUnavailable:
+            // Platform-split rather than a vague joint sentence, so each host
+            // gets exactly one next step (`docs/ui-spec.md` §Voice). The macOS
+            // wording is unchanged from before the SecretStore abstraction.
+            #if os(macOS)
             return "The password for this destination could not be read from the keychain. "
                 + "Unlock your login keychain, then run the backup again."
+            #else
+            return "The password for this destination could not be read from secure storage. "
+                + "Check the permissions on the secrets file, then run the backup again."
+            #endif
         case .launchFailed:
             return "The restic program could not be started. "
                 + "Check the restic path in Settings."

--- a/Core/Sources/ResticStationCore/Restic/ResticRunner.swift
+++ b/Core/Sources/ResticStationCore/Restic/ResticRunner.swift
@@ -149,6 +149,15 @@ public final class ResticRunner: Sendable {
         return try await execute(cmd, env: baseEnvironment(), onLine: onLine, onRawLine: onRawLine, timeout: timeout)
     }
 
+    /// Which secret backend this runner reads passwords from.
+    ///
+    /// Exposed so collaborators that only hold a `ResticRunner` — notably
+    /// `Reachability` — can word a secret-store failure for the store
+    /// actually in use rather than for the host OS.
+    public var secretBackend: SecretBackend {
+        secrets.backend
+    }
+
     // MARK: - Secret-store pre-flight
 
     private func preflightSecrets(destination: Destination) async throws {

--- a/Core/Sources/ResticStationCore/Restic/ResticRunner.swift
+++ b/Core/Sources/ResticStationCore/Restic/ResticRunner.swift
@@ -42,7 +42,7 @@ public struct ResticOutcome: Sendable {
 // MARK: - ResticRunner
 
 /// The single place restic is executed. Builds the environment, performs the
-/// keychain pre-flight, streams NDJSON, and maps exit codes.
+/// secret-store pre-flight, streams NDJSON, and maps exit codes.
 ///
 /// **Environment (docs/restic-cli.md §General).** The inherited environment
 /// is *replaced*, never extended: a scheduled launchd invocation and a
@@ -55,17 +55,19 @@ public struct ResticOutcome: Sendable {
 ///    `ssh` via PATH lookup. Every program *we* spawn is named absolutely;
 ///    the PATH exists solely for restic's own children, and a destination's
 ///    `nonSecretEnv` may override it (e.g. to reach a Homebrew `rclone`).
-/// 2. from-destination's `nonSecretEnv`, then its keychain secret-env blob
-/// 3. destination's `nonSecretEnv`, then its keychain secret-env blob —
+/// 2. from-destination's `nonSecretEnv`, then its stored secret-env blob
+/// 3. destination's `nonSecretEnv`, then its stored secret-env blob —
 ///    **so on a key collision the destination (the `-r` repo) wins over the
 ///    from-repo.** Two S3 destinations in one set needing *different*
 ///    credentials is a known v1 limitation (restic-cli.md §init secondary).
-///    Within one destination the keychain blob wins over `nonSecretEnv`, so
+///    Within one destination the stored blob wins over `nonSecretEnv`, so
 ///    a non-secret config entry can never shadow a stored credential.
-/// 4. `RESTIC_CACHE_DIR`, `RESTIC_PASSWORD_COMMAND` and (when a
-///    from-destination is present) `RESTIC_FROM_PASSWORD_COMMAND` — written
-///    last so no user-supplied `nonSecretEnv` entry can hijack how restic
-///    obtains a password or where it caches.
+/// 4. `RESTIC_CACHE_DIR`, the secret store's own
+///    `passwordCommandEnvironment` (empty on the keychain backend),
+///    `RESTIC_PASSWORD_COMMAND` and (when a from-destination is present)
+///    `RESTIC_FROM_PASSWORD_COMMAND` — written last so no user-supplied
+///    `nonSecretEnv` entry can hijack how restic obtains a password or where
+///    it caches.
 ///
 /// **Secrets.** Passwords never appear in argv (`ResticCommand` guarantees
 /// this) and are never logged: the pre-flight read is discarded, and no env
@@ -82,14 +84,14 @@ public final class ResticRunner: Sendable {
 
     private let resticPath: String
     private let paths: AppPaths
-    private let keychain: KeychainClient
+    private let secrets: any SecretStore
     private let runner: ProcessRunning
     private let decoder = ResticMessageDecoder()
 
-    public init(resticPath: String, paths: AppPaths, keychain: KeychainClient, runner: ProcessRunning) {
+    public init(resticPath: String, paths: AppPaths, secrets: any SecretStore, runner: ProcessRunning) {
         self.resticPath = resticPath
         self.paths = paths
-        self.keychain = keychain
+        self.secrets = secrets
         self.runner = runner
     }
 
@@ -116,12 +118,13 @@ public final class ResticRunner: Sendable {
         try Task.checkCancellation()
 
         // Pre-flight: read every password we are about to make restic read,
-        // so a locked keychain is a clean, retryable error instead of a
+        // so an unreadable secret store (a locked keychain, a secrets file
+        // with the wrong mode) is a clean, retryable error instead of a
         // confusing restic failure mid-run (T09 scenario 9). The values are
         // discarded immediately — only reachability is being tested.
-        try await preflightKeychain(destination: inv.destination)
+        try await preflightSecrets(destination: inv.destination)
         if let fromDestination = inv.fromDestination {
-            try await preflightKeychain(destination: fromDestination)
+            try await preflightSecrets(destination: fromDestination)
         }
 
         let env = try await environment(for: inv)
@@ -130,7 +133,7 @@ public final class ResticRunner: Sendable {
 
     /// Runs a command that targets no repository — currently only
     /// `.version`, used to validate a discovered restic binary before any
-    /// destination exists. No keychain pre-flight, no password env.
+    /// destination exists. No secret-store pre-flight, no password env.
     @discardableResult
     public func runWithoutRepository(
         _ cmd: ResticCommand,
@@ -146,16 +149,16 @@ public final class ResticRunner: Sendable {
         return try await execute(cmd, env: baseEnvironment(), onLine: onLine, onRawLine: onRawLine, timeout: timeout)
     }
 
-    // MARK: - Keychain pre-flight
+    // MARK: - Secret-store pre-flight
 
-    private func preflightKeychain(destination: Destination) async throws {
+    private func preflightSecrets(destination: Destination) async throws {
         do {
-            _ = try await keychain.password(destId: destination.id)
+            _ = try await secrets.password(destId: destination.id)
         } catch {
-            // The underlying `security` failure text is intentionally dropped
+            // The underlying backend failure text is intentionally dropped
             // here rather than wrapped: it is of no use to the user and this
             // error string ends up in run logs.
-            throw ResticRunnerError.keychainUnavailable(destinationId: destination.id)
+            throw ResticRunnerError.secretsUnavailable(destinationId: destination.id)
         }
     }
 
@@ -174,20 +177,25 @@ public final class ResticRunner: Sendable {
 
         // Written last: these must not be overridable by configured env.
         env["RESTIC_CACHE_DIR"] = paths.resticCacheDir.path
-        env["RESTIC_PASSWORD_COMMAND"] = KeychainClient.passwordCommand(destId: inv.destination.id)
+        // What the password command's child needs to find the same store —
+        // empty for the keychain backend, so macOS's assembled environment is
+        // exactly what it was before T23. See
+        // `SecretStore.passwordCommandEnvironment`.
+        env.merge(secrets.passwordCommandEnvironment) { _, new in new }
+        env["RESTIC_PASSWORD_COMMAND"] = secrets.passwordCommand(destId: inv.destination.id)
         if let fromDestination = inv.fromDestination {
-            env["RESTIC_FROM_PASSWORD_COMMAND"] = KeychainClient.passwordCommand(destId: fromDestination.id)
+            env["RESTIC_FROM_PASSWORD_COMMAND"] = secrets.passwordCommand(destId: fromDestination.id)
         }
         return env
     }
 
     private func secretEnv(for destination: Destination) async throws -> [String: String] {
         do {
-            return try await keychain.secretEnv(destId: destination.id)
+            return try await secrets.secretEnv(destId: destination.id)
         } catch {
-            // Same reasoning as the pre-flight: a keychain that cannot be
+            // Same reasoning as the pre-flight: a secret store that cannot be
             // read is retryable, and the raw failure text never propagates.
-            throw ResticRunnerError.keychainUnavailable(destinationId: destination.id)
+            throw ResticRunnerError.secretsUnavailable(destinationId: destination.id)
         }
     }
 

--- a/Core/Sources/ResticStationCore/Secrets/FileSecretStore.swift
+++ b/Core/Sources/ResticStationCore/Secrets/FileSecretStore.swift
@@ -1,0 +1,492 @@
+import Foundation
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+/// The Linux ``SecretStore`` backend (and an opt-in alternative on macOS):
+/// a single `0600` JSON file at `<AppPaths.root>/secrets.json`.
+///
+/// **Why a plain file.** The Linux host this ships to has no desktop
+/// session, no keyring daemon, and no GPG agent — a headless machine whose
+/// only interactive surface is SSH. Every "real" secret service on Linux
+/// (`gnome-keyring`, `kwallet`, `pass`) needs one of those. A file whose
+/// mode is enforced is the honest option: its threat model is exactly the
+/// Unix file-permission model, with no hidden dependency that fails at 03:00
+/// when a scheduled backup fires. See `docs/keychain-and-fda.md` §5 for the
+/// full threat model and how it differs from the macOS ACL strategy.
+///
+/// **Secrets never reach argv.** macOS's accepted `security -w <value>`
+/// tradeoff is specific to `security(1)`; nothing here ever passes a secret
+/// as a process argument, writes one to a log, or embeds one in an error.
+/// The password reaches restic through
+/// `RESTIC_PASSWORD_COMMAND=<helper> print-password --dest <uuid>`, i.e. over
+/// the child's stdout, never its command line.
+///
+/// **Permissions.** The file is created `0600` and the containing directory
+/// `0700`, both at creation time via `open(2)`/`mkdir(2)` modes — never
+/// create-then-`chmod`, which would leave a window in which the file is
+/// world-readable. Every read re-verifies the mode and refuses to read a
+/// group- or world-accessible file (see ``load()``).
+///
+/// **Atomicity.** Writes go to a fixed-name temp file in the same directory,
+/// created `O_EXCL` at `0600`, `fsync`ed, then `rename(2)`d over the real
+/// file — the same pattern as `ConfigStore.save(_:)`. A crash can therefore
+/// never truncate `secrets.json`; the worst case is a leftover temp file,
+/// which the next write unlinks.
+///
+/// **Concurrency.** The tick helper and an interactive `secret set` can run
+/// at the same time, so every read-modify-write happens under the shared
+/// `locks/secrets.lock` `flock`. Reads take no lock: `rename(2)` is atomic,
+/// so a reader always observes one complete generation of the file.
+public struct FileSecretStore: SecretStore {
+
+    /// Bumped only if the on-disk shape changes. A file whose `version` is
+    /// newer than this is refused rather than silently misread.
+    static let currentVersion = 1
+
+    /// How long a writer waits for `locks/secrets.lock` before giving up.
+    /// Generous: the critical section is a small read-modify-write, and the
+    /// only realistic contender is another `secret` invocation.
+    static let lockTimeout: TimeInterval = 10
+    private static let lockPollNanoseconds: UInt64 = 25_000_000
+
+    private let paths: AppPaths
+    private let helperPath: String
+
+    /// - Parameters:
+    ///   - paths: supplies `root` (the secrets file's directory) and
+    ///     `locksDir`.
+    ///   - helperPath: the absolute path baked into
+    ///     ``passwordCommand(destId:)``. Defaults to *this* executable,
+    ///     resolved from `/proc/self/exe` on Linux — deliberately **not**
+    ///     `CommandLine.arguments[0]`, which is whatever the caller chose to
+    ///     put in `argv[0]` and is trivially spoofable.
+    public init(paths: AppPaths, helperPath: String = FileSecretStore.currentExecutablePath()) {
+        self.paths = paths
+        self.helperPath = helperPath
+    }
+
+    // MARK: - Paths
+
+    /// `<AppPaths.root>/secrets.json`.
+    public var fileURL: URL {
+        paths.root.appendingPathComponent("secrets.json", isDirectory: false)
+    }
+
+    /// The fixed-name temp file ``store(_:)`` renames from. Fixed, not
+    /// randomized, so a crash between write and rename leaves a
+    /// deterministic, recognizable leftover that the next write removes.
+    var tempFileURL: URL {
+        paths.root.appendingPathComponent("secrets.json.tmp", isDirectory: false)
+    }
+
+    /// `locks/secrets.lock`. Composed here rather than in `AppPaths` only
+    /// because `AppPaths` is owned elsewhere right now; it belongs there.
+    var lockFileURL: URL {
+        paths.locksDir.appendingPathComponent("secrets.lock", isDirectory: false)
+    }
+
+    // MARK: - Repo password
+
+    public func setPassword(_ password: String, destId: UUID) async throws {
+        try await mutate { document in
+            document.secrets[SecretAccount.password(destId)] = password
+        }
+    }
+
+    public func password(destId: UUID) async throws -> String {
+        guard let value = try load().secrets[SecretAccount.password(destId)] else {
+            throw SecretStoreError.itemNotFound
+        }
+        return value
+    }
+
+    public func deletePassword(destId: UUID) async throws {
+        try await mutate { document in
+            document.secrets.removeValue(forKey: SecretAccount.password(destId))
+        }
+    }
+
+    // MARK: - Secret env
+
+    public func setSecretEnv(_ env: [String: String], destId: UUID) async throws {
+        let json = try SecretEnvBlob.encode(env)
+        try await mutate { document in
+            document.secrets[SecretAccount.secretEnv(destId)] = json
+        }
+    }
+
+    /// `[:]` when absent, matching ``KeychainSecretStore`` — no secret env
+    /// was ever configured for this destination.
+    public func secretEnv(destId: UUID) async throws -> [String: String] {
+        guard let json = try load().secrets[SecretAccount.secretEnv(destId)] else {
+            return [:]
+        }
+        return try SecretEnvBlob.decode(json)
+    }
+
+    public func deleteSecretEnv(destId: UUID) async throws {
+        try await mutate { document in
+            document.secrets.removeValue(forKey: SecretAccount.secretEnv(destId))
+        }
+    }
+
+    // MARK: - Password command
+
+    /// `<absolute-helper-path> print-password --dest <uuid>`.
+    ///
+    /// restic word-splits `RESTIC_PASSWORD_COMMAND` with its own splitter
+    /// (not `sh -c`), which understands single- and double-quoted arguments
+    /// but **not** backslash escapes — verified against restic 0.18.1, see
+    /// `docs/restic-cli.md` §General. So the path is double-quoted only when
+    /// it contains a character that needs it (the overwhelmingly common case
+    /// produces an unquoted string, the same shape the keychain backend
+    /// emits).
+    public func passwordCommand(destId: UUID) -> String {
+        "\(Self.quoteForRestic(helperPath)) print-password --dest \(SecretAccount.password(destId))"
+    }
+
+    /// The child that ``passwordCommand(destId:)`` names is another copy of
+    /// *this* helper, and it re-resolves the store from its own environment.
+    /// Without these two variables it would read the default data directory
+    /// with the platform-default backend — which on macOS-with-`file` is the
+    /// keychain, and under a `RESTIC_STATION_DATA_DIR` override (tests,
+    /// `scripts/integration-test.sh`, a non-standard install) is the wrong
+    /// directory. Both are non-secret by construction: a path and the word
+    /// "file".
+    public var passwordCommandEnvironment: [String: String] {
+        [
+            "RESTIC_STATION_DATA_DIR": paths.root.path,
+            SecretBackend.environmentKey: SecretBackend.file.rawValue,
+        ]
+    }
+
+    /// Characters restic's splitter passes through unquoted. Anything else
+    /// (space, quote, `$`, backslash, …) forces double quotes.
+    private static let unquotedSafe = Set(
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789/._-+=:,@"
+    )
+
+    /// - Note: a path containing a literal `"` cannot be expressed at all —
+    ///   restic's splitter has no escape mechanism and reports
+    ///   `double-quoted string not terminated`. Such a path is refused at
+    ///   ``init(paths:helperPath:)`` time by nobody, because it is not
+    ///   reachable in practice (the helper is installed by us); it is called
+    ///   out here so a future reader does not have to rediscover it.
+    static func quoteForRestic(_ path: String) -> String {
+        if !path.isEmpty, path.allSatisfy({ unquotedSafe.contains($0) }) {
+            return path
+        }
+        return "\"\(path)\""
+    }
+
+    // MARK: - Executable path
+
+    /// This executable's absolute path, as the kernel/dyld reports it.
+    ///
+    /// - Linux: `/proc/self/exe` — unforgeable, and correct even when the
+    ///   binary was invoked through a symlink or a `PATH` lookup.
+    /// - Darwin: `_NSGetExecutablePath`, then `realpath` to resolve `..`,
+    ///   symlinks and a relative launch path.
+    ///
+    /// Deliberately **not** `CommandLine.arguments[0]`: `argv[0]` is whatever
+    /// the caller chose to put there, and baking it into a command string
+    /// restic will execute would be a straightforward code-execution hole.
+    ///
+    /// Deliberately **not** `Bundle.main.executablePath` either: for a
+    /// command-line tool living inside an `.app` bundle's `Contents/MacOS/`
+    /// — which is exactly where `restic-station-helper` ships — the main
+    /// bundle is the *app*, so that property returns the app's executable
+    /// rather than this one. It is kept only as a last-resort fallback.
+    public static func currentExecutablePath() -> String {
+        #if os(Linux)
+        var buffer = [CChar](repeating: 0, count: Int(PATH_MAX) + 1)
+        let length = readlink("/proc/self/exe", &buffer, buffer.count - 1)
+        if length > 0 {
+            buffer[length] = 0
+            if let resolved = Self.string(fromNulTerminated: buffer) {
+                return resolved
+            }
+        }
+        #elseif canImport(Darwin)
+        var size = UInt32(PATH_MAX) * 2
+        var raw = [CChar](repeating: 0, count: Int(size))
+        if _NSGetExecutablePath(&raw, &size) == 0 {
+            var resolved = [CChar](repeating: 0, count: Int(PATH_MAX) + 1)
+            if realpath(raw, &resolved) != nil, let path = Self.string(fromNulTerminated: resolved) {
+                return path
+            }
+            if let path = Self.string(fromNulTerminated: raw) {
+                return path
+            }
+        }
+        #endif
+        if let executable = Bundle.main.executablePath, !executable.isEmpty {
+            return executable
+        }
+        // Reached only if the process cannot introspect itself at all.
+        return "restic-station-helper"
+    }
+
+    // MARK: - Document
+
+    /// The on-disk shape:
+    /// `{"version":1,"secrets":{"<uuid>":"…","<uuid>-env":"{…}"}}` —
+    /// deliberately mirroring the keychain account naming so the two
+    /// backends stay structurally comparable.
+    struct Document: Codable, Equatable {
+        var version: Int
+        var secrets: [String: String]
+
+        init(version: Int = FileSecretStore.currentVersion, secrets: [String: String] = [:]) {
+            self.version = version
+            self.secrets = secrets
+        }
+    }
+
+    // MARK: - Reading
+
+    /// Reads and validates the file. A missing file is an empty document
+    /// (nothing stored yet), not an error.
+    ///
+    /// Refuses, with an actionable message, any file that is not a regular
+    /// file, is a symlink, or has any group/other permission bit set.
+    /// Silently reading a leaked secret file is worse than failing.
+    func load() throws -> Document {
+        guard let data = try readEnforcingMode() else {
+            return Document()
+        }
+        let document: Document
+        do {
+            document = try JSONDecoder().decode(Document.self, from: data)
+        } catch {
+            // `error` describes JSON structure, never a value: `DecodingError`
+            // reports key paths and expected types only.
+            throw SecretStoreError.backendFailed(
+                "\(fileURL.path) is not readable as a secrets file: \(error)"
+            )
+        }
+        guard document.version <= Self.currentVersion else {
+            throw SecretStoreError.backendFailed(
+                "\(fileURL.path) was written by a newer version of Restic Station "
+                    + "(format \(document.version), this build understands \(Self.currentVersion)). "
+                    + "Upgrade Restic Station rather than letting it overwrite the file."
+            )
+        }
+        return document
+    }
+
+    /// `nil` when the file does not exist.
+    private func readEnforcingMode() throws -> Data? {
+        let path = fileURL.path
+        // O_NOFOLLOW closes the symlink-swap hole, and fstat-on-the-open-fd
+        // closes the TOCTOU hole a path-based stat would leave: the mode we
+        // check is the mode of the exact file we are about to read.
+        let fd = path.withCString { open($0, O_RDONLY | O_NOFOLLOW) }
+        guard fd >= 0 else {
+            let code = errno
+            if code == ENOENT {
+                return nil
+            }
+            if code == ELOOP {
+                throw SecretStoreError.backendFailed(
+                    "refusing to read \(path): it is a symbolic link. "
+                        + "Replace it with a regular file owned by you (mode 0600)."
+                )
+            }
+            throw SecretStoreError.backendFailed("could not open \(path): \(Self.describe(errno: code))")
+        }
+        defer { close(fd) }
+
+        var info = stat()
+        guard fstat(fd, &info) == 0 else {
+            throw SecretStoreError.backendFailed("could not stat \(path): \(Self.describe(errno: errno))")
+        }
+        let mode = UInt32(info.st_mode)
+        guard mode & UInt32(S_IFMT) == UInt32(S_IFREG) else {
+            throw SecretStoreError.backendFailed(
+                "refusing to read \(path): it is not a regular file."
+            )
+        }
+        let permissions = mode & 0o777
+        guard permissions & 0o077 == 0 else {
+            throw SecretStoreError.backendFailed(
+                "refusing to read \(path): it is group- or world-accessible "
+                    + "(mode \(Self.octal(permissions))). Fix it with: chmod 600 \(path)"
+            )
+        }
+
+        let handle = FileHandle(fileDescriptor: fd, closeOnDealloc: false)
+        return handle.readDataToEndOfFile()
+    }
+
+    // MARK: - Writing
+
+    /// Read-modify-write under `locks/secrets.lock`, so a concurrent
+    /// `secret set` can never lose the other writer's entry.
+    private func mutate(_ change: @Sendable (inout Document) -> Void) async throws {
+        try await withWriteLock {
+            var document = try load()
+            document.version = Self.currentVersion
+            change(&document)
+            try store(document)
+        }
+    }
+
+    private func withWriteLock(_ body: () throws -> Void) async throws {
+        try prepareDirectories()
+        let lock = FileLock(path: lockFileURL)
+        let deadline = Date().addingTimeInterval(Self.lockTimeout)
+        while !lock.tryAcquire() {
+            guard Date() < deadline else {
+                throw SecretStoreError.backendFailed(
+                    "timed out after \(Int(Self.lockTimeout))s waiting for the secrets lock at "
+                        + "\(lockFileURL.path). Another Restic Station process may be stuck; "
+                        + "check for running restic-station-helper processes."
+                )
+            }
+            try await Task.sleep(nanoseconds: Self.lockPollNanoseconds)
+        }
+        defer { lock.release() }
+        try body()
+    }
+
+    /// temp file (`O_EXCL`, `0600`) → `fsync` → `rename(2)`.
+    private func store(_ document: Document) throws {
+        try prepareDirectories()
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data: Data
+        do {
+            data = try encoder.encode(document)
+        } catch {
+            throw SecretStoreError.backendFailed("could not encode the secrets file: \(error)")
+        }
+
+        let tempPath = tempFileURL.path
+        // Clear any leftover from a crashed write so O_EXCL always creates a
+        // brand-new file — which is what guarantees the 0600 creation mode
+        // actually applies (open(2) ignores `mode` for an existing file).
+        _ = tempPath.withCString { unlink($0) }
+        let fd = tempPath.withCString { open($0, O_CREAT | O_EXCL | O_WRONLY, 0o600) }
+        guard fd >= 0 else {
+            throw SecretStoreError.backendFailed(
+                "could not create \(tempPath): \(Self.describe(errno: errno))"
+            )
+        }
+        // Not "create-then-chmod": the file was *created* at 0600 and a umask
+        // can only clear bits, never set them, so the file has never been
+        // wider than 0600 for an instant. This pins the mode to exactly 0600
+        // whatever the process umask happened to strip.
+        _ = fchmod(fd, 0o600)
+
+        do {
+            try Self.writeAll(fd: fd, data: data)
+            guard fsync(fd) == 0 else {
+                throw SecretStoreError.backendFailed(
+                    "could not flush \(tempPath): \(Self.describe(errno: errno))"
+                )
+            }
+        } catch {
+            close(fd)
+            _ = tempPath.withCString { unlink($0) }
+            throw error
+        }
+        close(fd)
+
+        let destinationPath = fileURL.path
+        let renamed = tempPath.withCString { from in
+            destinationPath.withCString { to in
+                rename(from, to)
+            }
+        }
+        guard renamed == 0 else {
+            let code = errno
+            _ = tempPath.withCString { unlink($0) }
+            throw SecretStoreError.backendFailed(
+                "could not replace \(destinationPath): \(Self.describe(errno: code))"
+            )
+        }
+    }
+
+    private static func writeAll(fd: Int32, data: Data) throws {
+        var offset = 0
+        try data.withUnsafeBytes { raw in
+            guard let base = raw.baseAddress else { return }
+            while offset < raw.count {
+                let written = write(fd, base.advanced(by: offset), raw.count - offset)
+                if written < 0 {
+                    if errno == EINTR { continue }
+                    throw SecretStoreError.backendFailed("write failed: \(describe(errno: errno))")
+                }
+                if written == 0 { break }
+                offset += written
+            }
+        }
+        guard offset == data.count else {
+            throw SecretStoreError.backendFailed("short write to the secrets file")
+        }
+    }
+
+    // MARK: - Directories
+
+    /// Creates `root` at `0700` and `locks/` if they are missing.
+    ///
+    /// `root` is created with `mkdir(2)`'s mode argument, never
+    /// create-then-`chmod`. An *existing* `root` is left alone: it may have
+    /// been created at `0755` by `AppPaths.ensureDirectories()` (it holds
+    /// non-secret state too), and the `0600` file mode — enforced on every
+    /// read — is what actually protects the secrets. The `0700` directory is
+    /// defence in depth for the case where we get there first.
+    func prepareDirectories() throws {
+        try createDirectory(at: paths.root, mode: 0o700)
+        // Lock files hold nothing; the default mode is fine.
+        try FileManager.default.createDirectory(at: paths.locksDir, withIntermediateDirectories: true)
+    }
+
+    private func createDirectory(at url: URL, mode: mode_t) throws {
+        var info = stat()
+        if url.path.withCString({ stat($0, &info) }) == 0 {
+            return
+        }
+        let parent = url.deletingLastPathComponent()
+        if parent.path != url.path {
+            try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+        }
+        let created = url.path.withCString { mkdir($0, mode) }
+        if created == 0 {
+            // Same reasoning as the file's fchmod: the directory was created
+            // at `mode`, so this only pins it there against the umask.
+            _ = url.path.withCString { chmod($0, mode) }
+            return
+        }
+        if errno != EEXIST {
+            throw SecretStoreError.backendFailed(
+                "could not create \(url.path): \(Self.describe(errno: errno))"
+            )
+        }
+    }
+
+    // MARK: - Small helpers
+
+    private static func describe(errno code: Int32) -> String {
+        String(cString: strerror(code))
+    }
+
+    /// Decodes a NUL-terminated `CChar` buffer. Spelled by hand rather than
+    /// with `String(validatingCString:)` (deprecated in newer toolchains) or
+    /// its replacement (absent from older ones), so the same source compiles
+    /// warning-free on both the Linux CI toolchain and current macOS ones.
+    private static func string(fromNulTerminated buffer: [CChar]) -> String? {
+        guard let end = buffer.firstIndex(of: 0), end > 0 else { return nil }
+        return String(decoding: buffer[..<end].map { UInt8(bitPattern: $0) }, as: UTF8.self)
+    }
+
+    private static func octal(_ permissions: UInt32) -> String {
+        "0" + String(permissions, radix: 8)
+    }
+}

--- a/Core/Sources/ResticStationCore/Secrets/FileSecretStore.swift
+++ b/Core/Sources/ResticStationCore/Secrets/FileSecretStore.swift
@@ -53,18 +53,27 @@ public struct FileSecretStore: SecretStore {
     static let lockTimeout: TimeInterval = 10
     private static let lockPollNanoseconds: UInt64 = 25_000_000
 
+    public let backend = SecretBackend.file
+
     private let paths: AppPaths
     private let helperPath: String
 
     /// - Parameters:
     ///   - paths: supplies `root` (the secrets file's directory) and
     ///     `locksDir`.
-    ///   - helperPath: the absolute path baked into
-    ///     ``passwordCommand(destId:)``. Defaults to *this* executable,
-    ///     resolved from `/proc/self/exe` on Linux — deliberately **not**
+    ///   - helperPath: absolute path of the `restic-station-helper` binary,
+    ///     baked into ``passwordCommand(destId:)``.
+    ///
+    ///     Required, with **no default**. "This executable" is the right
+    ///     answer only inside the helper; the app process builds a store too
+    ///     (restore browsing, `mount`, primary `init`), and a default there
+    ///     would point `RESTIC_PASSWORD_COMMAND` at the SwiftUI app binary.
+    ///     See `SecretStoreFactory.make(paths:runner:helperExecutablePath:environment:)`.
+    ///     The helper passes ``currentExecutablePath()``, which reads
+    ///     `/proc/self/exe` — deliberately **not**
     ///     `CommandLine.arguments[0]`, which is whatever the caller chose to
     ///     put in `argv[0]` and is trivially spoofable.
-    public init(paths: AppPaths, helperPath: String = FileSecretStore.currentExecutablePath()) {
+    public init(paths: AppPaths, helperPath: String) {
         self.paths = paths
         self.helperPath = helperPath
     }

--- a/Core/Sources/ResticStationCore/Secrets/KeychainSecretStore.swift
+++ b/Core/Sources/ResticStationCore/Secrets/KeychainSecretStore.swift
@@ -1,15 +1,10 @@
+#if os(macOS)
 import Foundation
 
-/// Typed errors surfaced by `KeychainClient`.
-public enum KeychainError: Error, Sendable, Equatable {
-    /// `security`'s documented exit code 44 — no matching item.
-    case itemNotFound
-    /// Any other nonzero exit from `/usr/bin/security`, with its stderr.
-    case securityCommandFailed(String)
-}
-
-/// All keychain I/O for Restic Station, exactly per `docs/keychain-and-fda.md` §1:
-/// every read AND write goes through the `/usr/bin/security` command-line
+/// The macOS ``SecretStore`` backend: all keychain I/O for Restic Station,
+/// exactly per `docs/keychain-and-fda.md` §1.
+///
+/// Every read AND write goes through the `/usr/bin/security` command-line
 /// tool (never `SecItemAdd`/the Security framework), and every item we
 /// create is created with `-T /usr/bin/security` so a headless launchd
 /// context can read it back without a GUI consent prompt.
@@ -24,8 +19,13 @@ public enum KeychainError: Error, Sendable, Equatable {
 /// Note (documented, not "fixed" — see keychain-and-fda.md): passing
 /// `-w <value>` puts the secret in `security`'s argv, momentarily visible
 /// to `ps` on the local machine. Accepted tradeoff for a single-user
-/// machine; there is no programmatic non-interactive alternative.
-public struct KeychainClient: Sendable {
+/// machine; there is no programmatic non-interactive alternative. It is
+/// specific to `security(1)` and is deliberately **not** reproduced by
+/// ``FileSecretStore``, which never puts a secret in any argv.
+///
+/// Gated to macOS: `/usr/bin/security` does not exist elsewhere, and offering
+/// a backend that can only fail is worse than not offering it at all.
+public struct KeychainSecretStore: SecretStore {
     private static let securityPath = "/usr/bin/security"
     private static let service = "restic-station"
 
@@ -37,16 +37,16 @@ public struct KeychainClient: Sendable {
 
     // MARK: - Repo password
 
-    public func setPassword(_ pw: String, destId: UUID) async throws {
-        try await setValue(pw, account: Self.account(destId))
+    public func setPassword(_ password: String, destId: UUID) async throws {
+        try await setValue(password, account: SecretAccount.password(destId))
     }
 
     public func password(destId: UUID) async throws -> String {
-        try await readValue(account: Self.account(destId))
+        try await readValue(account: SecretAccount.password(destId))
     }
 
     public func deletePassword(destId: UUID) async throws {
-        try await deleteValueTolerant(account: Self.account(destId))
+        try await deleteValueTolerant(account: SecretAccount.password(destId))
     }
 
     // MARK: - Secret env (e.g. S3 keys)
@@ -56,16 +56,8 @@ public struct KeychainClient: Sendable {
     /// password, not arbitrary env vars — `ResticRunner` reads this blob
     /// itself and injects the real env vars.
     public func setSecretEnv(_ env: [String: String], destId: UUID) async throws {
-        let data: Data
-        do {
-            data = try JSONEncoder().encode(env)
-        } catch {
-            throw KeychainError.securityCommandFailed("failed to encode secret env as JSON: \(error)")
-        }
-        guard let json = String(data: data, encoding: .utf8) else {
-            throw KeychainError.securityCommandFailed("failed to encode secret env as UTF-8 JSON")
-        }
-        try await setValue(json, account: Self.envAccount(destId))
+        let json = try SecretEnvBlob.encode(env)
+        try await setValue(json, account: SecretAccount.secretEnv(destId))
     }
 
     /// A missing item is not an error here — it just means no secret env
@@ -73,22 +65,15 @@ public struct KeychainClient: Sendable {
     public func secretEnv(destId: UUID) async throws -> [String: String] {
         let json: String
         do {
-            json = try await readValue(account: Self.envAccount(destId))
-        } catch KeychainError.itemNotFound {
+            json = try await readValue(account: SecretAccount.secretEnv(destId))
+        } catch SecretStoreError.itemNotFound {
             return [:]
         }
-        guard let data = json.data(using: .utf8) else {
-            return [:]
-        }
-        do {
-            return try JSONDecoder().decode([String: String].self, from: data)
-        } catch {
-            throw KeychainError.securityCommandFailed("failed to decode secret env JSON: \(error)")
-        }
+        return try SecretEnvBlob.decode(json)
     }
 
     public func deleteSecretEnv(destId: UUID) async throws {
-        try await deleteValueTolerant(account: Self.envAccount(destId))
+        try await deleteValueTolerant(account: SecretAccount.secretEnv(destId))
     }
 
     // MARK: - Documented command string
@@ -96,22 +81,9 @@ public struct KeychainClient: Sendable {
     /// The exact command restic itself is configured to run via
     /// `RESTIC_PASSWORD_COMMAND` (see restic-cli.md). Our own reads use the
     /// same argv shape (via `readValue`), just invoked through `ProcessRunning`
-    /// instead of a shell string.
-    public static func passwordCommand(destId: UUID) -> String {
-        "\(securityPath) find-generic-password -s \(service) -a \(account(destId)) -w"
-    }
-
-    // MARK: - Account naming
-
-    /// Destination UUIDs never change (architecture.md §Identifiers) — the
-    /// destination UUID *is* the keychain account key, lowercased for a
-    /// stable, predictable account string.
-    private static func account(_ destId: UUID) -> String {
-        destId.uuidString.lowercased()
-    }
-
-    private static func envAccount(_ destId: UUID) -> String {
-        "\(account(destId))-env"
+    /// instead of a shell string. Contains no character needing quoting.
+    public func passwordCommand(destId: UUID) -> String {
+        "\(Self.securityPath) find-generic-password -s \(Self.service) -a \(SecretAccount.password(destId)) -w"
     }
 
     // MARK: - security subprocess plumbing
@@ -119,7 +91,7 @@ public struct KeychainClient: Sendable {
     private func setValue(_ value: String, account: String) async throws {
         do {
             try await deleteValue(account: account)
-        } catch KeychainError.itemNotFound {
+        } catch SecretStoreError.itemNotFound {
             // Nothing to delete — proceed straight to add.
         }
 
@@ -132,7 +104,7 @@ public struct KeychainClient: Sendable {
         ]
         let result = try await runSecurity(argv)
         guard result.exitCode == 0 else {
-            throw KeychainError.securityCommandFailed(Self.trimmedStderr(result))
+            throw SecretStoreError.backendFailed(Self.trimmedStderr(result))
         }
     }
 
@@ -145,10 +117,10 @@ public struct KeychainClient: Sendable {
         ]
         let result = try await runSecurity(argv)
         if result.exitCode == 44 {
-            throw KeychainError.itemNotFound
+            throw SecretStoreError.itemNotFound
         }
         guard result.exitCode == 0 else {
-            throw KeychainError.securityCommandFailed(Self.trimmedStderr(result))
+            throw SecretStoreError.backendFailed(Self.trimmedStderr(result))
         }
         var raw = String(decoding: result.stdout, as: UTF8.self)
         if raw.hasSuffix("\n") {
@@ -157,7 +129,7 @@ public struct KeychainClient: Sendable {
         return raw
     }
 
-    /// Deletes the item, throwing `KeychainError.itemNotFound` (typed) if
+    /// Deletes the item, throwing `SecretStoreError.itemNotFound` (typed) if
     /// there wasn't one. Used both directly and by the tolerant wrapper.
     private func deleteValue(account: String) async throws {
         let argv = [
@@ -167,10 +139,10 @@ public struct KeychainClient: Sendable {
         ]
         let result = try await runSecurity(argv)
         if result.exitCode == 44 {
-            throw KeychainError.itemNotFound
+            throw SecretStoreError.itemNotFound
         }
         guard result.exitCode == 0 else {
-            throw KeychainError.securityCommandFailed(Self.trimmedStderr(result))
+            throw SecretStoreError.backendFailed(Self.trimmedStderr(result))
         }
     }
 
@@ -179,7 +151,7 @@ public struct KeychainClient: Sendable {
     private func deleteValueTolerant(account: String) async throws {
         do {
             try await deleteValue(account: account)
-        } catch KeychainError.itemNotFound {
+        } catch SecretStoreError.itemNotFound {
             // Already gone.
         }
     }
@@ -199,3 +171,4 @@ public struct KeychainClient: Sendable {
         String(decoding: result.stderr, as: UTF8.self).trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }
+#endif

--- a/Core/Sources/ResticStationCore/Secrets/KeychainSecretStore.swift
+++ b/Core/Sources/ResticStationCore/Secrets/KeychainSecretStore.swift
@@ -29,6 +29,8 @@ public struct KeychainSecretStore: SecretStore {
     private static let securityPath = "/usr/bin/security"
     private static let service = "restic-station"
 
+    public let backend = SecretBackend.keychain
+
     private let runner: ProcessRunning
 
     public init(runner: ProcessRunning) {

--- a/Core/Sources/ResticStationCore/Secrets/SecretBackend.swift
+++ b/Core/Sources/ResticStationCore/Secrets/SecretBackend.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// Which ``SecretStore`` implementation this process uses.
+///
+/// The default follows the platform — macOS gets the keychain, everything
+/// else gets the file backend — and is overridable with
+/// `RESTIC_STATION_SECRET_BACKEND=keychain|file`.
+///
+/// The override is not a convenience knob: it is how the Linux file backend
+/// gets exercised on macOS (developer runs, `swift test`, and the macOS CI
+/// job), which is the only way this repository can test that code path
+/// without a Linux host. It is also the escape hatch for a macOS user who
+/// prefers a file to the login keychain.
+///
+/// An unrecognised value is a **hard error**, never a silent fallback:
+/// quietly falling back to the wrong backend would look like "all my
+/// passwords disappeared".
+public enum SecretBackend: String, Sendable, CaseIterable {
+    case keychain
+    case file
+
+    public static let environmentKey = "RESTIC_STATION_SECRET_BACKEND"
+
+    public static var platformDefault: SecretBackend {
+        #if os(macOS)
+        return .keychain
+        #else
+        return .file
+        #endif
+    }
+
+    /// - Throws: ``SecretStoreError/backendFailed(_:)`` naming the variable,
+    ///   the bad value, and the accepted values.
+    public static func resolve(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) throws -> SecretBackend {
+        guard let raw = environment[environmentKey] else {
+            return platformDefault
+        }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            // An empty value is "unset" everywhere else in this codebase
+            // (`AppPaths.default()` treats it the same way).
+            return platformDefault
+        }
+        guard let backend = SecretBackend(rawValue: trimmed.lowercased()) else {
+            throw SecretStoreError.backendFailed(
+                "\(environmentKey)=\"\(raw)\" is not a known secret backend — "
+                    + "expected \"keychain\" or \"file\""
+            )
+        }
+        return backend
+    }
+}
+
+/// Builds the ``SecretStore`` this process should use.
+///
+/// Every entry point that touches secrets goes through here — the helper's
+/// `HelperContext`, the `secret` subcommands, and the app — so backend
+/// selection happens in exactly one place.
+public enum SecretStoreFactory {
+
+    /// - Parameters:
+    ///   - paths: the file backend's data directory.
+    ///   - runner: the keychain backend's `/usr/bin/security` subprocess
+    ///     runner. Unused by the file backend.
+    /// - Throws: ``SecretStoreError/backendFailed(_:)`` for an unrecognised
+    ///   `RESTIC_STATION_SECRET_BACKEND`, or for `keychain` on a platform
+    ///   that has no `/usr/bin/security`.
+    public static func make(
+        paths: AppPaths,
+        runner: ProcessRunning,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) throws -> any SecretStore {
+        switch try SecretBackend.resolve(environment: environment) {
+        case .keychain:
+            #if os(macOS)
+            return KeychainSecretStore(runner: runner)
+            #else
+            throw SecretStoreError.backendFailed(
+                "\(SecretBackend.environmentKey)=keychain is only available on macOS — "
+                    + "/usr/bin/security does not exist on this platform. "
+                    + "Use \(SecretBackend.environmentKey)=file, or leave it unset."
+            )
+            #endif
+        case .file:
+            return FileSecretStore(paths: paths)
+        }
+    }
+}

--- a/Core/Sources/ResticStationCore/Secrets/SecretBackend.swift
+++ b/Core/Sources/ResticStationCore/Secrets/SecretBackend.swift
@@ -51,6 +51,69 @@ public enum SecretBackend: String, Sendable, CaseIterable {
         }
         return backend
     }
+
+    /// The backend this process is configured to use, for **user-facing text
+    /// only**.
+    ///
+    /// Falls back to the platform default when the override is unrecognised,
+    /// because a message must never throw — the *construction* path already
+    /// treats that same value as a hard error, so a process that got far
+    /// enough to render an error message resolved successfully here too.
+    ///
+    /// Prefer a `SecretStore`'s own ``SecretStore/backend`` wherever a store
+    /// is in hand: that is the store actually in use. This exists for the one
+    /// place that has no store — ``ResticRunnerError/userFacingMessage``,
+    /// which is a property on an error value.
+    public static var configured: SecretBackend {
+        (try? resolve()) ?? platformDefault
+    }
+
+    // MARK: - User-facing wording
+    //
+    // All secret-store wording lives here, so it is chosen by the backend in
+    // use rather than by the host OS. The pre-T23 macOS strings are
+    // reproduced verbatim by the `.keychain` cases: on macOS without an
+    // override nothing a user sees has changed.
+
+    /// A noun phrase naming this store, e.g. "the login keychain could not be
+    /// read for destination …".
+    public var displayName: String {
+        switch self {
+        case .keychain: return "the login keychain"
+        case .file: return "the secrets file"
+        }
+    }
+
+    /// One sentence of "what happened", for
+    /// ``ResticRunnerError/secretsUnavailable(destinationId:)``.
+    public var unavailableSummary: String {
+        switch self {
+        case .keychain: return "The password for this destination could not be read from the keychain."
+        case .file: return "The password for this destination could not be read from the secrets file."
+        }
+    }
+
+    /// One sentence of "what to do next" (`docs/ui-spec.md` §Voice).
+    public var unavailableAdvice: String {
+        switch self {
+        case .keychain: return "Unlock your login keychain, then run the backup again."
+        case .file: return "Check the permissions on the secrets file, then run the backup again."
+        }
+    }
+
+    /// What `Reachability` records in `state/repo-status-<destId>.json` when
+    /// the secret pre-flight fails.
+    ///
+    /// The `.keychain` string is matched by the app's badge heuristic
+    /// (`SetsBadges.offlineOrError`) to classify the failure as environmental
+    /// rather than as a repository error — changing it would silently turn an
+    /// "offline" badge into an "error" badge. `SetsBadges` knows both.
+    public var unavailableProbeReason: String {
+        switch self {
+        case .keychain: return "keychain locked"
+        case .file: return "secret store unavailable"
+        }
+    }
 }
 
 /// Builds the ``SecretStore`` this process should use.
@@ -64,12 +127,27 @@ public enum SecretStoreFactory {
     ///   - paths: the file backend's data directory.
     ///   - runner: the keychain backend's `/usr/bin/security` subprocess
     ///     runner. Unused by the file backend.
+    ///   - helperExecutablePath: absolute path of the
+    ///     **`restic-station-helper` binary**, which the file backend bakes
+    ///     into `RESTIC_PASSWORD_COMMAND`.
+    ///
+    ///     Deliberately required, with no default. The obvious default —
+    ///     "this executable" — is right only inside the helper: the app
+    ///     process also builds a store (restore browsing, `mount`, primary
+    ///     `init`), and defaulting there would point
+    ///     `RESTIC_PASSWORD_COMMAND` at the SwiftUI app binary, which cannot
+    ///     print a password and would try to start a UI from restic's child
+    ///     process. Making every caller name the binary turns that into a
+    ///     compile error instead of a runtime hang. The helper passes
+    ///     ``FileSecretStore/currentExecutablePath()``; the app passes its
+    ///     embedded helper's path.
     /// - Throws: ``SecretStoreError/backendFailed(_:)`` for an unrecognised
     ///   `RESTIC_STATION_SECRET_BACKEND`, or for `keychain` on a platform
     ///   that has no `/usr/bin/security`.
     public static func make(
         paths: AppPaths,
         runner: ProcessRunning,
+        helperExecutablePath: String,
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) throws -> any SecretStore {
         switch try SecretBackend.resolve(environment: environment) {
@@ -84,7 +162,7 @@ public enum SecretStoreFactory {
             )
             #endif
         case .file:
-            return FileSecretStore(paths: paths)
+            return FileSecretStore(paths: paths, helperPath: helperExecutablePath)
         }
     }
 }

--- a/Core/Sources/ResticStationCore/Secrets/SecretStore.swift
+++ b/Core/Sources/ResticStationCore/Secrets/SecretStore.swift
@@ -1,0 +1,170 @@
+import Foundation
+
+// MARK: - SecretStoreError
+
+/// Typed errors surfaced by every ``SecretStore`` backend.
+///
+/// **Invariant: no case ever carries secret material.** ``itemNotFound`` is
+/// data-free by construction, and ``backendFailed(_:)`` may only be
+/// constructed from a backend's own diagnostic text (a `security` stderr
+/// line, a file path, an errno string) — never from a password, a secret-env
+/// value, or a decoded blob. These strings reach run logs and the UI.
+public enum SecretStoreError: Error, Sendable, Equatable, CustomStringConvertible {
+    /// No stored item for this destination. On the keychain backend this is
+    /// `security`'s documented exit code 44; on the file backend it is a
+    /// missing key (or a missing `secrets.json`).
+    case itemNotFound
+    /// Any other backend failure, with the backend's own diagnostic text.
+    case backendFailed(String)
+
+    public var description: String {
+        switch self {
+        case .itemNotFound:
+            return "no stored secret for this destination"
+        case .backendFailed(let detail):
+            return detail
+        }
+    }
+}
+
+extension SecretStoreError: LocalizedError {
+    public var errorDescription: String? { description }
+}
+
+// MARK: - SecretStore
+
+/// Where Restic Station keeps a destination's repository password and its
+/// secret environment variables.
+///
+/// Two backends implement this (see `docs/keychain-and-fda.md`):
+/// ``KeychainSecretStore`` (macOS, `/usr/bin/security`) and
+/// ``FileSecretStore`` (Linux default, `<AppPaths.root>/secrets.json`).
+/// ``SecretStoreFactory/make(paths:runner:environment:)`` picks one.
+///
+/// **Semantics every backend must preserve** — these are load-bearing and
+/// each has a shared conformance test in `SecretStoreConformanceTests`:
+///
+/// - ``password(destId:)`` throws ``SecretStoreError/itemNotFound`` when the
+///   destination has no stored password.
+/// - ``secretEnv(destId:)`` returns `[:]` — it does **not** throw — when no
+///   secret env was ever configured. "Absent" and "empty" are the same thing
+///   here; no destination is required to have secret env vars.
+/// - Both delete methods are idempotent: deleting an absent item is a no-op,
+///   not an error.
+/// - Writes replace rather than merge, and are delete-then-add (a macOS
+///   keychain item's ACL is fixed at creation and `-U` cannot repair it, so
+///   the keychain backend must re-create; the file backend follows the same
+///   replace semantics so the two stay behaviourally identical).
+///
+/// ``passwordCommand(destId:)`` is an instance requirement, not a static one:
+/// each backend produces its own `RESTIC_PASSWORD_COMMAND` string, and the
+/// file backend's depends on where *this* executable lives.
+public protocol SecretStore: Sendable {
+
+    // MARK: Repository password
+
+    func setPassword(_ password: String, destId: UUID) async throws
+    func password(destId: UUID) async throws -> String
+    func deletePassword(destId: UUID) async throws
+
+    // MARK: Secret env (e.g. S3 keys)
+
+    func setSecretEnv(_ env: [String: String], destId: UUID) async throws
+    func secretEnv(destId: UUID) async throws -> [String: String]
+    func deleteSecretEnv(destId: UUID) async throws
+
+    // MARK: Password command
+
+    /// The exact command restic is configured to run via
+    /// `RESTIC_PASSWORD_COMMAND` / `RESTIC_FROM_PASSWORD_COMMAND` to obtain
+    /// this destination's password.
+    ///
+    /// restic **word-splits this itself** — it does not hand it to `sh -c`
+    /// (`docs/restic-cli.md` §General). The returned string must therefore be
+    /// splittable by restic's own splitter and must never be built from user
+    /// input.
+    func passwordCommand(destId: UUID) -> String
+
+    /// Environment variables the ``passwordCommand(destId:)`` child needs in
+    /// order to reach *this* store.
+    ///
+    /// `ResticRunner` replaces restic's environment rather than extending it
+    /// (`docs/restic-cli.md` §General), and restic's password-command child
+    /// inherits that replaced environment. A backend whose location is
+    /// configurable — ``FileSecretStore``, which lives under
+    /// `AppPaths.root` — must therefore say so here, or the child would look
+    /// in the *default* data directory with the *default* backend and fail
+    /// to find the password this process just read successfully.
+    ///
+    /// Empty for ``KeychainSecretStore``: `/usr/bin/security` needs no
+    /// configuration, which is why macOS's assembled environment is
+    /// unchanged by this requirement.
+    ///
+    /// **Never** put a secret in here: these values are passed to restic and
+    /// on to its children.
+    var passwordCommandEnvironment: [String: String] { get }
+}
+
+extension SecretStore {
+    /// Most backends need nothing.
+    public var passwordCommandEnvironment: [String: String] { [:] }
+}
+
+// MARK: - Account naming
+
+/// The storage key for a destination's secrets, shared by both backends so
+/// the keychain accounts and the `secrets.json` keys stay structurally
+/// identical (`docs/data-model.md`).
+///
+/// Destination UUIDs never change (architecture.md §Identifiers) — the
+/// destination UUID *is* the key, lowercased for a stable, predictable
+/// string.
+public enum SecretAccount {
+    public static func password(_ destId: UUID) -> String {
+        destId.uuidString.lowercased()
+    }
+
+    public static func secretEnv(_ destId: UUID) -> String {
+        "\(password(destId))-env"
+    }
+}
+
+// MARK: - Secret-env blob
+
+/// The secret-env value both backends store: a compact JSON object of
+/// `{"VAR": "value"}`.
+///
+/// restic's password-command mechanism only covers the repository password,
+/// not arbitrary environment variables (e.g. `AWS_SECRET_ACCESS_KEY`), so
+/// `ResticRunner` reads this blob itself and injects real env vars.
+///
+/// Shared between the backends deliberately: the encoding is part of the
+/// on-disk/on-keychain contract, and one implementation means the two
+/// backends can never drift.
+enum SecretEnvBlob {
+    /// - Note: the thrown message never includes `env` — its values are
+    ///   secrets. Only the `Error`'s own type-level description is used.
+    static func encode(_ env: [String: String]) throws -> String {
+        let data: Data
+        do {
+            data = try JSONEncoder().encode(env)
+        } catch {
+            throw SecretStoreError.backendFailed("failed to encode secret env as JSON: \(error)")
+        }
+        guard let json = String(data: data, encoding: .utf8) else {
+            throw SecretStoreError.backendFailed("failed to encode secret env as UTF-8 JSON")
+        }
+        return json
+    }
+
+    static func decode(_ json: String) throws -> [String: String] {
+        guard let data = json.data(using: .utf8) else {
+            return [:]
+        }
+        do {
+            return try JSONDecoder().decode([String: String].self, from: data)
+        } catch {
+            throw SecretStoreError.backendFailed("failed to decode secret env JSON: \(error)")
+        }
+    }
+}

--- a/Core/Sources/ResticStationCore/Secrets/SecretStore.swift
+++ b/Core/Sources/ResticStationCore/Secrets/SecretStore.swift
@@ -39,7 +39,8 @@ extension SecretStoreError: LocalizedError {
 /// Two backends implement this (see `docs/keychain-and-fda.md`):
 /// ``KeychainSecretStore`` (macOS, `/usr/bin/security`) and
 /// ``FileSecretStore`` (Linux default, `<AppPaths.root>/secrets.json`).
-/// ``SecretStoreFactory/make(paths:runner:environment:)`` picks one.
+/// ``SecretStoreFactory/make(paths:runner:helperExecutablePath:environment:)``
+/// picks one.
 ///
 /// **Semantics every backend must preserve** — these are load-bearing and
 /// each has a shared conformance test in `SecretStoreConformanceTests`:
@@ -60,6 +61,18 @@ extension SecretStoreError: LocalizedError {
 /// each backend produces its own `RESTIC_PASSWORD_COMMAND` string, and the
 /// file backend's depends on where *this* executable lives.
 public protocol SecretStore: Sendable {
+
+    /// Which backend this store is.
+    ///
+    /// Exists so every user-facing string about secret storage is chosen by
+    /// **the store actually in use**, not by the host OS: macOS with
+    /// `RESTIC_STATION_SECRET_BACKEND=file` is a supported configuration, and
+    /// telling that user to "unlock your login keychain" when their
+    /// `secrets.json` has the wrong mode sends them down the wrong path at
+    /// exactly the wrong moment. The wording itself lives on
+    /// ``SecretBackend`` so the two backends cannot describe themselves
+    /// inconsistently.
+    var backend: SecretBackend { get }
 
     // MARK: Repository password
 

--- a/Core/Tests/ResticStationCoreTests/Engine/BackupEngineTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Engine/BackupEngineTests.swift
@@ -83,7 +83,7 @@ struct BackupEngineTests {
     /// Everything one engine test needs, wired to a temp data dir. Local
     /// destinations are used throughout so `Reachability` answers from the
     /// filesystem and every spawned argv in `fake.invocations` is either a
-    /// keychain read or a restic command the engine itself issued.
+    /// restic command the engine itself issued.
     struct Env {
         let root: URL
         let paths: AppPaths
@@ -125,6 +125,7 @@ struct BackupEngineTests {
     ///   - reachableSecondaries: one flag per secondary; an unreachable one
     ///     simply has no repository directory on disk.
     static func makeEnv(
+        secretsUnavailableFor: [UUID] = [],
         script: [FakeProcessRunner.Expectation],
         retention: RetentionPolicy? = RetentionPolicy(keepLast: 3),
         checkPolicy: CheckPolicy? = nil,
@@ -179,11 +180,14 @@ struct BackupEngineTests {
         let processRunner: ProcessRunning = onSpawn.map {
             ObservingProcessRunner(inner: fake, onSpawn: $0)
         } ?? fake
-        let keychain = KeychainClient(runner: processRunner)
+        let secrets = FakeSecretStore(defaultPassword: "repo-password")
+        for id in secretsUnavailableFor {
+            secrets.failPassword(for: id)
+        }
         let restic = ResticRunner(
             resticPath: resticPath,
             paths: paths,
-            keychain: keychain,
+            secrets: secrets,
             runner: processRunner
         )
         let runStore = RunStore(paths: paths, now: clock.now)
@@ -193,7 +197,7 @@ struct BackupEngineTests {
             config: config,
             paths: paths,
             restic: restic,
-            keychain: keychain,
+            secrets: secrets,
             runStore: runStore,
             stateStore: stateStore,
             reachability: Reachability(restic: restic),
@@ -216,38 +220,14 @@ struct BackupEngineTests {
 
     // MARK: Scripting helpers
 
-    static func securityRead(_ account: String) -> [String] {
-        ["/usr/bin/security", "find-generic-password", "-s", "restic-station", "-a", account]
-    }
-
-    /// The engine's own step-1 pre-flight read (and every other
-    /// `keychainAvailable` read): one `find-generic-password` per destination.
-    static func keychainPassword(_ id: UUID, exitCode: Int32 = 0) -> FakeProcessRunner.Expectation {
-        .init(
-            argvPrefix: securityRead(id.uuidString.lowercased()),
-            stdoutLines: exitCode == 0 ? ["repo-password"] : [],
-            stderr: exitCode == 0 ? "" : "SecKeychainSearchCopyNext: User interaction is not allowed.",
-            exitCode: exitCode
-        )
-    }
-
-    static func keychainEnv(_ id: UUID) -> FakeProcessRunner.Expectation {
-        .init(argvPrefix: securityRead("\(id.uuidString.lowercased())-env"), exitCode: 44)
-    }
-
-    /// The keychain reads `ResticRunner` performs before one spawn: the
-    /// destination pre-flight, the from-destination pre-flight (copy /
-    /// init --from-repo only), then the secret-env blobs (from-destination
-    /// first, destination last — see `ResticRunner.environment(for:)`).
-    static func keychainReads(dest: UUID, from: UUID? = nil) -> [FakeProcessRunner.Expectation] {
-        guard let from else {
-            return [keychainPassword(dest), keychainEnv(dest)]
-        }
-        return [keychainPassword(dest), keychainPassword(from), keychainEnv(from), keychainEnv(dest)]
-    }
-
-    /// One scripted restic spawn: the keychain reads it triggers, then the
-    /// reply itself. `argv` is matched in full (prefix == whole argv).
+    /// One scripted restic spawn. `argv` is matched in full (prefix == whole
+    /// argv).
+    ///
+    /// Before T23 this also had to script the four `/usr/bin/security` reads
+    /// each spawn triggered; secrets now come from an injected
+    /// `FakeSecretStore`, so the process script is restic and nothing else.
+    /// `dest`/`from` are kept in the signature because they document which
+    /// destinations a call reads secrets for.
     static func resticCall(
         _ argv: [String],
         dest: UUID,
@@ -256,7 +236,7 @@ struct BackupEngineTests {
         stderr: String = "",
         exitCode: Int32 = 0
     ) -> [FakeProcessRunner.Expectation] {
-        keychainReads(dest: dest, from: from) + [
+        [
             .init(
                 argvPrefix: [resticPath] + argv,
                 stdoutLines: stdoutLines,
@@ -286,7 +266,7 @@ struct BackupEngineTests {
 
     @Test("row 1: primary + 2 reachable secondaries + retention → backup, 2 copies, 3 prunes, one group")
     func rowOneHappyPath() async throws {
-        var script = [Self.keychainPassword(Self.primaryId)]
+        var script: [FakeProcessRunner.Expectation] = []
         let env = Self.makeEnv(script: [])
         defer { env.cleanUp() }
         let primaryRepo = env.primary.repoURL
@@ -356,7 +336,7 @@ struct BackupEngineTests {
     @Test("row 2: primary unreachable → failed backup record, no restic at all, lastBackupStart still updated")
     func rowTwoPrimaryUnreachable() async throws {
         let env = Self.makeEnv(
-            script: [Self.keychainPassword(Self.primaryId)],
+            script: [],
             primaryReachable: false
         )
         defer { env.cleanUp() }
@@ -402,7 +382,7 @@ struct BackupEngineTests {
             status.lastSyncedAt = staleSync
         }
 
-        var script = [Self.keychainPassword(Self.primaryId)]
+        var script: [FakeProcessRunner.Expectation] = []
         script += Self.resticCall(
             Self.backupArgv(env.primary.repoURL), dest: Self.primaryId, stdoutLines: Self.backupStream()
         )
@@ -446,7 +426,7 @@ struct BackupEngineTests {
         defer { env.cleanUp() }
         let secondary = env.secondaries[0]
 
-        var script = [Self.keychainPassword(Self.primaryId)]
+        var script: [FakeProcessRunner.Expectation] = []
         script += Self.resticCall(
             Self.backupArgv(env.primary.repoURL),
             dest: Self.primaryId,
@@ -481,7 +461,7 @@ struct BackupEngineTests {
         let env = Self.makeEnv(script: [])
         defer { env.cleanUp() }
 
-        var script = [Self.keychainPassword(Self.primaryId)]
+        var script: [FakeProcessRunner.Expectation] = []
         script += Self.resticCall(
             Self.backupArgv(env.primary.repoURL),
             dest: Self.primaryId,
@@ -515,7 +495,7 @@ struct BackupEngineTests {
         let failing = env.secondaries[0]
         let healthy = env.secondaries[1]
 
-        var script = [Self.keychainPassword(Self.primaryId)]
+        var script: [FakeProcessRunner.Expectation] = []
         script += Self.resticCall(
             Self.backupArgv(env.primary.repoURL), dest: Self.primaryId, stdoutLines: Self.backupStream()
         )
@@ -571,7 +551,7 @@ struct BackupEngineTests {
         defer { env.cleanUp() }
         let lockedError = (try? FixtureLoader.string("locked-error.json").trimmingCharacters(in: .newlines)) ?? ""
 
-        var script = [Self.keychainPassword(Self.primaryId)]
+        var script: [FakeProcessRunner.Expectation] = []
         script += Self.resticCall(
             Self.backupArgv(env.primary.repoURL),
             dest: Self.primaryId,
@@ -616,7 +596,7 @@ struct BackupEngineTests {
         let env = Self.makeEnv(script: [], retention: nil, reachableSecondaries: [])
         defer { env.cleanUp() }
 
-        var script = [Self.keychainPassword(Self.primaryId)]
+        var script: [FakeProcessRunner.Expectation] = []
         script += Self.resticCall(
             Self.backupArgv(env.primary.repoURL), dest: Self.primaryId, exitCode: 11
         )
@@ -639,11 +619,11 @@ struct BackupEngineTests {
         #expect(backup.errorSummary?.contains("locked") == true)
     }
 
-    // MARK: - Row 9 — keychain locked pre-flight (safety: no trace at all)
+    // MARK: - Row 9 — unreadable secret store (safety: no trace at all)
 
-    @Test("row 9: a locked keychain leaves NO run record, NO lastBackupStart, NO lock file")
-    func rowNineKeychainLocked() async throws {
-        let env = Self.makeEnv(script: [Self.keychainPassword(Self.primaryId, exitCode: 1)])
+    @Test("row 9: an unreadable secret store leaves NO run record, NO lastBackupStart, NO lock file")
+    func rowNineSecretsUnavailable() async throws {
+        let env = Self.makeEnv(secretsUnavailableFor: [Self.primaryId], script: [])
         defer { env.cleanUp() }
 
         let outcome = await env.engine.runSet(env.set, trigger: .scheduled)
@@ -652,9 +632,9 @@ struct BackupEngineTests {
             Issue.record("expected .retryable, got \(outcome)")
             return
         }
-        // Exactly one process was ever spawned: the pre-flight read itself.
-        #expect(env.fake.invocations.count == 1)
-        #expect(env.fake.invocations[0].argv == Self.securityRead(Self.primaryId.uuidString.lowercased()) + ["-w"])
+        // Nothing was spawned at all — the pre-flight is not a subprocess,
+        // and it runs before anything else the engine does.
+        #expect(env.fake.invocations.isEmpty)
         #expect(env.indexEntries.isEmpty)
         #expect(env.stateStore.readScheduleState() == nil, "no schedule-state write at all")
         #expect(
@@ -668,7 +648,7 @@ struct BackupEngineTests {
 
     @Test("row 10: set lock busy → one .skipped record and nothing else (no lastBackupStart)")
     func rowTenLockBusy() async throws {
-        let env = Self.makeEnv(script: [Self.keychainPassword(Self.primaryId)])
+        let env = Self.makeEnv(script: [])
         defer { env.cleanUp() }
         try env.paths.ensureDirectories()
 
@@ -704,7 +684,7 @@ struct BackupEngineTests {
         defer { env.cleanUp() }
         let secondary = env.secondaries[0]
 
-        var script = [Self.keychainPassword(Self.primaryId)]
+        var script: [FakeProcessRunner.Expectation] = []
         script += Self.resticCall(
             Self.backupArgv(env.primary.repoURL), dest: Self.primaryId, stdoutLines: Self.backupStream()
         )
@@ -735,7 +715,7 @@ struct BackupEngineTests {
         defer { env.cleanUp() }
         let secondary = env.secondaries[0]
 
-        var script = [Self.keychainPassword(Self.primaryId)]
+        var script: [FakeProcessRunner.Expectation] = []
         script += Self.resticCall(
             Self.backupArgv(env.primary.repoURL), dest: Self.primaryId, stdoutLines: Self.backupStream()
         )
@@ -764,7 +744,7 @@ struct BackupEngineTests {
         let env = Self.makeEnv(script: [], retention: nil, reachableSecondaries: [])
         defer { env.cleanUp() }
 
-        var script = [Self.keychainPassword(Self.primaryId)]
+        var script: [FakeProcessRunner.Expectation] = []
         script += Self.resticCall(
             Self.backupArgv(env.primary.repoURL),
             dest: Self.primaryId,
@@ -816,7 +796,7 @@ struct BackupEngineTests {
         defer { env.cleanUp() }
         let secondary = env.secondaries[0]
 
-        var script = [Self.keychainPassword(Self.primaryId)]
+        var script: [FakeProcessRunner.Expectation] = []
         script += Self.resticCall(
             Self.backupArgv(env.primary.repoURL), dest: Self.primaryId, stdoutLines: Self.backupStream()
         )
@@ -919,7 +899,7 @@ struct BackupEngineTests {
         let env = Self.makeEnv(script: [], retention: nil, reachableSecondaries: [])
         defer { env.cleanUp() }
 
-        var script = [Self.keychainPassword(Self.primaryId)]
+        var script: [FakeProcessRunner.Expectation] = []
         script += Self.resticCall(
             Self.backupArgv(env.primary.repoURL), dest: Self.primaryId, stdoutLines: Self.backupStream()
         )
@@ -946,7 +926,7 @@ struct BackupEngineTests {
             state.checkCount = 1
         }
 
-        var script = [Self.keychainPassword(Self.primaryId)]
+        var script: [FakeProcessRunner.Expectation] = []
         script += Self.resticCall(
             ["-r", env.primary.repoURL, "check", "--read-data-subset=8/20"],
             dest: Self.primaryId,
@@ -983,7 +963,7 @@ struct BackupEngineTests {
             state.checkCount = 1
         }
 
-        var script = [Self.keychainPassword(Self.primaryId)]
+        var script: [FakeProcessRunner.Expectation] = []
         script += Self.resticCall(
             ["-r", env.primary.repoURL, "check", "--read-data-subset=8/20"],
             dest: Self.primaryId,
@@ -1016,7 +996,7 @@ struct BackupEngineTests {
             state.checkCount = 3 // this run is the 4th
         }
 
-        var script = [Self.keychainPassword(Self.primaryId)]
+        var script: [FakeProcessRunner.Expectation] = []
         script += Self.resticCall(
             ["-r", env.primary.repoURL, "check", "--read-data-subset=4/20"],
             dest: Self.primaryId,
@@ -1045,7 +1025,7 @@ struct BackupEngineTests {
 
     @Test("runCheck: set lock busy → .skipped record, no restic")
     func checkLockBusy() async throws {
-        let env = Self.makeEnv(script: [Self.keychainPassword(Self.primaryId)], reachableSecondaries: [])
+        let env = Self.makeEnv(script: [], reachableSecondaries: [])
         defer { env.cleanUp() }
         try env.paths.ensureDirectories()
         let holder = FileLock(path: env.paths.setLockFile(setId: Self.setId))
@@ -1075,7 +1055,7 @@ struct BackupEngineTests {
         }
         try env.stateStore.updateRepoStatus(destId: fresh.id) { $0.lastSyncedAt = Self.t0 }
 
-        var script = [Self.keychainPassword(Self.primaryId)]
+        var script: [FakeProcessRunner.Expectation] = []
         script += Self.resticCall(Self.forgetArgv(env.primary.repoURL), dest: Self.primaryId)
         script += Self.resticCall(Self.forgetArgv(fresh.repoURL), dest: Self.secondaryBId)
         env.fake.script = script
@@ -1105,7 +1085,7 @@ struct BackupEngineTests {
             try env.stateStore.updateRepoStatus(destId: secondary.id) { $0.lastSyncedAt = Self.t0 }
         }
 
-        var script = [Self.keychainPassword(Self.primaryId)]
+        var script: [FakeProcessRunner.Expectation] = []
         script += Self.resticCall(Self.forgetArgv(env.primary.repoURL), dest: Self.primaryId)
         env.fake.script = script
 
@@ -1126,7 +1106,7 @@ struct BackupEngineTests {
         let status = await env.engine.runPrune(env.set)
 
         #expect(status == .skipped)
-        #expect(env.fake.invocations.isEmpty, "not even a keychain read — the guard is the first thing checked")
+        #expect(env.fake.invocations.isEmpty, "nothing spawned — the guard is the first thing checked")
         #expect(env.indexEntries.isEmpty)
     }
 
@@ -1138,7 +1118,7 @@ struct BackupEngineTests {
         defer { env.cleanUp() }
         let target = env.root.appendingPathComponent("restore-target", isDirectory: true).path
 
-        var script = [Self.keychainPassword(Self.primaryId)]
+        var script: [FakeProcessRunner.Expectation] = []
         script += Self.resticCall(
             [
                 "-r", env.primary.repoURL, "restore", "--json", "abc123:/proj/src",
@@ -1172,7 +1152,7 @@ struct BackupEngineTests {
 
     @Test("safety: a restore cannot start while the set lock is held by a backup")
     func restoreRespectsSetLock() async throws {
-        let env = Self.makeEnv(script: [Self.keychainPassword(Self.primaryId)])
+        let env = Self.makeEnv(script: [])
         defer { env.cleanUp() }
         try env.paths.ensureDirectories()
         let holder = FileLock(path: env.paths.setLockFile(setId: Self.setId))
@@ -1195,7 +1175,7 @@ struct BackupEngineTests {
         let env = Self.makeEnv(script: [], reachableSecondaries: [])
         defer { env.cleanUp() }
 
-        var script = [Self.keychainPassword(Self.primaryId)]
+        var script: [FakeProcessRunner.Expectation] = []
         script += Self.resticCall(
             ["-r", env.primary.repoURL, "restore", "--json", "abc123", "--target", "/tmp/target"],
             dest: Self.primaryId,
@@ -1225,7 +1205,7 @@ struct BackupEngineTests {
         defer { env.cleanUp() }
         let secondary = env.secondaries[0]
 
-        var script = [Self.keychainPassword(Self.secondaryAId), Self.keychainPassword(Self.primaryId)]
+        var script: [FakeProcessRunner.Expectation] = []
         script += Self.resticCall(
             [
                 "-r", secondary.repoURL, "init", "--json",

--- a/Core/Tests/ResticStationCoreTests/Engine/BackupEngineTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Engine/BackupEngineTests.swift
@@ -126,6 +126,7 @@ struct BackupEngineTests {
     ///     simply has no repository directory on disk.
     static func makeEnv(
         secretsUnavailableFor: [UUID] = [],
+        secretBackend: SecretBackend = .platformDefault,
         script: [FakeProcessRunner.Expectation],
         retention: RetentionPolicy? = RetentionPolicy(keepLast: 3),
         checkPolicy: CheckPolicy? = nil,
@@ -180,7 +181,7 @@ struct BackupEngineTests {
         let processRunner: ProcessRunning = onSpawn.map {
             ObservingProcessRunner(inner: fake, onSpawn: $0)
         } ?? fake
-        let secrets = FakeSecretStore(defaultPassword: "repo-password")
+        let secrets = FakeSecretStore(defaultPassword: "repo-password", backend: secretBackend)
         for id in secretsUnavailableFor {
             secrets.failPassword(for: id)
         }
@@ -642,6 +643,33 @@ struct BackupEngineTests {
             "the set lock must not even be created before the pre-flight passes"
         )
         #expect(env.stateStore.readCurrentRun(setId: Self.setId) == nil)
+    }
+
+    /// Regression test for the review finding that the engine's wording
+    /// branched on `#if os(macOS)`. The `.retryable` reason is shown to the
+    /// user and logged; on a host running the file backend it must point at
+    /// the secrets file, not at a login keychain the host may not even have.
+    @Test("row 9: the retryable reason names the store in use, not the host OS")
+    func rowNineReasonFollowsTheBackend() async throws {
+        for backend in SecretBackend.allCases {
+            let env = Self.makeEnv(
+                secretsUnavailableFor: [Self.primaryId],
+                secretBackend: backend,
+                script: []
+            )
+            defer { env.cleanUp() }
+
+            let outcome = await env.engine.runSet(env.set, trigger: .scheduled)
+
+            guard case .retryable(let reason) = outcome else {
+                Issue.record("expected .retryable, got \(outcome)")
+                return
+            }
+            #expect(reason.hasPrefix(backend.displayName), "reason was: \(reason)")
+            if backend == .file {
+                #expect(!reason.lowercased().contains("keychain"), "reason was: \(reason)")
+            }
+        }
     }
 
     // MARK: - Row 10 — set lock busy

--- a/Core/Tests/ResticStationCoreTests/Engine/ReachabilityTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Engine/ReachabilityTests.swift
@@ -11,31 +11,28 @@ struct ReachabilityTests {
         AppPaths(root: URL(fileURLWithPath: "/tmp/restic-station-reachability-tests", isDirectory: true))
     }
 
-    static func makeReachability(_ fake: FakeProcessRunner) -> Reachability {
+    static func makeReachability(
+        _ fake: FakeProcessRunner,
+        secrets: FakeSecretStore = FakeSecretStore(defaultPassword: password)
+    ) -> Reachability {
         let runner = ResticRunner(
             resticPath: "/usr/local/bin/restic",
             paths: paths(),
-            keychain: KeychainClient(runner: fake),
+            secrets: secrets,
             runner: fake
         )
         return Reachability(restic: runner)
     }
 
-    static func securityRead(_ account: String) -> [String] {
-        ["/usr/bin/security", "find-generic-password", "-s", "restic-station", "-a", account]
-    }
-
-    static func passwordAccount(_ id: UUID) -> String { id.uuidString.lowercased() }
-    static func envAccount(_ id: UUID) -> String { "\(id.uuidString.lowercased())-env" }
-
-    /// Scripted keychain replies for the pre-flight (password) + env-blob
-    /// reads `ResticRunner.run` performs before invoking restic itself —
-    /// same shape as `ResticRunnerTests.keychainScript`.
-    static func keychainScript(for id: UUID) -> [FakeProcessRunner.Expectation] {
-        [
-            .init(argvPrefix: securityRead(passwordAccount(id)), stdoutLines: [password]),
-            .init(argvPrefix: securityRead(envAccount(id)), exitCode: 44),
-        ]
+    /// The `offline` reason `ResticRunner`'s secret pre-flight produces.
+    /// Platform-split in `Reachability` so the macOS wording — which the
+    /// app's badge heuristic matches on — is unchanged by T23.
+    static var secretsUnavailableReason: String {
+        #if os(macOS)
+        return "keychain locked"
+        #else
+        return "secret store unavailable"
+        #endif
     }
 
     // MARK: - Local: present / missing
@@ -91,8 +88,7 @@ struct ReachabilityTests {
     @Test("remote destination: exit 0 is reachable")
     func remoteExitZeroIsReachable() async throws {
         let dest = Destination(id: Self.destId, label: "R2", repoURL: "s3:https://x/bucket", isPrimary: false)
-        let fake = FakeProcessRunner(script:
-            Self.keychainScript(for: Self.destId) + [
+        let fake = FakeProcessRunner(script: [
                 .init(argvPrefix: ["/usr/local/bin/restic", "-r", dest.repoURL, "cat", "config"], exitCode: 0),
             ]
         )
@@ -109,8 +105,7 @@ struct ReachabilityTests {
     @Test("remote destination: a ProcessRunning timeout is offline, not error")
     func remoteTimeoutIsOffline() async throws {
         let dest = Destination(id: Self.destId, label: "R2", repoURL: "s3:https://x/bucket", isPrimary: false)
-        let fake = FakeProcessRunner(script:
-            Self.keychainScript(for: Self.destId) + [
+        let fake = FakeProcessRunner(script: [
                 .init(argvPrefix: ["/usr/local/bin/restic", "-r", dest.repoURL, "cat", "config"], failure: .timeout),
             ]
         )
@@ -130,8 +125,7 @@ struct ReachabilityTests {
         // confirm Reachability still surfaces the timeout mapping when the
         // fake takes some (bounded) time before throwing.
         let dest = Destination(id: Self.destId, label: "R2", repoURL: "s3:https://x/bucket", isPrimary: false)
-        let fake = FakeProcessRunner(script:
-            Self.keychainScript(for: Self.destId) + [
+        let fake = FakeProcessRunner(script: [
                 .init(
                     argvPrefix: ["/usr/local/bin/restic", "-r", dest.repoURL, "cat", "config"],
                     delay: 0.05,
@@ -148,8 +142,7 @@ struct ReachabilityTests {
     @Test("remote destination: exit 10 (repo does not exist) is .error, not .offline")
     func remoteExitTenIsError() async throws {
         let dest = Destination(id: Self.destId, label: "R2", repoURL: "s3:https://x/bucket", isPrimary: false)
-        let fake = FakeProcessRunner(script:
-            Self.keychainScript(for: Self.destId) + [
+        let fake = FakeProcessRunner(script: [
                 .init(argvPrefix: ["/usr/local/bin/restic", "-r", dest.repoURL, "cat", "config"], exitCode: 10),
             ]
         )
@@ -162,8 +155,7 @@ struct ReachabilityTests {
     @Test("remote destination: exit 12 (wrong password) is .error, not .offline")
     func remoteExitTwelveIsError() async throws {
         let dest = Destination(id: Self.destId, label: "R2", repoURL: "s3:https://x/bucket", isPrimary: false)
-        let fake = FakeProcessRunner(script:
-            Self.keychainScript(for: Self.destId) + [
+        let fake = FakeProcessRunner(script: [
                 .init(argvPrefix: ["/usr/local/bin/restic", "-r", dest.repoURL, "cat", "config"], exitCode: 12),
             ]
         )
@@ -173,29 +165,24 @@ struct ReachabilityTests {
         #expect(result == .error(.wrongPassword))
     }
 
-    @Test("remote destination: keychain pre-flight failure is offline('keychain locked'), never .error")
-    func remoteKeychainPreflightFailureIsOffline() async throws {
+    @Test("remote destination: secret pre-flight failure is offline, never .error")
+    func remoteSecretPreflightFailureIsOffline() async throws {
         let dest = Destination(id: Self.destId, label: "R2", repoURL: "s3:https://x/bucket", isPrimary: false)
-        let fake = FakeProcessRunner(script: [
-            .init(
-                argvPrefix: Self.securityRead(Self.passwordAccount(Self.destId)),
-                stderr: "SecKeychainSearchCopyNext: User interaction is not allowed.",
-                exitCode: 1
-            ),
-        ])
-        let reachability = Self.makeReachability(fake)
+        let fake = FakeProcessRunner()
+        let secrets = FakeSecretStore(defaultPassword: Self.password)
+        secrets.failPassword(for: Self.destId)
+        let reachability = Self.makeReachability(fake, secrets: secrets)
 
         let result = await reachability.probe(dest)
-        #expect(result == .offline(reason: "keychain locked"))
+        #expect(result == .offline(reason: Self.secretsUnavailableReason))
         // restic itself was never spawned.
-        #expect(fake.invocations.count == 1)
+        #expect(fake.invocations.isEmpty)
     }
 
     @Test("remote destination: launch failure is offline with the launch failure reason")
     func remoteLaunchFailureIsOffline() async throws {
         let dest = Destination(id: Self.destId, label: "R2", repoURL: "s3:https://x/bucket", isPrimary: false)
-        let fake = FakeProcessRunner(script:
-            Self.keychainScript(for: Self.destId) + [
+        let fake = FakeProcessRunner(script: [
                 .init(
                     argvPrefix: ["/usr/local/bin/restic", "-r", dest.repoURL, "cat", "config"],
                     failure: .launchFailed("No such file or directory")

--- a/Core/Tests/ResticStationCoreTests/Engine/ReachabilityTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Engine/ReachabilityTests.swift
@@ -24,15 +24,12 @@ struct ReachabilityTests {
         return Reachability(restic: runner)
     }
 
-    /// The `offline` reason `ResticRunner`'s secret pre-flight produces.
-    /// Platform-split in `Reachability` so the macOS wording — which the
-    /// app's badge heuristic matches on — is unchanged by T23.
+    /// The `offline` reason `ResticRunner`'s secret pre-flight produces —
+    /// taken from the **store in use**, not from the host OS. The keychain
+    /// wording (which the app's badge heuristic matches on) is unchanged by
+    /// T23.
     static var secretsUnavailableReason: String {
-        #if os(macOS)
-        return "keychain locked"
-        #else
-        return "secret store unavailable"
-        #endif
+        SecretBackend.platformDefault.unavailableProbeReason
     }
 
     // MARK: - Local: present / missing
@@ -177,6 +174,25 @@ struct ReachabilityTests {
         #expect(result == .offline(reason: Self.secretsUnavailableReason))
         // restic itself was never spawned.
         #expect(fake.invocations.isEmpty)
+    }
+
+    /// Regression test for the review finding that this reason branched on
+    /// `#if os(macOS)`. A macOS host running `RESTIC_STATION_SECRET_BACKEND=file`
+    /// must not record "keychain locked" in `repo-status-<destId>.json`, and
+    /// a keychain host must still record exactly that (the app's badge
+    /// heuristic matches on it).
+    @Test("the offline reason names the store in use, on every host")
+    func secretPreflightReasonFollowsTheBackend() async throws {
+        let dest = Destination(id: Self.destId, label: "R2", repoURL: "s3:https://x/bucket", isPrimary: false)
+
+        for backend in SecretBackend.allCases {
+            let secrets = FakeSecretStore(defaultPassword: Self.password, backend: backend)
+            secrets.failPassword(for: Self.destId)
+            let reachability = Self.makeReachability(FakeProcessRunner(), secrets: secrets)
+
+            let result = await reachability.probe(dest)
+            #expect(result == .offline(reason: backend.unavailableProbeReason))
+        }
     }
 
     @Test("remote destination: launch failure is offline with the launch failure reason")

--- a/Core/Tests/ResticStationCoreTests/Restic/ResticErrorTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Restic/ResticErrorTests.swift
@@ -90,7 +90,7 @@ struct ResticErrorTests {
     @Test("ResticRunnerError categories follow architecture.md's taxonomy")
     func runnerErrorCategories() {
         let destinationId = UUID()
-        #expect(ResticRunnerError.keychainUnavailable(destinationId: destinationId).category == .retryable)
+        #expect(ResticRunnerError.secretsUnavailable(destinationId: destinationId).category == .retryable)
         #expect(ResticRunnerError.launchFailed("no such file").category == .terminal)
         #expect(ResticRunnerError.timedOut.category == .terminal)
     }
@@ -98,7 +98,7 @@ struct ResticErrorTests {
     @Test("ResticRunnerError descriptions never carry secret material")
     func runnerErrorDescriptions() {
         let destinationId = UUID()
-        let error = ResticRunnerError.keychainUnavailable(destinationId: destinationId)
+        let error = ResticRunnerError.secretsUnavailable(destinationId: destinationId)
         #expect(error.description.contains(destinationId.uuidString))
         #expect(!error.userFacingMessage.isEmpty)
     }

--- a/Core/Tests/ResticStationCoreTests/Restic/ResticErrorTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Restic/ResticErrorTests.swift
@@ -95,6 +95,23 @@ struct ResticErrorTests {
         #expect(ResticRunnerError.timedOut.category == .terminal)
     }
 
+    /// Regression test for the review finding that this message branched on
+    /// `#if os(macOS)`. It has no store to ask (it is a property on an error
+    /// value), so it follows the *configured* backend — which in production
+    /// is the same environment every store is built from.
+    @Test("secretsUnavailable is worded for the configured backend, not the host OS")
+    func secretsUnavailableWordingFollowsTheBackend() {
+        let message = ResticRunnerError.secretsUnavailable(destinationId: UUID()).userFacingMessage
+        let backend = SecretBackend.configured
+        #expect(message == "\(backend.unavailableSummary) \(backend.unavailableAdvice)")
+
+        // Both backends produce a "what happened" + "one next step" pair, and
+        // neither borrows the other's remediation.
+        #expect(SecretBackend.file.unavailableSummary.contains("secrets file"))
+        #expect(!SecretBackend.file.unavailableAdvice.lowercased().contains("keychain"))
+        #expect(SecretBackend.keychain.unavailableAdvice.contains("Unlock your login keychain"))
+    }
+
     @Test("ResticRunnerError descriptions never carry secret material")
     func runnerErrorDescriptions() {
         let destinationId = UUID()

--- a/Core/Tests/ResticStationCoreTests/Restic/ResticRunnerSmokeTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Restic/ResticRunnerSmokeTests.swift
@@ -1,3 +1,9 @@
+#if os(macOS)
+// Keychain-backed by construction: this is the macOS end-to-end proof that
+// `RESTIC_PASSWORD_COMMAND` works prompt-free from our own process. The
+// equivalent proof for `FileSecretStore` needs the real helper binary (its
+// password command names an executable), so it lives in
+// `scripts/secret-cli-test.sh` rather than here.
 import Foundation
 import Testing
 @testable import ResticStationCore
@@ -31,7 +37,7 @@ struct ResticRunnerSmokeTests {
     @Test("version, init, backup and snapshots against a throwaway local repo")
     func realResticRoundTrip() async throws {
         let processRunner = DefaultProcessRunner()
-        let keychain = KeychainClient(runner: processRunner)
+        let keychain = KeychainSecretStore(runner: processRunner)
 
         let destinationId = UUID()
         let scratch = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
@@ -63,12 +69,12 @@ struct ResticRunnerSmokeTests {
         let runner = ResticRunner(
             resticPath: Self.resticPath,
             paths: AppPaths(root: scratch.appendingPathComponent("data", isDirectory: true)),
-            keychain: keychain,
+            secrets: keychain,
             runner: processRunner
         )
         let invocation = ResticInvocation(destination: destination)
 
-        // 1. version (no repository, no keychain).
+        // 1. version (no repository, no secrets).
         let version = try await runner.runWithoutRepository(.version, timeout: 30)
         #expect(version.status == .success)
         let versionInfo = try makeResticJSONDecoder().decode(
@@ -106,3 +112,4 @@ struct ResticRunnerSmokeTests {
         try await keychain.deletePassword(destId: destinationId)
     }
 }
+#endif

--- a/Core/Tests/ResticStationCoreTests/Restic/ResticRunnerTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Restic/ResticRunnerTests.swift
@@ -2,7 +2,7 @@ import Foundation
 import Testing
 @testable import ResticStationCore
 
-@Suite("ResticRunner: env assembly, keychain pre-flight, streaming, exit mapping")
+@Suite("ResticRunner: env assembly, secret pre-flight, streaming, exit mapping")
 struct ResticRunnerTests {
     // MARK: - Fixtures for these tests
 
@@ -30,59 +30,45 @@ struct ResticRunnerTests {
         AppPaths(root: URL(fileURLWithPath: "/tmp/restic-station-tests", isDirectory: true))
     }
 
-    static func makeRunner(_ fake: FakeProcessRunner) -> ResticRunner {
+    /// The secret store is injected as a `FakeSecretStore`, so the scripted
+    /// process expectations below contain restic spawns and nothing else —
+    /// there is no `/usr/bin/security` argv anywhere in this file any more.
+    /// That is what makes these tests run identically on macOS and Linux.
+    static func makeRunner(
+        _ fake: FakeProcessRunner,
+        secrets: FakeSecretStore = FakeSecretStore(defaultPassword: password)
+    ) -> ResticRunner {
         ResticRunner(
             resticPath: resticPath,
             paths: paths(),
-            keychain: KeychainClient(runner: fake),
+            secrets: secrets,
             runner: fake
         )
     }
 
-    /// argv prefix for a keychain read of `account` — the shape
-    /// `KeychainClient` uses (see `docs/keychain-and-fda.md`).
-    static func securityRead(_ account: String) -> [String] {
-        ["/usr/bin/security", "find-generic-password", "-s", "restic-station", "-a", account]
-    }
-
-    static func passwordAccount(_ id: UUID) -> String { id.uuidString.lowercased() }
-    static func envAccount(_ id: UUID) -> String { "\(id.uuidString.lowercased())-env" }
-
     static func expectedPasswordCommand(_ id: UUID) -> String {
-        "/usr/bin/security find-generic-password -s restic-station -a \(id.uuidString.lowercased()) -w"
+        FakeSecretStore.passwordCommand(destId: id)
     }
 
-    /// Scripted keychain replies for one destination: password, then env blob.
-    static func keychainScript(
-        for id: UUID,
-        secretEnvJSON: String? = nil
-    ) -> [FakeProcessRunner.Expectation] {
-        var script: [FakeProcessRunner.Expectation] = [
-            .init(argvPrefix: securityRead(passwordAccount(id)), stdoutLines: [password]),
-        ]
-        if let secretEnvJSON {
-            script.append(.init(argvPrefix: securityRead(envAccount(id)), stdoutLines: [secretEnvJSON]))
-        } else {
-            // `security` exit 44 = no such item; KeychainClient maps it to "no
-            // secret env configured".
-            script.append(.init(argvPrefix: securityRead(envAccount(id)), exitCode: 44))
-        }
-        return script
+    /// A store where every destination has ``password`` and `id` also has a
+    /// secret-env blob.
+    static func secretStore(for id: UUID, secretEnv: [String: String]) -> FakeSecretStore {
+        let store = FakeSecretStore(defaultPassword: password)
+        store.store(secretEnv: secretEnv, for: id)
+        return store
     }
 
     // MARK: - Environment assembly
 
     @Test("single destination: exact password command, cache dir, secret env injected, nothing inherited")
     func environmentForSingleDestination() async throws {
-        let fake = FakeProcessRunner(script:
-            Self.keychainScript(
-                for: Self.primaryId,
-                secretEnvJSON: #"{"AWS_ACCESS_KEY_ID":"AKIAPRIMARY","AWS_SECRET_ACCESS_KEY":"primary-secret"}"#
-            ) + [
-                .init(argvPrefix: [Self.resticPath, "-r", Self.primary.repoURL, "backup", "--json"]),
-            ]
-        )
-        let runner = Self.makeRunner(fake)
+        let fake = FakeProcessRunner(script: [
+            .init(argvPrefix: [Self.resticPath, "-r", Self.primary.repoURL, "backup", "--json"]),
+        ])
+        let runner = Self.makeRunner(fake, secrets: Self.secretStore(
+            for: Self.primaryId,
+            secretEnv: ["AWS_ACCESS_KEY_ID": "AKIAPRIMARY", "AWS_SECRET_ACCESS_KEY": "primary-secret"]
+        ))
 
         let outcome = try await runner.run(
             .backup(repo: Self.primary.repoURL, sources: ["/Users/user/Documents"]),
@@ -91,9 +77,10 @@ struct ResticRunnerTests {
         #expect(outcome.exitCode == 0)
         #expect(outcome.status == .success)
 
-        // Keychain pre-flight, then the env blob, then restic itself.
-        #expect(fake.invocations.count == 3)
-        let resticCall = fake.invocations[2]
+        // Reading secrets is not a subprocess any more: restic is the only
+        // thing this runner spawns.
+        #expect(fake.invocations.count == 1)
+        let resticCall = fake.invocations[0]
         #expect(resticCall.argv == [
             Self.resticPath, "-r", Self.primary.repoURL, "backup", "--json", "/Users/user/Documents",
         ])
@@ -120,17 +107,19 @@ struct ResticRunnerTests {
 
     @Test("argv never contains a secret, by construction")
     func argvContainsNoSecrets() async throws {
-        let fake = FakeProcessRunner(script:
-            Self.keychainScript(for: Self.primaryId, secretEnvJSON: #"{"AWS_SECRET_ACCESS_KEY":"primary-secret"}"#)
-                + [.init(argvPrefix: [Self.resticPath, "-r", Self.primary.repoURL, "backup", "--json"])]
-        )
-        let runner = Self.makeRunner(fake)
+        let fake = FakeProcessRunner(script: [
+            .init(argvPrefix: [Self.resticPath, "-r", Self.primary.repoURL, "backup", "--json"]),
+        ])
+        let runner = Self.makeRunner(fake, secrets: Self.secretStore(
+            for: Self.primaryId,
+            secretEnv: ["AWS_SECRET_ACCESS_KEY": "primary-secret"]
+        ))
         _ = try await runner.run(
             .backup(repo: Self.primary.repoURL, sources: ["/Users/user/Documents"]),
             for: ResticInvocation(destination: Self.primary)
         )
 
-        let resticArgv = fake.invocations[2].argv
+        let resticArgv = fake.invocations[0].argv
         for element in resticArgv {
             #expect(element != Self.password)
             #expect(!element.contains(Self.password))
@@ -142,30 +131,21 @@ struct ResticRunnerTests {
     func environmentWithFromDestination() async throws {
         // Both destinations define AWS_ACCESS_KEY_ID (secret) and
         // AWS_DEFAULT_REGION (non-secret); the `-r` destination must win.
-        let fake = FakeProcessRunner(script:
-            [
-                // Pre-flight reads both passwords before anything is spawned.
-                .init(argvPrefix: Self.securityRead(Self.passwordAccount(Self.secondaryId)),
-                      stdoutLines: [Self.password]),
-                .init(argvPrefix: Self.securityRead(Self.passwordAccount(Self.primaryId)),
-                      stdoutLines: [Self.password]),
-                // Then the env blobs: from-destination first, destination second.
-                .init(argvPrefix: Self.securityRead(Self.envAccount(Self.primaryId)),
-                      stdoutLines: [#"{"AWS_ACCESS_KEY_ID":"AKIAPRIMARY","PRIMARY_ONLY":"yes"}"#]),
-                .init(argvPrefix: Self.securityRead(Self.envAccount(Self.secondaryId)),
-                      stdoutLines: [#"{"AWS_ACCESS_KEY_ID":"AKIASECONDARY"}"#]),
-                .init(argvPrefix: [Self.resticPath, "-r", Self.secondary.repoURL, "copy"]),
-            ]
-        )
-        let runner = Self.makeRunner(fake)
+        let fake = FakeProcessRunner(script: [
+            .init(argvPrefix: [Self.resticPath, "-r", Self.secondary.repoURL, "copy"]),
+        ])
+        let secrets = FakeSecretStore(defaultPassword: Self.password)
+        secrets.store(secretEnv: ["AWS_ACCESS_KEY_ID": "AKIAPRIMARY", "PRIMARY_ONLY": "yes"], for: Self.primaryId)
+        secrets.store(secretEnv: ["AWS_ACCESS_KEY_ID": "AKIASECONDARY"], for: Self.secondaryId)
+        let runner = Self.makeRunner(fake, secrets: secrets)
 
         _ = try await runner.run(
             .copy(toRepo: Self.secondary.repoURL, fromRepo: Self.primary.repoURL),
             for: ResticInvocation(destination: Self.secondary, fromDestination: Self.primary)
         )
 
-        #expect(fake.invocations.count == 5)
-        let resticCall = fake.invocations[4]
+        #expect(fake.invocations.count == 1)
+        let resticCall = fake.invocations[0]
         #expect(resticCall.argv == [
             Self.resticPath, "-r", Self.secondary.repoURL, "copy", "--from-repo", Self.primary.repoURL,
         ])
@@ -194,14 +174,13 @@ struct ResticRunnerTests {
                 "RESTIC_PASSWORD": "pwned",
             ]
         )
-        let fake = FakeProcessRunner(script:
-            Self.keychainScript(for: Self.primaryId)
-                + [.init(argvPrefix: [Self.resticPath, "-r", "/repo", "snapshots", "--json"])]
-        )
+        let fake = FakeProcessRunner(script: [
+            .init(argvPrefix: [Self.resticPath, "-r", "/repo", "snapshots", "--json"]),
+        ])
         let runner = Self.makeRunner(fake)
         _ = try await runner.run(.snapshots(repo: "/repo"), for: ResticInvocation(destination: hostile))
 
-        let env = try #require(fake.invocations[2].env)
+        let env = try #require(fake.invocations[0].env)
         #expect(env["RESTIC_PASSWORD_COMMAND"] == Self.expectedPasswordCommand(Self.primaryId))
         #expect(env["RESTIC_CACHE_DIR"] == Self.paths().resticCacheDir.path)
         // RESTIC_PASSWORD is not one of ours, so it passes through as
@@ -219,18 +198,17 @@ struct ResticRunnerTests {
             isPrimary: true,
             nonSecretEnv: ["PATH": "/opt/homebrew/bin:/usr/bin:/bin"]
         )
-        let fake = FakeProcessRunner(script:
-            Self.keychainScript(for: Self.primaryId)
-                + [.init(argvPrefix: [Self.resticPath, "-r", "rclone:remote:bucket", "snapshots", "--json"])]
-        )
+        let fake = FakeProcessRunner(script: [
+            .init(argvPrefix: [Self.resticPath, "-r", "rclone:remote:bucket", "snapshots", "--json"]),
+        ])
         let runner = Self.makeRunner(fake)
         _ = try await runner.run(.snapshots(repo: "rclone:remote:bucket"), for: ResticInvocation(destination: destination))
 
-        let env = try #require(fake.invocations[2].env)
+        let env = try #require(fake.invocations[0].env)
         #expect(env["PATH"] == "/opt/homebrew/bin:/usr/bin:/bin")
     }
 
-    @Test("keychain secret env wins over nonSecretEnv for the same destination")
+    @Test("stored secret env wins over nonSecretEnv for the same destination")
     func secretEnvBeatsNonSecretEnv() async throws {
         let destination = Destination(
             id: Self.primaryId,
@@ -239,18 +217,65 @@ struct ResticRunnerTests {
             isPrimary: true,
             nonSecretEnv: ["AWS_SECRET_ACCESS_KEY": "stale-plaintext"]
         )
-        let fake = FakeProcessRunner(script:
-            Self.keychainScript(for: Self.primaryId, secretEnvJSON: #"{"AWS_SECRET_ACCESS_KEY":"from-keychain"}"#)
-                + [.init(argvPrefix: [Self.resticPath, "-r", "/repo", "snapshots", "--json"])]
-        )
-        let runner = Self.makeRunner(fake)
+        let fake = FakeProcessRunner(script: [
+            .init(argvPrefix: [Self.resticPath, "-r", "/repo", "snapshots", "--json"]),
+        ])
+        let runner = Self.makeRunner(fake, secrets: Self.secretStore(
+            for: Self.primaryId,
+            secretEnv: ["AWS_SECRET_ACCESS_KEY": "from-the-store"]
+        ))
         _ = try await runner.run(.snapshots(repo: "/repo"), for: ResticInvocation(destination: destination))
 
-        let env = try #require(fake.invocations[2].env)
-        #expect(env["AWS_SECRET_ACCESS_KEY"] == "from-keychain")
+        let env = try #require(fake.invocations[0].env)
+        #expect(env["AWS_SECRET_ACCESS_KEY"] == "from-the-store")
     }
 
-    @Test("runWithoutRepository (version probe): no keychain calls, no password env")
+    /// End-to-end env assembly with the *real* file backend, on every
+    /// platform: the assembled environment must carry both the password
+    /// command and the two variables its child needs to find the same
+    /// `secrets.json`. This is the unit-level half of what
+    /// `scripts/secret-cli-test.sh` proves against real restic.
+    @Test("FileSecretStore: password command plus the env its child needs, and no secret anywhere")
+    func fileBackendEnvironmentAssembly() async throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("restic-station-runner-file-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let store = FileSecretStore(
+            paths: AppPaths(root: root),
+            helperPath: "/opt/restic-station/restic-station-helper"
+        )
+        try await store.setPassword(Self.password, destId: Self.primaryId)
+        try await store.setSecretEnv(["AWS_SECRET_ACCESS_KEY": "file-backed-secret"], destId: Self.primaryId)
+
+        let fake = FakeProcessRunner(script: [
+            .init(argvPrefix: [Self.resticPath, "-r", Self.primary.repoURL, "snapshots", "--json"]),
+        ])
+        let runner = ResticRunner(resticPath: Self.resticPath, paths: Self.paths(), secrets: store, runner: fake)
+        _ = try await runner.run(
+            .snapshots(repo: Self.primary.repoURL),
+            for: ResticInvocation(destination: Self.primary)
+        )
+
+        let env = try #require(fake.invocations[0].env)
+        #expect(
+            env["RESTIC_PASSWORD_COMMAND"]
+                == "/opt/restic-station/restic-station-helper print-password "
+                + "--dest \(Self.primaryId.uuidString.lowercased())"
+        )
+        #expect(env["RESTIC_STATION_DATA_DIR"] == root.path)
+        #expect(env[SecretBackend.environmentKey] == "file")
+        // The secret env blob is still injected as real variables…
+        #expect(env["AWS_SECRET_ACCESS_KEY"] == "file-backed-secret")
+        // …but the repository password reaches restic only through the
+        // command, never through the environment or the argv.
+        #expect(!env.values.contains(Self.password))
+        for element in fake.invocations[0].argv {
+            #expect(!element.contains(Self.password))
+        }
+    }
+
+    @Test("runWithoutRepository (version probe): no secret reads, no password env")
     func versionProbeNeedsNoDestination() async throws {
         let fake = FakeProcessRunner(script: [
             .init(
@@ -271,61 +296,52 @@ struct ResticRunnerTests {
         #expect(env["PATH"] == "/usr/bin:/bin:/usr/sbin:/sbin")
     }
 
-    // MARK: - Keychain pre-flight
+    // MARK: - Secret-store pre-flight
 
-    @Test("pre-flight failure throws keychainUnavailable and never spawns restic")
-    func keychainPreflightFailure() async throws {
-        let fake = FakeProcessRunner(script: [
-            .init(
-                argvPrefix: Self.securityRead(Self.passwordAccount(Self.primaryId)),
-                stderr: "SecKeychainSearchCopyNext: User interaction is not allowed.",
-                exitCode: 1
-            ),
-        ])
-        let runner = Self.makeRunner(fake)
+    @Test("pre-flight failure throws secretsUnavailable and never spawns restic")
+    func secretPreflightFailure() async throws {
+        let fake = FakeProcessRunner()
+        let secrets = FakeSecretStore(defaultPassword: Self.password)
+        secrets.failPassword(for: Self.primaryId)
+        let runner = Self.makeRunner(fake, secrets: secrets)
 
-        await #expect(throws: ResticRunnerError.keychainUnavailable(destinationId: Self.primaryId)) {
+        await #expect(throws: ResticRunnerError.secretsUnavailable(destinationId: Self.primaryId)) {
             _ = try await runner.run(
                 .backup(repo: Self.primary.repoURL, sources: ["/Users/user/Documents"]),
                 for: ResticInvocation(destination: Self.primary)
             )
         }
-        // Only the failed keychain read happened — restic was never spawned.
-        #expect(fake.invocations.count == 1)
+        // Nothing was spawned at all: restic never ran.
+        #expect(fake.invocations.isEmpty)
     }
 
     @Test("pre-flight covers the from-destination too")
-    func keychainPreflightFailureOnFromDestination() async throws {
-        let fake = FakeProcessRunner(script: [
-            .init(argvPrefix: Self.securityRead(Self.passwordAccount(Self.secondaryId)),
-                  stdoutLines: [Self.password]),
-            .init(argvPrefix: Self.securityRead(Self.passwordAccount(Self.primaryId)), exitCode: 44),
-        ])
-        let runner = Self.makeRunner(fake)
+    func secretPreflightFailureOnFromDestination() async throws {
+        let fake = FakeProcessRunner()
+        let secrets = FakeSecretStore(defaultPassword: Self.password)
+        secrets.failPassword(for: Self.primaryId)
+        let runner = Self.makeRunner(fake, secrets: secrets)
 
-        await #expect(throws: ResticRunnerError.keychainUnavailable(destinationId: Self.primaryId)) {
+        await #expect(throws: ResticRunnerError.secretsUnavailable(destinationId: Self.primaryId)) {
             _ = try await runner.run(
                 .copy(toRepo: Self.secondary.repoURL, fromRepo: Self.primary.repoURL),
                 for: ResticInvocation(destination: Self.secondary, fromDestination: Self.primary)
             )
         }
-        #expect(fake.invocations.count == 2)
+        #expect(fake.invocations.isEmpty)
     }
 
     @Test("an unreadable secret-env blob is also retryable, not a crash")
-    func secretEnvFailureIsKeychainUnavailable() async throws {
-        let fake = FakeProcessRunner(script: [
-            .init(argvPrefix: Self.securityRead(Self.passwordAccount(Self.primaryId)),
-                  stdoutLines: [Self.password]),
-            .init(argvPrefix: Self.securityRead(Self.envAccount(Self.primaryId)),
-                  stderr: "User interaction is not allowed.", exitCode: 1),
-        ])
-        let runner = Self.makeRunner(fake)
+    func secretEnvFailureIsSecretsUnavailable() async throws {
+        let fake = FakeProcessRunner()
+        let secrets = FakeSecretStore(defaultPassword: Self.password)
+        secrets.failSecretEnv(for: Self.primaryId)
+        let runner = Self.makeRunner(fake, secrets: secrets)
 
-        await #expect(throws: ResticRunnerError.keychainUnavailable(destinationId: Self.primaryId)) {
+        await #expect(throws: ResticRunnerError.secretsUnavailable(destinationId: Self.primaryId)) {
             _ = try await runner.run(.snapshots(repo: "/repo"), for: ResticInvocation(destination: Self.primary))
         }
-        #expect(fake.invocations.count == 2)
+        #expect(fake.invocations.isEmpty)
     }
 
     // MARK: - NDJSON streaming
@@ -333,13 +349,12 @@ struct ResticRunnerTests {
     @Test("streams decoded NDJSON messages and captures raw output")
     func streamsNdjson() async throws {
         let lines = try FixtureLoader.lines("backup.ndjson")
-        let fake = FakeProcessRunner(script:
-            Self.keychainScript(for: Self.primaryId)
-                + [.init(
+        let fake = FakeProcessRunner(script: [
+            .init(
                     argvPrefix: [Self.resticPath, "-r", Self.primary.repoURL, "backup", "--json"],
                     stdoutLines: lines
-                )]
-        )
+            ),
+        ])
         let runner = Self.makeRunner(fake)
 
         let streamed = MessageBox()
@@ -367,15 +382,14 @@ struct ResticRunnerTests {
 
     @Test("stderr lines reach onRawLine (the run log) but never onLine")
     func stderrGoesToRawLog() async throws {
-        let fake = FakeProcessRunner(script:
-            Self.keychainScript(for: Self.primaryId)
-                + [.init(
+        let fake = FakeProcessRunner(script: [
+            .init(
                     argvPrefix: [Self.resticPath, "-r", Self.primary.repoURL, "snapshots", "--json"],
                     stdoutLines: ["[]"],
                     stderr: "Fatal: unable to open config file",
                     exitCode: 1
-                )]
-        )
+            ),
+        ])
         let runner = Self.makeRunner(fake)
 
         let streamed = MessageBox()
@@ -397,14 +411,13 @@ struct ResticRunnerTests {
 
     @Test("exit 3 is the incomplete-read warning, not a failure")
     func exitThreeIsWarning() async throws {
-        let fake = FakeProcessRunner(script:
-            Self.keychainScript(for: Self.primaryId)
-                + [.init(
+        let fake = FakeProcessRunner(script: [
+            .init(
                     argvPrefix: [Self.resticPath, "-r", Self.primary.repoURL, "backup", "--json"],
                     stdoutLines: try FixtureLoader.lines("backup.ndjson"),
                     exitCode: 3
-                )]
-        )
+            ),
+        ])
         let runner = Self.makeRunner(fake)
         let outcome = try await runner.run(
             .backup(repo: Self.primary.repoURL, sources: ["/src"]),
@@ -418,14 +431,13 @@ struct ResticRunnerTests {
     @Test("exit_error line (locked-error.json) surfaces .repoLocked on exit 11")
     func exitErrorOnElevenSurfacesRepoLocked() async throws {
         let line = try FixtureLoader.string("locked-error.json").trimmingCharacters(in: .whitespacesAndNewlines)
-        let fake = FakeProcessRunner(script:
-            Self.keychainScript(for: Self.primaryId)
-                + [.init(
+        let fake = FakeProcessRunner(script: [
+            .init(
                     argvPrefix: [Self.resticPath, "-r", Self.primary.repoURL, "backup", "--json"],
                     stdoutLines: [line],
                     exitCode: 11
-                )]
-        )
+            ),
+        ])
         let runner = Self.makeRunner(fake)
         let outcome = try await runner.run(
             .backup(repo: Self.primary.repoURL, sources: ["/src"]),
@@ -445,14 +457,13 @@ struct ResticRunnerTests {
     @Test("a streamed exit_error code beats a generic exit status")
     func exitErrorCodeBeatsGenericExitStatus() async throws {
         let line = try FixtureLoader.string("locked-error.json").trimmingCharacters(in: .whitespacesAndNewlines)
-        let fake = FakeProcessRunner(script:
-            Self.keychainScript(for: Self.primaryId)
-                + [.init(
+        let fake = FakeProcessRunner(script: [
+            .init(
                     argvPrefix: [Self.resticPath, "-r", Self.primary.repoURL, "backup", "--json"],
                     stdoutLines: [line],
                     exitCode: 1
-                )]
-        )
+            ),
+        ])
         let runner = Self.makeRunner(fake)
         let outcome = try await runner.run(
             .backup(repo: Self.primary.repoURL, sources: ["/src"]),
@@ -465,14 +476,13 @@ struct ResticRunnerTests {
     @Test("an exit_error on a successful run does not manufacture a failure")
     func exitZeroStaysSuccess() async throws {
         let line = try FixtureLoader.string("locked-error.json").trimmingCharacters(in: .whitespacesAndNewlines)
-        let fake = FakeProcessRunner(script:
-            Self.keychainScript(for: Self.primaryId)
-                + [.init(
+        let fake = FakeProcessRunner(script: [
+            .init(
                     argvPrefix: [Self.resticPath, "-r", Self.primary.repoURL, "backup", "--json"],
                     stdoutLines: [line],
                     exitCode: 0
-                )]
-        )
+            ),
+        ])
         let runner = Self.makeRunner(fake)
         let outcome = try await runner.run(
             .backup(repo: Self.primary.repoURL, sources: ["/src"]),
@@ -483,14 +493,13 @@ struct ResticRunnerTests {
 
     @Test("exit 12 maps to wrongPassword using the captured stderr fixture")
     func exitTwelveWrongPassword() async throws {
-        let fake = FakeProcessRunner(script:
-            Self.keychainScript(for: Self.primaryId)
-                + [.init(
+        let fake = FakeProcessRunner(script: [
+            .init(
                     argvPrefix: [Self.resticPath, "-r", Self.primary.repoURL, "snapshots", "--json"],
                     stderr: try FixtureLoader.string("err-wrongpw.txt"),
                     exitCode: 12
-                )]
-        )
+            ),
+        ])
         let runner = Self.makeRunner(fake)
         let outcome = try await runner.run(
             .snapshots(repo: Self.primary.repoURL),
@@ -504,13 +513,12 @@ struct ResticRunnerTests {
 
     @Test("a ProcessRunning timeout becomes ResticRunnerError.timedOut")
     func timeoutIsMapped() async throws {
-        let fake = FakeProcessRunner(script:
-            Self.keychainScript(for: Self.primaryId)
-                + [.init(
+        let fake = FakeProcessRunner(script: [
+            .init(
                     argvPrefix: [Self.resticPath, "-r", Self.primary.repoURL, "cat", "config"],
                     failure: .timeout
-                )]
-        )
+            ),
+        ])
         let runner = Self.makeRunner(fake)
 
         await #expect(throws: ResticRunnerError.timedOut) {
@@ -524,13 +532,12 @@ struct ResticRunnerTests {
 
     @Test("a launch failure becomes ResticRunnerError.launchFailed")
     func launchFailureIsMapped() async throws {
-        let fake = FakeProcessRunner(script:
-            Self.keychainScript(for: Self.primaryId)
-                + [.init(
+        let fake = FakeProcessRunner(script: [
+            .init(
                     argvPrefix: [Self.resticPath, "-r", Self.primary.repoURL, "cat", "config"],
                     failure: .launchFailed("No such file or directory")
-                )]
-        )
+            ),
+        ])
         let runner = Self.makeRunner(fake)
 
         await #expect(throws: ResticRunnerError.launchFailed("No such file or directory")) {
@@ -543,13 +550,12 @@ struct ResticRunnerTests {
 
     @Test("cancelling the calling task surfaces CancellationError")
     func cancellationPropagates() async throws {
-        let fake = FakeProcessRunner(script:
-            Self.keychainScript(for: Self.primaryId)
-                + [.init(
+        let fake = FakeProcessRunner(script: [
+            .init(
                     argvPrefix: [Self.resticPath, "-r", Self.primary.repoURL, "backup", "--json"],
                     delay: 30
-                )]
-        )
+            ),
+        ])
         let runner = Self.makeRunner(fake)
 
         let task = Task {
@@ -612,7 +618,7 @@ struct ResticRunnerTests {
         let runner = ResticRunner(
             resticPath: "/bin/sh",
             paths: Self.paths(),
-            keychain: KeychainClient(runner: FakeProcessRunner()),
+            secrets: FakeSecretStore(),
             runner: DefaultProcessRunner()
         )
         let streamed = MessageBox()

--- a/Core/Tests/ResticStationCoreTests/Secrets/FileSecretStoreTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Secrets/FileSecretStoreTests.swift
@@ -1,0 +1,307 @@
+import Foundation
+import Testing
+@testable import ResticStationCore
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+/// `FileSecretStore` specifics: permissions, atomicity, locking, and the
+/// `RESTIC_PASSWORD_COMMAND` string.
+///
+/// Deliberately **not** gated to Linux. The file backend is Linux's default
+/// but works everywhere, and running this suite on macOS (locally and in the
+/// macOS CI job) is the only way this repository gets real coverage of the
+/// Linux secrets path before T29 adds a Linux integration matrix.
+@Suite("FileSecretStore")
+struct FileSecretStoreTests {
+    static let destId = UUID(uuidString: "A1B2C3D4-E5F6-4789-A012-3456789ABCDE")!
+    static let otherId = UUID(uuidString: "B1B2C3D4-E5F6-4789-A012-3456789ABCDE")!
+
+    /// A store over a fresh temp root, and the root so the caller can clean up.
+    static func makeStore(helperPath: String = "/opt/restic-station/restic-station-helper")
+        -> (store: FileSecretStore, root: URL) {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("restic-station-file-secrets-\(UUID().uuidString)", isDirectory: true)
+        return (FileSecretStore(paths: AppPaths(root: root), helperPath: helperPath), root)
+    }
+
+    static func permissions(of url: URL) throws -> UInt32 {
+        var info = stat()
+        let ok = url.path.withCString { stat($0, &info) }
+        try #require(ok == 0, "stat failed for \(url.path)")
+        return UInt32(info.st_mode) & 0o777
+    }
+
+    // MARK: - Permissions at creation
+
+    @Test("the secrets file is created 0600 and its directory 0700, at creation time")
+    func createsWithTightModes() async throws {
+        let (store, root) = Self.makeStore()
+        defer { try? FileManager.default.removeItem(at: root) }
+        #expect(!FileManager.default.fileExists(atPath: root.path))
+
+        try await store.setPassword("hunter2", destId: Self.destId)
+
+        #expect(try Self.permissions(of: store.fileURL) == 0o600)
+        #expect(try Self.permissions(of: root) == 0o700)
+    }
+
+    @Test("the temp file a write goes through is itself created 0600")
+    func tempFileIsAlsoTight() async throws {
+        let (store, root) = Self.makeStore()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        // Pre-create the temp path world-readable, exactly as a crashed write
+        // under a permissive umask might have left it. The next write must
+        // unlink it and create a fresh 0600 one rather than reuse it (open(2)
+        // ignores `mode` for an existing file).
+        try store.prepareDirectories()
+        FileManager.default.createFile(
+            atPath: store.tempFileURL.path,
+            contents: Data("stale".utf8),
+            attributes: [.posixPermissions: 0o644]
+        )
+        #expect(try Self.permissions(of: store.tempFileURL) == 0o644)
+
+        try await store.setPassword("hunter2", destId: Self.destId)
+
+        #expect(try Self.permissions(of: store.fileURL) == 0o600)
+        #expect(try await store.password(destId: Self.destId) == "hunter2")
+    }
+
+    // MARK: - Permissions on read
+
+    @Test("a 0644 secrets file is refused on read, with the file name and the chmod to run")
+    func refusesWorldReadableFile() async throws {
+        let (store, root) = Self.makeStore()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try await store.setPassword("hunter2", destId: Self.destId)
+        _ = store.fileURL.path.withCString { chmod($0, 0o644) }
+
+        do {
+            _ = try await store.password(destId: Self.destId)
+            Issue.record("expected a group/world-readable secrets file to be refused")
+        } catch let error as SecretStoreError {
+            guard case .backendFailed(let message) = error else {
+                Issue.record("expected .backendFailed, got \(error)")
+                return
+            }
+            #expect(message.contains(store.fileURL.path))
+            #expect(message.contains("chmod 600"))
+            #expect(message.contains("0644"))
+            // Never the secret itself.
+            #expect(!message.contains("hunter2"))
+        }
+    }
+
+    @Test("a group-readable (0640) secrets file is refused too")
+    func refusesGroupReadableFile() async throws {
+        let (store, root) = Self.makeStore()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try await store.setPassword("hunter2", destId: Self.destId)
+        _ = store.fileURL.path.withCString { chmod($0, 0o640) }
+
+        await #expect(throws: SecretStoreError.self) {
+            _ = try await store.password(destId: Self.destId)
+        }
+    }
+
+    @Test("0400 is accepted — the rule is 'no group/other bits', not 'exactly 0600'")
+    func acceptsOwnerOnlyReadOnly() async throws {
+        let (store, root) = Self.makeStore()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try await store.setPassword("hunter2", destId: Self.destId)
+        _ = store.fileURL.path.withCString { chmod($0, 0o400) }
+
+        #expect(try await store.password(destId: Self.destId) == "hunter2")
+    }
+
+    @Test("a symlink in place of the secrets file is refused, never followed")
+    func refusesSymlink() async throws {
+        let (store, root) = Self.makeStore()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try store.prepareDirectories()
+        let decoy = root.appendingPathComponent("decoy.json", isDirectory: false)
+        try Data(#"{"version":1,"secrets":{}}"#.utf8).write(to: decoy)
+        try FileManager.default.createSymbolicLink(at: store.fileURL, withDestinationURL: decoy)
+
+        do {
+            _ = try await store.password(destId: Self.destId)
+            Issue.record("expected a symlinked secrets file to be refused")
+        } catch let error as SecretStoreError {
+            guard case .backendFailed(let message) = error else {
+                Issue.record("expected .backendFailed, got \(error)")
+                return
+            }
+            #expect(message.contains("symbolic link"))
+        }
+    }
+
+    // MARK: - Atomicity
+
+    @Test("a stale temp file left by a crashed write does not corrupt the real file")
+    func staleTempFileIsHarmless() async throws {
+        let (store, root) = Self.makeStore()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try await store.setPassword("original", destId: Self.destId)
+
+        // Simulate a crash between the temp write and the rename: half a JSON
+        // document sitting at the temp path.
+        try Data(#"{"version":1,"secrets":{"broken"#.utf8).write(to: store.tempFileURL)
+
+        // The previous generation is still intact and readable…
+        #expect(try await store.password(destId: Self.destId) == "original")
+
+        // …and the next write overwrites the leftover rather than tripping on it.
+        try await store.setPassword("replacement", destId: Self.destId)
+        #expect(try await store.password(destId: Self.destId) == "replacement")
+        #expect(!FileManager.default.fileExists(atPath: store.tempFileURL.path))
+    }
+
+    @Test("a file written by a newer format version is refused rather than overwritten")
+    func refusesNewerVersion() async throws {
+        let (store, root) = Self.makeStore()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try store.prepareDirectories()
+        try Data(#"{"version":99,"secrets":{}}"#.utf8).write(to: store.fileURL)
+        _ = store.fileURL.path.withCString { chmod($0, 0o600) }
+
+        await #expect(throws: SecretStoreError.self) {
+            _ = try await store.password(destId: Self.destId)
+        }
+    }
+
+    // MARK: - Concurrency
+
+    @Test("concurrent writers under FileLock do not lose an entry")
+    func concurrentWritesKeepEveryEntry() async throws {
+        let (store, root) = Self.makeStore()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let ids = (0..<12).map { _ in UUID() }
+        await withTaskGroup(of: Void.self) { group in
+            for (index, id) in ids.enumerated() {
+                group.addTask {
+                    // Each writer is its own read-modify-write of the whole
+                    // file; without the lock the last one in would clobber the
+                    // others.
+                    try? await store.setPassword("pw-\(index)", destId: id)
+                }
+            }
+        }
+
+        let document = try store.load()
+        #expect(document.secrets.count == ids.count)
+        for (index, id) in ids.enumerated() {
+            #expect(try await store.password(destId: id) == "pw-\(index)")
+        }
+    }
+
+    @Test("a concurrent delete and set both survive")
+    func concurrentDeleteAndSet() async throws {
+        let (store, root) = Self.makeStore()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try await store.setPassword("doomed", destId: Self.destId)
+        await withTaskGroup(of: Void.self) { group in
+            group.addTask { try? await store.deletePassword(destId: Self.destId) }
+            group.addTask { try? await store.setPassword("kept", destId: Self.otherId) }
+        }
+
+        #expect(try await store.password(destId: Self.otherId) == "kept")
+        await #expect(throws: SecretStoreError.itemNotFound) {
+            _ = try await store.password(destId: Self.destId)
+        }
+    }
+
+    // MARK: - passwordCommand
+
+    @Test("passwordCommand names the helper absolutely and passes the uuid, not the secret")
+    func passwordCommandShape() {
+        let (store, _) = Self.makeStore(helperPath: "/opt/restic-station/restic-station-helper")
+        #expect(
+            store.passwordCommand(destId: Self.destId)
+                == "/opt/restic-station/restic-station-helper print-password "
+                + "--dest a1b2c3d4-e5f6-4789-a012-3456789abcde"
+        )
+    }
+
+    /// restic splits `RESTIC_PASSWORD_COMMAND` itself with a shell-like
+    /// splitter that understands quotes but not backslash escapes (verified
+    /// against restic 0.18.1 — see `docs/restic-cli.md` §General).
+    @Test("passwordCommand double-quotes a helper path that needs it, and leaves plain paths bare")
+    func passwordCommandQuoting() {
+        #expect(FileSecretStore.quoteForRestic("/usr/local/bin/restic-station-helper")
+            == "/usr/local/bin/restic-station-helper")
+        #expect(FileSecretStore.quoteForRestic("/Applications/Restic Station.app/Contents/MacOS/helper")
+            == "\"/Applications/Restic Station.app/Contents/MacOS/helper\"")
+        #expect(FileSecretStore.quoteForRestic("/opt/it's/helper") == "\"/opt/it's/helper\"")
+        #expect(FileSecretStore.quoteForRestic("/opt/$HOME/helper") == "\"/opt/$HOME/helper\"")
+    }
+
+    /// The password command spawns another copy of the helper, which
+    /// re-resolves the store from *its own* environment — and `ResticRunner`
+    /// replaces restic's environment wholesale. Without these two variables
+    /// that child reads the default data directory with the platform-default
+    /// backend, i.e. the wrong store.
+    @Test("passwordCommandEnvironment points the child at this store, and holds no secret")
+    func passwordCommandEnvironmentPointsAtThisStore() async throws {
+        let (store, root) = Self.makeStore()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try await store.setPassword("hunter2", destId: Self.destId)
+        let env = store.passwordCommandEnvironment
+        #expect(env["RESTIC_STATION_DATA_DIR"] == root.path)
+        #expect(env[SecretBackend.environmentKey] == "file")
+        #expect(env.count == 2)
+        #expect(!env.values.contains("hunter2"))
+    }
+
+    @Test("the keychain backend needs no password-command environment")
+    func keychainNeedsNoPasswordCommandEnvironment() {
+        #if os(macOS)
+        #expect(KeychainSecretStore(runner: FakeProcessRunner()).passwordCommandEnvironment.isEmpty)
+        #endif
+    }
+
+    @Test("currentExecutablePath is absolute and is not argv[0]")
+    func currentExecutablePathIsAbsolute() {
+        let path = FileSecretStore.currentExecutablePath()
+        #expect(path.hasPrefix("/"), "expected an absolute path, got \(path)")
+    }
+
+    // MARK: - No secret ever leaves except through a read
+
+    @Test("nothing but the password itself carries the password: file bytes are the only copy")
+    func errorsAndPathsNeverCarrySecrets() async throws {
+        let (store, root) = Self.makeStore()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let secret = "s3cr3t-\(UUID().uuidString)"
+        try await store.setPassword(secret, destId: Self.destId)
+        try await store.setSecretEnv(["AWS_SECRET_ACCESS_KEY": secret], destId: Self.destId)
+
+        #expect(!store.passwordCommand(destId: Self.destId).contains(secret))
+        #expect(!store.fileURL.path.contains(secret))
+        #expect(!store.lockFileURL.path.contains(secret))
+
+        // And the failure path: a widened mode reports the problem without
+        // quoting the contents it refused to read.
+        _ = store.fileURL.path.withCString { chmod($0, 0o644) }
+        do {
+            _ = try await store.password(destId: Self.destId)
+            Issue.record("expected the widened mode to be refused")
+        } catch {
+            #expect(!"\(error)".contains(secret))
+        }
+    }
+}

--- a/Core/Tests/ResticStationCoreTests/Secrets/KeychainSecretStoreTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Secrets/KeychainSecretStoreTests.swift
@@ -1,16 +1,18 @@
+#if os(macOS)
 import Foundation
 import Testing
 @testable import ResticStationCore
 
-@Suite("KeychainClient")
-struct KeychainClientTests {
+@Suite("KeychainSecretStore")
+struct KeychainSecretStoreTests {
     private static let destId = UUID(uuidString: "A1B2C3D4-E5F6-4789-A012-3456789ABCDE")!
     private static let account = "a1b2c3d4-e5f6-4789-a012-3456789abcde"
 
     @Test("passwordCommand matches the documented restic RESTIC_PASSWORD_COMMAND string byte-for-byte")
     func passwordCommandExactString() {
         let expected = "/usr/bin/security find-generic-password -s restic-station -a \(Self.account) -w"
-        #expect(KeychainClient.passwordCommand(destId: Self.destId) == expected)
+        let client = KeychainSecretStore(runner: FakeProcessRunner())
+        #expect(client.passwordCommand(destId: Self.destId) == expected)
     }
 
     @Test("setPassword deletes then adds, with -T on the create path, and ignores a not-found delete")
@@ -19,7 +21,7 @@ struct KeychainClientTests {
             .init(argvPrefix: ["/usr/bin/security", "delete-generic-password"], exitCode: 44),
             .init(argvPrefix: ["/usr/bin/security", "add-generic-password"], exitCode: 0),
         ])
-        let client = KeychainClient(runner: runner)
+        let client = KeychainSecretStore(runner: runner)
 
         try await client.setPassword("hunter2", destId: Self.destId)
 
@@ -50,7 +52,7 @@ struct KeychainClientTests {
             .init(argvPrefix: ["/usr/bin/security", "delete-generic-password"], exitCode: 0),
             .init(argvPrefix: ["/usr/bin/security", "add-generic-password"], exitCode: 0),
         ])
-        let client = KeychainClient(runner: runner)
+        let client = KeychainSecretStore(runner: runner)
 
         try await client.setPassword("newpw", destId: Self.destId)
 
@@ -64,9 +66,9 @@ struct KeychainClientTests {
         let runner = FakeProcessRunner(script: [
             .init(argvPrefix: ["/usr/bin/security", "delete-generic-password"], stderr: "boom", exitCode: 1),
         ])
-        let client = KeychainClient(runner: runner)
+        let client = KeychainSecretStore(runner: runner)
 
-        await #expect(throws: KeychainError.securityCommandFailed("boom")) {
+        await #expect(throws: SecretStoreError.backendFailed("boom")) {
             try await client.setPassword("pw", destId: Self.destId)
         }
         // add must never have been attempted.
@@ -78,7 +80,7 @@ struct KeychainClientTests {
         let runner = FakeProcessRunner(script: [
             .init(argvPrefix: ["/usr/bin/security", "find-generic-password"], stdoutLines: ["hunter2"], exitCode: 0),
         ])
-        let client = KeychainClient(runner: runner)
+        let client = KeychainSecretStore(runner: runner)
 
         let pw = try await client.password(destId: Self.destId)
 
@@ -91,26 +93,26 @@ struct KeychainClientTests {
         ])
     }
 
-    @Test("password() surfaces exit 44 as KeychainError.itemNotFound")
+    @Test("password() surfaces exit 44 as SecretStoreError.itemNotFound")
     func passwordNotFound() async throws {
         let runner = FakeProcessRunner(script: [
             .init(argvPrefix: ["/usr/bin/security", "find-generic-password"], exitCode: 44),
         ])
-        let client = KeychainClient(runner: runner)
+        let client = KeychainSecretStore(runner: runner)
 
-        await #expect(throws: KeychainError.itemNotFound) {
+        await #expect(throws: SecretStoreError.itemNotFound) {
             _ = try await client.password(destId: Self.destId)
         }
     }
 
-    @Test("password() surfaces other nonzero exits as KeychainError.securityCommandFailed with stderr")
+    @Test("password() surfaces other nonzero exits as SecretStoreError.backendFailed with stderr")
     func passwordOtherFailure() async throws {
         let runner = FakeProcessRunner(script: [
             .init(argvPrefix: ["/usr/bin/security", "find-generic-password"], stderr: "keychain locked", exitCode: 1),
         ])
-        let client = KeychainClient(runner: runner)
+        let client = KeychainSecretStore(runner: runner)
 
-        await #expect(throws: KeychainError.securityCommandFailed("keychain locked")) {
+        await #expect(throws: SecretStoreError.backendFailed("keychain locked")) {
             _ = try await client.password(destId: Self.destId)
         }
     }
@@ -120,7 +122,7 @@ struct KeychainClientTests {
         let runner = FakeProcessRunner(script: [
             .init(argvPrefix: ["/usr/bin/security", "delete-generic-password"], exitCode: 44),
         ])
-        let client = KeychainClient(runner: runner)
+        let client = KeychainSecretStore(runner: runner)
 
         // Must not throw.
         try await client.deletePassword(destId: Self.destId)
@@ -132,9 +134,9 @@ struct KeychainClientTests {
         let runner = FakeProcessRunner(script: [
             .init(argvPrefix: ["/usr/bin/security", "delete-generic-password"], stderr: "denied", exitCode: 1),
         ])
-        let client = KeychainClient(runner: runner)
+        let client = KeychainSecretStore(runner: runner)
 
-        await #expect(throws: KeychainError.securityCommandFailed("denied")) {
+        await #expect(throws: SecretStoreError.backendFailed("denied")) {
             try await client.deletePassword(destId: Self.destId)
         }
     }
@@ -147,7 +149,7 @@ struct KeychainClientTests {
             .init(argvPrefix: ["/usr/bin/security", "delete-generic-password"], exitCode: 44),
             .init(argvPrefix: ["/usr/bin/security", "add-generic-password"], exitCode: 0),
         ])
-        let setClient = KeychainClient(runner: setRunner)
+        let setClient = KeychainSecretStore(runner: setRunner)
         try await setClient.setSecretEnv(envVars, destId: Self.destId)
 
         // Account for the env blob is "<uuid>-env".
@@ -169,7 +171,7 @@ struct KeychainClientTests {
         let getRunner = FakeProcessRunner(script: [
             .init(argvPrefix: ["/usr/bin/security", "find-generic-password"], stdoutLines: [writtenJSON], exitCode: 0),
         ])
-        let getClient = KeychainClient(runner: getRunner)
+        let getClient = KeychainSecretStore(runner: getRunner)
         let roundTripped = try await getClient.secretEnv(destId: Self.destId)
 
         #expect(roundTripped == envVars)
@@ -186,7 +188,7 @@ struct KeychainClientTests {
         let runner = FakeProcessRunner(script: [
             .init(argvPrefix: ["/usr/bin/security", "find-generic-password"], exitCode: 44),
         ])
-        let client = KeychainClient(runner: runner)
+        let client = KeychainSecretStore(runner: runner)
 
         let result = try await client.secretEnv(destId: Self.destId)
         #expect(result.isEmpty)
@@ -197,7 +199,7 @@ struct KeychainClientTests {
         let runner = FakeProcessRunner(script: [
             .init(argvPrefix: ["/usr/bin/security", "delete-generic-password"], exitCode: 44),
         ])
-        let client = KeychainClient(runner: runner)
+        let client = KeychainSecretStore(runner: runner)
 
         try await client.deleteSecretEnv(destId: Self.destId)
         #expect(runner.invocations[0].argv == [
@@ -215,11 +217,12 @@ struct KeychainClientTests {
         let runner = FakeProcessRunner(script: [
             .init(argvPrefix: ["/usr/bin/security", "find-generic-password"], exitCode: 44),
         ])
-        let client = KeychainClient(runner: runner)
+        let client = KeychainSecretStore(runner: runner)
 
-        await #expect(throws: KeychainError.itemNotFound) {
+        await #expect(throws: SecretStoreError.itemNotFound) {
             _ = try await client.password(destId: mixedCaseId)
         }
         #expect(runner.invocations[0].argv.contains(Self.account))
     }
 }
+#endif

--- a/Core/Tests/ResticStationCoreTests/Secrets/KeychainSmokeTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Secrets/KeychainSmokeTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 import Foundation
 import Testing
 @testable import ResticStationCore
@@ -73,20 +74,20 @@ struct KeychainSmokeTests {
         #expect(readAfterDelete.exitCode == 44)
     }
 
-    /// Also exercises `KeychainClient` itself (via `DefaultProcessRunner`)
+    /// Also exercises `KeychainSecretStore` itself (via `DefaultProcessRunner`)
     /// end to end against the real keychain, using the same test service by
     /// constructing a throwaway client whose account happens to route
     /// through the same `/usr/bin/security` binary — the account/service
     /// strings are what matter here, not which client issued the call, so
-    /// this proves `DefaultProcessRunner` + `KeychainClient`'s exact argv
+    /// this proves `DefaultProcessRunner` + `KeychainSecretStore`'s exact argv
     /// really works against the real tool, prompt-free.
-    @Test("KeychainClient (DefaultProcessRunner) round-trips a real item, prompt-free")
+    @Test("KeychainSecretStore (DefaultProcessRunner) round-trips a real item, prompt-free")
     func keychainClientAgainstRealSecurity() async throws {
-        // KeychainClient hardcodes service "restic-station"; to keep this
+        // KeychainSecretStore hardcodes service "restic-station"; to keep this
         // smoke test isolated from any real app data we don't use
-        // KeychainClient's public API against the real service. Instead we
+        // KeychainSecretStore's public API against the real service. Instead we
         // reuse DefaultProcessRunner directly with the same argv shape
-        // KeychainClient uses, targeted at the test service — this is the
+        // KeychainSecretStore uses, targeted at the test service — this is the
         // most faithful way to smoke-test the production process runner
         // without ever touching service "restic-station".
         let runner = DefaultProcessRunner()
@@ -157,3 +158,4 @@ struct KeychainSmokeTests {
         )
     }
 }
+#endif

--- a/Core/Tests/ResticStationCoreTests/Secrets/SecretBackendTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Secrets/SecretBackendTests.swift
@@ -1,0 +1,87 @@
+import Foundation
+import Testing
+@testable import ResticStationCore
+
+@Suite("SecretBackend selection")
+struct SecretBackendTests {
+    static func paths() -> AppPaths {
+        AppPaths(root: URL(fileURLWithPath: "/tmp/restic-station-secret-backend-tests", isDirectory: true))
+    }
+
+    @Test("no override → the platform default (keychain on macOS, file elsewhere)")
+    func platformDefault() throws {
+        #expect(try SecretBackend.resolve(environment: [:]) == SecretBackend.platformDefault)
+        #if os(macOS)
+        #expect(SecretBackend.platformDefault == .keychain)
+        #else
+        #expect(SecretBackend.platformDefault == .file)
+        #endif
+    }
+
+    @Test("an empty override is treated as unset, like every other env override here")
+    func emptyOverrideIsUnset() throws {
+        let resolved = try SecretBackend.resolve(environment: [SecretBackend.environmentKey: "  "])
+        #expect(resolved == SecretBackend.platformDefault)
+    }
+
+    @Test("an explicit override wins, case-insensitively")
+    func explicitOverride() throws {
+        #expect(try SecretBackend.resolve(environment: [SecretBackend.environmentKey: "file"]) == .file)
+        #expect(try SecretBackend.resolve(environment: [SecretBackend.environmentKey: "FILE"]) == .file)
+        #expect(try SecretBackend.resolve(environment: [SecretBackend.environmentKey: "keychain"]) == .keychain)
+    }
+
+    @Test("an unrecognised value is a hard error, never a silent fallback")
+    func unrecognisedValueThrows() throws {
+        do {
+            _ = try SecretBackend.resolve(environment: [SecretBackend.environmentKey: "gnome-keyring"])
+            Issue.record("expected an unrecognised backend to throw")
+        } catch let error as SecretStoreError {
+            guard case .backendFailed(let message) = error else {
+                Issue.record("expected .backendFailed, got \(error)")
+                return
+            }
+            #expect(message.contains(SecretBackend.environmentKey))
+            #expect(message.contains("gnome-keyring"))
+            #expect(message.contains("keychain"))
+            #expect(message.contains("file"))
+        }
+    }
+
+    @Test("the factory builds a FileSecretStore when asked for file, on every platform")
+    func factoryBuildsFileBackend() throws {
+        let store = try SecretStoreFactory.make(
+            paths: Self.paths(),
+            runner: FakeProcessRunner(),
+            environment: [SecretBackend.environmentKey: "file"]
+        )
+        #expect(store is FileSecretStore)
+    }
+
+    @Test("the factory's default matches the platform default")
+    func factoryDefault() throws {
+        let store = try SecretStoreFactory.make(
+            paths: Self.paths(),
+            runner: FakeProcessRunner(),
+            environment: [:]
+        )
+        #if os(macOS)
+        #expect(store is KeychainSecretStore)
+        #else
+        #expect(store is FileSecretStore)
+        #endif
+    }
+
+    #if !os(macOS)
+    @Test("asking for the keychain off macOS fails loudly")
+    func keychainOffMacOSThrows() throws {
+        #expect(throws: SecretStoreError.self) {
+            _ = try SecretStoreFactory.make(
+                paths: Self.paths(),
+                runner: FakeProcessRunner(),
+                environment: [SecretBackend.environmentKey: "keychain"]
+            )
+        }
+    }
+    #endif
+}

--- a/Core/Tests/ResticStationCoreTests/Secrets/SecretBackendTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Secrets/SecretBackendTests.swift
@@ -4,6 +4,9 @@ import Testing
 
 @Suite("SecretBackend selection")
 struct SecretBackendTests {
+    static let helperPath = "/opt/restic-station/restic-station-helper"
+    static let destId = UUID(uuidString: "A1B2C3D4-E5F6-4789-A012-3456789ABCDE")!
+
     static func paths() -> AppPaths {
         AppPaths(root: URL(fileURLWithPath: "/tmp/restic-station-secret-backend-tests", isDirectory: true))
     }
@@ -53,9 +56,43 @@ struct SecretBackendTests {
         let store = try SecretStoreFactory.make(
             paths: Self.paths(),
             runner: FakeProcessRunner(),
+            helperExecutablePath: Self.helperPath,
             environment: [SecretBackend.environmentKey: "file"]
         )
         #expect(store is FileSecretStore)
+        #expect(store.backend == .file)
+    }
+
+    /// Regression test for the review finding that the file backend captured
+    /// the *current* executable as its password-command target.
+    ///
+    /// That default is correct only inside the helper. The app process builds
+    /// a store too (restore browsing, `mount`, primary `init`), and there it
+    /// would name the SwiftUI app binary — restic would run the app with
+    /// `print-password --dest …`, get no password, and possibly try to start
+    /// a UI from a background child. The factory therefore *requires* the
+    /// path, and this test pins that it is honoured rather than silently
+    /// falling back.
+    ///
+    /// The test process's own executable (the test runner) stands in for
+    /// "any wrong binary": it is emphatically not `restic-station-helper`.
+    @Test("the file backend uses the helper path it was given, never the current executable")
+    func factoryUsesTheGivenHelperPath() throws {
+        let store = try SecretStoreFactory.make(
+            paths: Self.paths(),
+            runner: FakeProcessRunner(),
+            helperExecutablePath: Self.helperPath,
+            environment: [SecretBackend.environmentKey: "file"]
+        )
+
+        let command = store.passwordCommand(destId: Self.destId)
+        #expect(command == "\(Self.helperPath) print-password --dest \(Self.destId.uuidString.lowercased())")
+
+        let currentExecutable = FileSecretStore.currentExecutablePath()
+        #expect(
+            !command.contains(currentExecutable),
+            "the password command named this process (\(currentExecutable)) instead of the helper"
+        )
     }
 
     @Test("the factory's default matches the platform default")
@@ -63,13 +100,68 @@ struct SecretBackendTests {
         let store = try SecretStoreFactory.make(
             paths: Self.paths(),
             runner: FakeProcessRunner(),
+            helperExecutablePath: Self.helperPath,
             environment: [:]
         )
+        #expect(store.backend == SecretBackend.platformDefault)
         #if os(macOS)
         #expect(store is KeychainSecretStore)
         #else
         #expect(store is FileSecretStore)
         #endif
+    }
+
+    // MARK: - User-facing wording follows the backend, not the OS
+
+    /// Regression test for the review finding that secret-store messaging
+    /// branched on `#if os(macOS)`. On a macOS host running the file backend
+    /// — a supported configuration, and the one the CI script exercises — a
+    /// widened `secrets.json` mode used to advise "unlock your login
+    /// keychain", which is the wrong next step during an incident.
+    @Test("each backend describes itself; wording never branches on the host OS")
+    func wordingFollowsTheBackend() {
+        // The keychain wording is byte-for-byte what shipped before the
+        // SecretStore abstraction: macOS users see no change.
+        #expect(SecretBackend.keychain.displayName == "the login keychain")
+        #expect(
+            SecretBackend.keychain.unavailableSummary
+                == "The password for this destination could not be read from the keychain."
+        )
+        #expect(
+            SecretBackend.keychain.unavailableAdvice
+                == "Unlock your login keychain, then run the backup again."
+        )
+        // `SetsBadges.offlineOrError` matches this string to classify the
+        // failure as environmental rather than as a repository error.
+        #expect(SecretBackend.keychain.unavailableProbeReason == "keychain locked")
+
+        // The file backend never mentions the keychain, and points at the
+        // thing a user can actually fix.
+        #expect(SecretBackend.file.displayName == "the secrets file")
+        #expect(SecretBackend.file.unavailableSummary.contains("secrets file"))
+        #expect(!SecretBackend.file.unavailableSummary.lowercased().contains("keychain"))
+        #expect(SecretBackend.file.unavailableAdvice.contains("permissions"))
+        #expect(!SecretBackend.file.unavailableAdvice.lowercased().contains("keychain"))
+        #expect(SecretBackend.file.unavailableProbeReason == "secret store unavailable")
+
+        // Each store reports its own backend, which is what the wording is
+        // taken from.
+        #expect(FileSecretStore(paths: Self.paths(), helperPath: Self.helperPath).backend == .file)
+        #if os(macOS)
+        #expect(KeychainSecretStore(runner: FakeProcessRunner()).backend == .keychain)
+        #endif
+    }
+
+    @Test("SecretBackend.configured follows the override, and never throws")
+    func configuredFollowsTheOverride() {
+        // `configured` reads the process environment, so it is asserted
+        // against `resolve` rather than by mutating the environment.
+        #expect(SecretBackend.configured == ((try? SecretBackend.resolve()) ?? .platformDefault))
+        // A bad value is a hard error when *constructing* a store, but a
+        // message must never throw.
+        #expect(
+            (try? SecretBackend.resolve(environment: [SecretBackend.environmentKey: "nope"])) == nil
+        )
     }
 
     #if !os(macOS)
@@ -79,6 +171,7 @@ struct SecretBackendTests {
             _ = try SecretStoreFactory.make(
                 paths: Self.paths(),
                 runner: FakeProcessRunner(),
+                helperExecutablePath: Self.helperPath,
                 environment: [SecretBackend.environmentKey: "keychain"]
             )
         }

--- a/Core/Tests/ResticStationCoreTests/Secrets/SecretStoreConformanceTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Secrets/SecretStoreConformanceTests.swift
@@ -1,0 +1,194 @@
+import Foundation
+import Testing
+@testable import ResticStationCore
+
+/// The behaviour every ``SecretStore`` backend must share, run against each
+/// backend in turn.
+///
+/// This is the contract `ResticRunner` and `BackupEngine` are written
+/// against: `itemNotFound` for a missing password, `[:]` for a missing
+/// secret env, idempotent deletes, overwrite-not-append. A backend that
+/// diverges here either loses access to a repository or leaks a stale
+/// credential into a run, so each rule is asserted for every backend rather
+/// than for whichever one the host platform happens to default to.
+///
+/// ``FileSecretStore`` is exercised on **both** platforms — that is how the
+/// Linux code path gets real coverage from a macOS run and from the macOS CI
+/// job. ``KeychainSecretStore`` is exercised through `FakeProcessRunner`
+/// (its real-`security` coverage lives in `KeychainSmokeTests`).
+@Suite("SecretStore conformance")
+struct SecretStoreConformanceTests {
+    static let destId = UUID(uuidString: "A1B2C3D4-E5F6-4789-A012-3456789ABCDE")!
+    static let otherId = UUID(uuidString: "B1B2C3D4-E5F6-4789-A012-3456789ABCDE")!
+
+    // MARK: - Scratch file backend
+
+    /// A `FileSecretStore` over a fresh temp directory, plus its cleanup.
+    static func makeFileStore() -> (store: FileSecretStore, root: URL) {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("restic-station-secrets-\(UUID().uuidString)", isDirectory: true)
+        return (FileSecretStore(paths: AppPaths(root: root), helperPath: "/opt/restic-station-helper"), root)
+    }
+
+    // MARK: - File backend
+
+    @Test("file: round-trips a password, then deletes it")
+    func fileRoundTrip() async throws {
+        let (store, root) = Self.makeFileStore()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try await store.setPassword("hunter2", destId: Self.destId)
+        #expect(try await store.password(destId: Self.destId) == "hunter2")
+
+        try await store.deletePassword(destId: Self.destId)
+        await #expect(throws: SecretStoreError.itemNotFound) {
+            _ = try await store.password(destId: Self.destId)
+        }
+    }
+
+    @Test("file: a missing password is .itemNotFound, not an empty string")
+    func fileMissingPassword() async throws {
+        let (store, root) = Self.makeFileStore()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        await #expect(throws: SecretStoreError.itemNotFound) {
+            _ = try await store.password(destId: Self.destId)
+        }
+    }
+
+    @Test("file: a missing secret env is [:] and does not throw")
+    func fileMissingSecretEnv() async throws {
+        let (store, root) = Self.makeFileStore()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        #expect(try await store.secretEnv(destId: Self.destId).isEmpty)
+    }
+
+    @Test("file: secret env round-trips as a JSON blob under the '-env' key")
+    func fileSecretEnvRoundTrip() async throws {
+        let (store, root) = Self.makeFileStore()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let env = ["AWS_ACCESS_KEY_ID": "AKIA123", "AWS_SECRET_ACCESS_KEY": "shh"]
+        try await store.setSecretEnv(env, destId: Self.destId)
+        #expect(try await store.secretEnv(destId: Self.destId) == env)
+
+        // The stored shape mirrors the keychain account naming.
+        let document = try store.load()
+        #expect(document.secrets[SecretAccount.secretEnv(Self.destId)] != nil)
+        #expect(document.secrets[SecretAccount.password(Self.destId)] == nil)
+
+        try await store.deleteSecretEnv(destId: Self.destId)
+        #expect(try await store.secretEnv(destId: Self.destId).isEmpty)
+    }
+
+    @Test("file: deletes are idempotent")
+    func fileIdempotentDeletes() async throws {
+        let (store, root) = Self.makeFileStore()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        // Deleting from a store that has no file at all must not throw.
+        try await store.deletePassword(destId: Self.destId)
+        try await store.deleteSecretEnv(destId: Self.destId)
+
+        try await store.setPassword("pw", destId: Self.destId)
+        try await store.deletePassword(destId: Self.destId)
+        try await store.deletePassword(destId: Self.destId)
+    }
+
+    @Test("file: overwriting replaces the value rather than appending")
+    func fileOverwriteReplaces() async throws {
+        let (store, root) = Self.makeFileStore()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try await store.setPassword("first", destId: Self.destId)
+        try await store.setPassword("second", destId: Self.destId)
+        #expect(try await store.password(destId: Self.destId) == "second")
+
+        try await store.setSecretEnv(["A": "1", "B": "2"], destId: Self.destId)
+        try await store.setSecretEnv(["A": "3"], destId: Self.destId)
+        #expect(try await store.secretEnv(destId: Self.destId) == ["A": "3"])
+
+        let document = try store.load()
+        #expect(document.secrets.count == 2, "one password key and one -env key, not four")
+    }
+
+    @Test("file: destinations do not interfere with each other")
+    func fileDestinationsAreIndependent() async throws {
+        let (store, root) = Self.makeFileStore()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try await store.setPassword("one", destId: Self.destId)
+        try await store.setPassword("two", destId: Self.otherId)
+        try await store.deletePassword(destId: Self.destId)
+
+        #expect(try await store.password(destId: Self.otherId) == "two")
+    }
+
+    @Test("file: keys are the lowercased UUID, matching the keychain accounts")
+    func fileKeysAreLowercasedUUIDs() async throws {
+        let (store, root) = Self.makeFileStore()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        #expect(Self.destId.uuidString != Self.destId.uuidString.lowercased())
+        try await store.setPassword("pw", destId: Self.destId)
+
+        let document = try store.load()
+        #expect(document.secrets.keys.sorted() == [Self.destId.uuidString.lowercased()])
+    }
+
+    // MARK: - Keychain backend (macOS)
+
+    #if os(macOS)
+    @Test("keychain: a missing password is .itemNotFound (security exit 44)")
+    func keychainMissingPassword() async throws {
+        let runner = FakeProcessRunner(script: [
+            .init(argvPrefix: ["/usr/bin/security", "find-generic-password"], exitCode: 44),
+        ])
+        let store = KeychainSecretStore(runner: runner)
+        await #expect(throws: SecretStoreError.itemNotFound) {
+            _ = try await store.password(destId: Self.destId)
+        }
+    }
+
+    @Test("keychain: a missing secret env is [:] and does not throw")
+    func keychainMissingSecretEnv() async throws {
+        let runner = FakeProcessRunner(script: [
+            .init(argvPrefix: ["/usr/bin/security", "find-generic-password"], exitCode: 44),
+        ])
+        let store = KeychainSecretStore(runner: runner)
+        #expect(try await store.secretEnv(destId: Self.destId).isEmpty)
+    }
+
+    @Test("keychain: deletes are idempotent")
+    func keychainIdempotentDeletes() async throws {
+        let runner = FakeProcessRunner(script: [
+            .init(argvPrefix: ["/usr/bin/security", "delete-generic-password"], exitCode: 44),
+            .init(argvPrefix: ["/usr/bin/security", "delete-generic-password"], exitCode: 44),
+        ])
+        let store = KeychainSecretStore(runner: runner)
+        try await store.deletePassword(destId: Self.destId)
+        try await store.deleteSecretEnv(destId: Self.destId)
+    }
+
+    @Test("keychain: a write replaces (delete-then-add), it never uses -U")
+    func keychainOverwriteReplaces() async throws {
+        let runner = FakeProcessRunner(script: [
+            .init(argvPrefix: ["/usr/bin/security", "delete-generic-password"], exitCode: 0),
+            .init(argvPrefix: ["/usr/bin/security", "add-generic-password"], exitCode: 0),
+        ])
+        let store = KeychainSecretStore(runner: runner)
+        try await store.setPassword("second", destId: Self.destId)
+        #expect(runner.invocations.count == 2)
+        #expect(!runner.invocations[1].argv.contains("-U"))
+    }
+    #endif
+
+    // MARK: - Both backends agree on the storage keys
+
+    @Test("both backends key on the same lowercased-UUID account strings")
+    func accountNamingIsShared() {
+        #expect(SecretAccount.password(Self.destId) == "a1b2c3d4-e5f6-4789-a012-3456789abcde")
+        #expect(SecretAccount.secretEnv(Self.destId) == "a1b2c3d4-e5f6-4789-a012-3456789abcde-env")
+    }
+}

--- a/Core/Tests/ResticStationCoreTests/Support/FakeSecretStore.swift
+++ b/Core/Tests/ResticStationCoreTests/Support/FakeSecretStore.swift
@@ -25,11 +25,22 @@ final class FakeSecretStore: SecretStore, @unchecked Sendable {
     private var _failingSecretEnvs: Set<UUID> = []
     private let defaultPassword: String?
 
-    /// - Parameter defaultPassword: returned for any destination with no
-    ///   explicitly stored password. `nil` makes the store behave like a real
-    ///   empty one (`itemNotFound`).
-    init(defaultPassword: String? = FakeSecretStore.standardPassword) {
+    /// Which backend this fake stands in for. Defaults to the platform's, so
+    /// a test that does not care gets the wording a real host would produce.
+    let backend: SecretBackend
+
+    /// - Parameters:
+    ///   - defaultPassword: returned for any destination with no explicitly
+    ///     stored password. `nil` makes the store behave like a real empty
+    ///     one (`itemNotFound`).
+    ///   - backend: the backend this fake reports as, for the user-facing
+    ///     wording derived from it.
+    init(
+        defaultPassword: String? = FakeSecretStore.standardPassword,
+        backend: SecretBackend = .platformDefault
+    ) {
         self.defaultPassword = defaultPassword
+        self.backend = backend
     }
 
     // MARK: - Test configuration

--- a/Core/Tests/ResticStationCoreTests/Support/FakeSecretStore.swift
+++ b/Core/Tests/ResticStationCoreTests/Support/FakeSecretStore.swift
@@ -1,0 +1,119 @@
+import Foundation
+@testable import ResticStationCore
+
+/// In-memory ``SecretStore`` double.
+///
+/// Before T23 every test that exercised `ResticRunner`/`BackupEngine` had to
+/// script `/usr/bin/security` invocations through `FakeProcessRunner`, which
+/// (a) coupled unrelated tests to the macOS keychain's argv and (b) made the
+/// ordered process script three or four entries longer per restic spawn. With
+/// the secret store behind a protocol, those tests inject this instead: the
+/// process script now contains restic calls and nothing else.
+///
+/// Defaults to "every destination has a password", because that is the
+/// uninteresting precondition of almost every test. Use ``failPassword(for:)``
+/// / ``failSecretEnv(for:)`` to reach the retryable-error paths.
+final class FakeSecretStore: SecretStore, @unchecked Sendable {
+    /// What `password(destId:)` returns for a destination nothing was stored
+    /// for, when ``defaultPassword`` is in effect.
+    static let standardPassword = "repo-password"
+
+    private let lock = NSLock()
+    private var _passwords: [UUID: String] = [:]
+    private var _secretEnvs: [UUID: [String: String]] = [:]
+    private var _failingPasswords: Set<UUID> = []
+    private var _failingSecretEnvs: Set<UUID> = []
+    private let defaultPassword: String?
+
+    /// - Parameter defaultPassword: returned for any destination with no
+    ///   explicitly stored password. `nil` makes the store behave like a real
+    ///   empty one (`itemNotFound`).
+    init(defaultPassword: String? = FakeSecretStore.standardPassword) {
+        self.defaultPassword = defaultPassword
+    }
+
+    // MARK: - Test configuration
+
+    func store(password: String, for destId: UUID) {
+        withLock { _passwords[destId] = password }
+    }
+
+    func store(secretEnv: [String: String], for destId: UUID) {
+        withLock { _secretEnvs[destId] = secretEnv }
+    }
+
+    /// Makes `password(destId:)` throw — the "locked keychain / unreadable
+    /// secrets file" pre-flight failure.
+    func failPassword(for destId: UUID) {
+        withLock { _failingPasswords.insert(destId) }
+    }
+
+    /// Makes `secretEnv(destId:)` throw (a *failure*, not "absent": absent is
+    /// `[:]` and is the default).
+    func failSecretEnv(for destId: UUID) {
+        withLock { _failingSecretEnvs.insert(destId) }
+    }
+
+    // MARK: - SecretStore
+
+    func setPassword(_ password: String, destId: UUID) async throws {
+        withLock { _passwords[destId] = password }
+    }
+
+    func password(destId: UUID) async throws -> String {
+        let outcome: Result<String, SecretStoreError> = withLock {
+            if _failingPasswords.contains(destId) {
+                return .failure(.backendFailed("fake: password read failed"))
+            }
+            if let stored = _passwords[destId] {
+                return .success(stored)
+            }
+            if let defaultPassword {
+                return .success(defaultPassword)
+            }
+            return .failure(.itemNotFound)
+        }
+        return try outcome.get()
+    }
+
+    func deletePassword(destId: UUID) async throws {
+        withLock { _passwords.removeValue(forKey: destId) }
+    }
+
+    func setSecretEnv(_ env: [String: String], destId: UUID) async throws {
+        withLock { _secretEnvs[destId] = env }
+    }
+
+    func secretEnv(destId: UUID) async throws -> [String: String] {
+        let outcome: Result<[String: String], SecretStoreError> = withLock {
+            if _failingSecretEnvs.contains(destId) {
+                return .failure(.backendFailed("fake: secret env read failed"))
+            }
+            return .success(_secretEnvs[destId] ?? [:])
+        }
+        return try outcome.get()
+    }
+
+    func deleteSecretEnv(destId: UUID) async throws {
+        withLock { _secretEnvs.removeValue(forKey: destId) }
+    }
+
+    /// Deterministic and obviously fake, so a test asserting env assembly is
+    /// asserting *that the store's command was used*, not re-deriving the
+    /// keychain's string.
+    func passwordCommand(destId: UUID) -> String {
+        FakeSecretStore.passwordCommand(destId: destId)
+    }
+
+    static func passwordCommand(destId: UUID) -> String {
+        "/fake/secret-store print-password --dest \(destId.uuidString.lowercased())"
+    }
+
+    // MARK: - Plumbing
+
+    private func withLock<T>(_ body: () -> T) -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return body()
+    }
+}

--- a/Helper/Sources/Commands/Secret.swift
+++ b/Helper/Sources/Commands/Secret.swift
@@ -1,0 +1,398 @@
+import ArgumentParser
+import Foundation
+import ResticStationCore
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+// MARK: - secret
+
+/// `secret …` — enter and manage repository passwords and secret environment
+/// variables from a terminal.
+///
+/// The Linux host has no GUI, so there is nowhere to type a password except
+/// here. On macOS these commands work too (against the login keychain), which
+/// makes them the scriptable equivalent of the destination editor's password
+/// field.
+///
+/// **No secret is ever an argument.** `secret set` and `secret set-env` read
+/// from stdin; nothing in this file puts a secret in argv, in a log line, in
+/// a run record, or in an error message. `secret list` prints which
+/// destinations have secrets, never what they are.
+struct Secret: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "secret",
+        abstract: "Store, inspect and remove destination passwords and secret environment variables. "
+            + "Values are read from stdin, never from the command line. Exit 0 ok, 1 error.",
+        subcommands: [
+            SecretSet.self,
+            SecretSetEnv.self,
+            SecretRemove.self,
+            SecretList.self,
+        ]
+    )
+}
+
+// MARK: - secret set
+
+struct SecretSet: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "set",
+        abstract: "Read a repository password from stdin and store it for one destination. "
+            + "On a terminal you are prompted with echo disabled; from a pipe the input is "
+            + "taken raw (one trailing newline is stripped), so "
+            + "`pass show repo | … secret set --dest <uuid>` works. Exit 0 ok, 1 error."
+    )
+
+    @Option(name: .long, help: "The destination UUID whose password is being set.")
+    var dest: UUID
+
+    func run() async throws {
+        let context = SecretContext.make()
+        let destination = context.destination(dest)
+
+        let password = SecretInput.read(prompt: "Password for \"\(destination.label)\": ")
+        guard !password.isEmpty else {
+            HelperExit.fail("refusing to store an empty password for \"\(destination.label)\"")
+        }
+
+        do {
+            try await context.store.setPassword(password, destId: dest)
+        } catch {
+            HelperExit.fail("could not store the password for \"\(destination.label)\": \(error)")
+        }
+        print("stored a password for \"\(destination.label)\"")
+        HelperExit.code(0)
+    }
+}
+
+// MARK: - secret set-env
+
+struct SecretSetEnv: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "set-env",
+        abstract: "Read a JSON object of secret environment variables "
+            + "(e.g. {\"AWS_ACCESS_KEY_ID\":\"…\"}) from stdin and store it for one destination. "
+            + "Replaces any previously stored set. Exit 0 ok, 1 error."
+    )
+
+    @Option(name: .long, help: "The destination UUID whose secret environment is being set.")
+    var dest: UUID
+
+    func run() async throws {
+        let context = SecretContext.make()
+        let destination = context.destination(dest)
+
+        let raw = SecretInput.readAllStdin()
+        let env: [String: String]
+        do {
+            env = try SecretEnvInput.parse(raw)
+        } catch let error as SecretEnvInput.ParseError {
+            // `error` describes the *shape* of the input, never a value.
+            HelperExit.fail("could not read the secret environment: \(error.message)")
+        }
+
+        do {
+            try await context.store.setSecretEnv(env, destId: dest)
+        } catch {
+            HelperExit.fail("could not store the secret environment for \"\(destination.label)\": \(error)")
+        }
+        let names = env.keys.sorted().joined(separator: ", ")
+        print("stored \(env.count) secret environment variable(s) for \"\(destination.label)\": \(names)")
+        HelperExit.code(0)
+    }
+}
+
+// MARK: - secret rm
+
+struct SecretRemove: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "rm",
+        abstract: "Remove a destination's stored password, or (with --env) its stored secret "
+            + "environment. Idempotent: removing something that is not there succeeds. "
+            + "Exit 0 ok, 1 error."
+    )
+
+    @Option(name: .long, help: "The destination UUID to remove a secret from.")
+    var dest: UUID
+
+    @Flag(
+        name: .long,
+        help: "Remove the secret environment variables instead of the repository password."
+    )
+    var env = false
+
+    func run() async throws {
+        let context = SecretContext.make()
+        let destination = context.destination(dest)
+
+        do {
+            if env {
+                try await context.store.deleteSecretEnv(destId: dest)
+            } else {
+                try await context.store.deletePassword(destId: dest)
+            }
+        } catch {
+            HelperExit.fail("could not remove the secret for \"\(destination.label)\": \(error)")
+        }
+        // Deliberately does not claim something was removed: the delete is
+        // idempotent, so the honest report is the resulting state.
+        let what = env ? "secret environment" : "password"
+        print("\"\(destination.label)\": no \(what) is stored any more")
+        HelperExit.code(0)
+    }
+}
+
+// MARK: - secret list
+
+struct SecretList: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "list",
+        abstract: "List the configured destinations that have a stored password and/or secret "
+            + "environment. Never prints a secret value. Exit 0 ok, 1 error."
+    )
+
+    func run() async throws {
+        let context = SecretContext.make()
+
+        var rows: [SecretListing.Row] = []
+        for entry in context.destinations {
+            let destId = entry.destination.id
+            var hasPassword = false
+            do {
+                // The value is read and immediately discarded — presence is
+                // the only thing this command reports.
+                _ = try await context.store.password(destId: destId)
+                hasPassword = true
+            } catch SecretStoreError.itemNotFound {
+                hasPassword = false
+            } catch {
+                HelperExit.fail("could not read stored secrets: \(error)")
+            }
+
+            let secretEnvCount: Int
+            do {
+                secretEnvCount = try await context.store.secretEnv(destId: destId).count
+            } catch {
+                HelperExit.fail("could not read stored secrets: \(error)")
+            }
+
+            rows.append(
+                SecretListing.Row(
+                    destId: destId,
+                    label: entry.destination.label,
+                    setName: entry.setName,
+                    hasPassword: hasPassword,
+                    secretEnvCount: secretEnvCount
+                )
+            )
+        }
+
+        for line in SecretListing.format(rows) {
+            print(line)
+        }
+        HelperExit.code(0)
+    }
+}
+
+// MARK: - print-password
+
+/// `print-password --dest <uuid>` — writes the raw password to stdout with
+/// **no trailing newline**.
+///
+/// This exists solely so `FileSecretStore.passwordCommand(destId:)` has
+/// something to name in `RESTIC_PASSWORD_COMMAND`; restic runs it as a child
+/// and reads the password off its stdout. It is hidden from `--help`
+/// (`shouldDisplay: false`) because it is machinery, not a user-facing
+/// action — a `secret` subcommand that prints a password would invite
+/// exactly the copy-paste-into-a-log habit this whole design avoids.
+///
+/// Unlike the `secret` subcommands this does **not** load `config.json`: the
+/// password path must have as few moving parts as possible, and a
+/// destination's presence in the config is irrelevant to whether its
+/// password can be read.
+struct PrintPassword: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "print-password",
+        abstract: "Write one destination's repository password to stdout, with no trailing newline. "
+            + "Used by RESTIC_PASSWORD_COMMAND. Exit 0 ok, 1 error.",
+        shouldDisplay: false
+    )
+
+    @Option(name: .long, help: "The destination UUID whose password should be printed.")
+    var dest: UUID
+
+    func run() async throws {
+        let paths = AppPaths.default()
+        let store = HelperContext.makeSecretStore(paths: paths, runner: DefaultProcessRunner())
+
+        let password: String
+        do {
+            password = try await store.password(destId: dest)
+        } catch SecretStoreError.itemNotFound {
+            HelperExit.fail("no stored password for destination \(dest)")
+        } catch {
+            HelperExit.fail("could not read the password for destination \(dest): \(error)")
+        }
+
+        // Raw bytes, no newline: restic trims a trailing newline itself, but
+        // emitting one would make `secret set` / `print-password` a lossy
+        // round trip for a password that legitimately ends in one.
+        FileHandle.standardOutput.write(Data(password.utf8))
+        HelperExit.code(0)
+    }
+}
+
+// MARK: - stdin
+
+/// Reads secrets from stdin. Never from argv — a command line is visible to
+/// every process on the machine and lands in shell history.
+enum SecretInput {
+
+    /// One secret, as text.
+    ///
+    /// - On a TTY: writes `prompt` to **stderr** (stdout may be redirected),
+    ///   disables terminal echo, and reads one line.
+    /// - On a pipe or file: reads stdin to EOF and strips exactly one
+    ///   trailing newline, so `printf '%s' pw |` and `echo pw |` both give
+    ///   the same result and a password containing newlines survives.
+    static func read(prompt: String) -> String {
+        guard isatty(STDIN_FILENO) == 1 else {
+            return stripOneTrailingNewline(readAllStdin())
+        }
+        FileHandle.standardError.write(Data(prompt.utf8))
+        let line = withEchoDisabled { readLine(strippingNewline: true) ?? "" }
+        // The user's Return was swallowed by the disabled echo; put the
+        // cursor back on its own line.
+        FileHandle.standardError.write(Data("\n".utf8))
+        return line
+    }
+
+    static func readAllStdin() -> String {
+        let data = FileHandle.standardInput.readDataToEndOfFile()
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    /// Exactly one — not "all trailing whitespace". A password may end in a
+    /// newline, and trimming greedily would silently change it.
+    static func stripOneTrailingNewline(_ text: String) -> String {
+        var value = text
+        if value.hasSuffix("\n") {
+            value.removeLast()
+        }
+        return value
+    }
+
+    private static func withEchoDisabled<T>(_ body: () -> T) -> T {
+        var original = termios()
+        guard tcgetattr(STDIN_FILENO, &original) == 0 else {
+            // Not a real terminal after all — better to echo than to refuse.
+            return body()
+        }
+        var modified = original
+        modified.c_lflag &= ~tcflag_t(ECHO)
+        _ = tcsetattr(STDIN_FILENO, TCSAFLUSH, &modified)
+        defer { _ = tcsetattr(STDIN_FILENO, TCSAFLUSH, &original) }
+        return body()
+    }
+}
+
+// MARK: - secret set-env parsing
+
+/// Parses the `{"VAR":"value"}` object `secret set-env` reads from stdin.
+///
+/// Split out from the command so it can be unit-tested without a process:
+/// the failure messages are the whole point here, and they must describe the
+/// *shape* of the input without ever quoting a value.
+enum SecretEnvInput {
+    struct ParseError: Error {
+        let message: String
+    }
+
+    static func parse(_ text: String) throws -> [String: String] {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw ParseError(message: "stdin was empty; expected a JSON object like {\"AWS_ACCESS_KEY_ID\":\"…\"}")
+        }
+
+        let any: Any
+        do {
+            // `.fragmentsAllowed` so a top-level string or number parses and
+            // can be reported as "you gave me a string", rather than being
+            // lumped in with genuinely malformed JSON.
+            any = try JSONSerialization.jsonObject(with: Data(trimmed.utf8), options: [.fragmentsAllowed])
+        } catch {
+            throw ParseError(message: "stdin is not valid JSON")
+        }
+        guard let object = any as? [String: Any] else {
+            throw ParseError(
+                message: "expected a JSON object of environment variables like "
+                    + "{\"AWS_ACCESS_KEY_ID\":\"…\"}, got a \(describe(any))"
+            )
+        }
+
+        var env: [String: String] = [:]
+        for key in object.keys.sorted() {
+            guard let value = object[key] as? String else {
+                throw ParseError(
+                    message: "the value of \"\(key)\" is a \(describe(object[key] as Any)); "
+                        + "environment variables must be JSON strings"
+                )
+            }
+            guard !key.isEmpty else {
+                throw ParseError(message: "an environment variable name cannot be empty")
+            }
+            env[key] = value
+        }
+        return env
+    }
+
+    /// Names a JSON value's *kind* — never its contents.
+    private static func describe(_ value: Any) -> String {
+        switch value {
+        case is [Any]: return "array"
+        case is [String: Any]: return "object"
+        case is String: return "string"
+        case is NSNull: return "null"
+        case is NSNumber: return "number or boolean"
+        default: return "value of an unsupported type"
+        }
+    }
+}
+
+// MARK: - secret list formatting
+
+/// Renders `secret list`. Pure, so a test can assert on the exact lines and
+/// prove no secret value can reach stdout.
+enum SecretListing {
+    struct Row {
+        let destId: UUID
+        let label: String
+        let setName: String
+        let hasPassword: Bool
+        let secretEnvCount: Int
+
+        var hasAnything: Bool { hasPassword || secretEnvCount > 0 }
+    }
+
+    static func format(_ rows: [Row]) -> [String] {
+        let stored = rows.filter(\.hasAnything)
+        guard !stored.isEmpty else {
+            return ["no destination has a stored password or secret environment"]
+        }
+        return stored.map { row in
+            var kinds: [String] = []
+            if row.hasPassword {
+                kinds.append("password")
+            }
+            if row.secretEnvCount > 0 {
+                kinds.append("secret-env (\(row.secretEnvCount) variable(s))")
+            }
+            return "\(row.destId.uuidString.lowercased())  \"\(row.label)\" "
+                + "(set \"\(row.setName)\")  \(kinds.joined(separator: ", "))"
+        }
+    }
+}

--- a/Helper/Sources/HelperContext.swift
+++ b/Helper/Sources/HelperContext.swift
@@ -40,7 +40,7 @@ struct HelperContext {
     let configStore: ConfigStore
     let stateStore: StateStore
     let runStore: RunStore
-    let keychain: KeychainClient
+    let secrets: any SecretStore
     let restic: ResticRunner
     let reachability: Reachability
     let engine: BackupEngine
@@ -74,8 +74,8 @@ struct HelperContext {
             return nil
         }
         let processRunner = DefaultProcessRunner()
-        let keychain = KeychainClient(runner: processRunner)
-        let restic = ResticRunner(resticPath: resticPath, paths: paths, keychain: keychain, runner: processRunner)
+        let secrets = makeSecretStore(paths: paths, runner: processRunner)
+        let restic = ResticRunner(resticPath: resticPath, paths: paths, secrets: secrets, runner: processRunner)
         let runStore = RunStore(paths: paths)
         let stateStore = StateStore(paths: paths)
         let reachability = Reachability(restic: restic)
@@ -83,7 +83,7 @@ struct HelperContext {
             config: config,
             paths: paths,
             restic: restic,
-            keychain: keychain,
+            secrets: secrets,
             runStore: runStore,
             stateStore: stateStore,
             reachability: reachability
@@ -93,11 +93,70 @@ struct HelperContext {
             configStore: configStore,
             stateStore: stateStore,
             runStore: runStore,
-            keychain: keychain,
+            secrets: secrets,
             restic: restic,
             reachability: reachability,
             engine: engine,
             config: config
         )
+    }
+
+    /// The one place the helper decides which secret backend to use:
+    /// keychain on macOS, `secrets.json` elsewhere, overridable with
+    /// `RESTIC_STATION_SECRET_BACKEND` (`docs/keychain-and-fda.md` §5).
+    ///
+    /// A bad override is fatal even for `tick`, whose contract is otherwise
+    /// "exit 0 unless config itself is broken": a helper that cannot tell
+    /// which store holds the passwords must not guess, and guessing wrong
+    /// looks exactly like "all my passwords disappeared".
+    static func makeSecretStore(paths: AppPaths, runner: ProcessRunning) -> any SecretStore {
+        do {
+            return try SecretStoreFactory.make(paths: paths, runner: runner)
+        } catch {
+            HelperExit.fail("secret storage is misconfigured: \(error)")
+        }
+    }
+}
+
+/// The minimal context the `secret` subcommands need: a secret store and
+/// (for the ones that name destinations) the configuration.
+///
+/// Deliberately *not* `HelperContext`: entering a password must work before
+/// a restic binary has ever been configured, and `HelperContext.make()`
+/// exits 1 when `resticPath` is missing.
+struct SecretContext {
+    let paths: AppPaths
+    let store: any SecretStore
+    let config: AppConfig
+
+    static func make() -> SecretContext {
+        let paths = AppPaths.default()
+        let config: AppConfig
+        do {
+            config = try ConfigStore(paths: paths).load()
+        } catch {
+            HelperExit.fail("could not load configuration: \(error)")
+        }
+        return SecretContext(
+            paths: paths,
+            store: HelperContext.makeSecretStore(paths: paths, runner: DefaultProcessRunner()),
+            config: config
+        )
+    }
+
+    /// Every configured destination, in config order, with its owning set's
+    /// name for display.
+    var destinations: [(setName: String, destination: Destination)] {
+        config.sets.flatMap { set in
+            set.destinations.map { (setName: set.name, destination: $0) }
+        }
+    }
+
+    /// Resolves `--dest`, or exits 1 per the T10 contract.
+    func destination(_ destId: UUID) -> Destination {
+        guard let match = destinations.first(where: { $0.destination.id == destId })?.destination else {
+            HelperExit.fail("no configured destination with id \(destId)")
+        }
+        return match
     }
 }

--- a/Helper/Sources/HelperContext.swift
+++ b/Helper/Sources/HelperContext.swift
@@ -109,9 +109,18 @@ struct HelperContext {
     /// "exit 0 unless config itself is broken": a helper that cannot tell
     /// which store holds the passwords must not guess, and guessing wrong
     /// looks exactly like "all my passwords disappeared".
+    /// `helperExecutablePath` is *this* binary: the helper is the one process
+    /// for which "the current executable" really is the right target for the
+    /// file backend's `RESTIC_PASSWORD_COMMAND` — the app must pass its
+    /// embedded helper's path instead, which is why the factory has no
+    /// default.
     static func makeSecretStore(paths: AppPaths, runner: ProcessRunning) -> any SecretStore {
         do {
-            return try SecretStoreFactory.make(paths: paths, runner: runner)
+            return try SecretStoreFactory.make(
+                paths: paths,
+                runner: runner,
+                helperExecutablePath: FileSecretStore.currentExecutablePath()
+            )
         } catch {
             HelperExit.fail("secret storage is misconfigured: \(error)")
         }

--- a/Helper/Sources/HelperMain.swift
+++ b/Helper/Sources/HelperMain.swift
@@ -28,6 +28,10 @@ struct HelperMain: AsyncParsableCommand {
             ProbeRepo.self,
             Unlock.self,
             FdaCheck.self,
+            Secret.self,
+            // Hidden from --help (`shouldDisplay: false`): it exists for
+            // RESTIC_PASSWORD_COMMAND, not for people.
+            PrintPassword.self,
         ]
         #if os(Linux)
         subcommands.append(TimerCommand.self)

--- a/Helper/Tests/HelperTests/SecretCommandTests.swift
+++ b/Helper/Tests/HelperTests/SecretCommandTests.swift
@@ -1,0 +1,155 @@
+import Foundation
+import Testing
+
+@testable import restic_station_helper
+
+/// Unit coverage for the pure parts of the `secret` subcommands — the stdin
+/// handling, the `set-env` parser, and the `list` renderer.
+///
+/// The end-to-end behaviour (real binary, real `secrets.json`, real restic
+/// authenticating through `RESTIC_PASSWORD_COMMAND`) is
+/// `scripts/secret-cli-test.sh`, which is what actually asserts on the
+/// process's stdout bytes; these tests pin the logic that script exercises.
+@Suite("secret CLI")
+struct SecretCommandTests {
+
+    // MARK: - stdin
+
+    @Test("exactly one trailing newline is stripped, never more")
+    func stripsExactlyOneNewline() {
+        #expect(SecretInput.stripOneTrailingNewline("hunter2\n") == "hunter2")
+        #expect(SecretInput.stripOneTrailingNewline("hunter2") == "hunter2")
+        // `echo` adds one; a password that genuinely ends in a newline keeps
+        // the rest.
+        #expect(SecretInput.stripOneTrailingNewline("hunter2\n\n") == "hunter2\n")
+        #expect(SecretInput.stripOneTrailingNewline("\n") == "")
+        // Interior newlines and trailing spaces are part of the password.
+        #expect(SecretInput.stripOneTrailingNewline("two\nlines\n") == "two\nlines")
+        #expect(SecretInput.stripOneTrailingNewline("trailing space \n") == "trailing space ")
+    }
+
+    // MARK: - set-env parsing
+
+    @Test("a JSON object of strings parses")
+    func parsesStringObject() throws {
+        let env = try SecretEnvInput.parse(#"{"AWS_ACCESS_KEY_ID":"AKIA123","AWS_SECRET_ACCESS_KEY":"shh"}"#)
+        #expect(env == ["AWS_ACCESS_KEY_ID": "AKIA123", "AWS_SECRET_ACCESS_KEY": "shh"])
+    }
+
+    @Test("surrounding whitespace and a trailing newline are tolerated")
+    func toleratesWhitespace() throws {
+        let env = try SecretEnvInput.parse("  {\"A\":\"1\"}\n")
+        #expect(env == ["A": "1"])
+    }
+
+    @Test("an empty object is a legitimate 'no secret env'")
+    func parsesEmptyObject() throws {
+        #expect(try SecretEnvInput.parse("{}").isEmpty)
+    }
+
+    @Test("empty stdin is rejected with a message that shows the expected shape")
+    func rejectsEmptyInput() {
+        #expect(throws: SecretEnvInput.ParseError.self) {
+            _ = try SecretEnvInput.parse("   \n")
+        }
+    }
+
+    @Test("a non-object is rejected, naming the kind it got")
+    func rejectsNonObject() {
+        for (input, kind) in [(#"["a","b"]"#, "array"), (#""just a string""#, "string"), ("42", "number")] {
+            do {
+                _ = try SecretEnvInput.parse(input)
+                Issue.record("expected \(input) to be rejected")
+            } catch let error as SecretEnvInput.ParseError {
+                #expect(error.message.contains(kind), "message was: \(error.message)")
+            } catch {
+                Issue.record("unexpected error \(error)")
+            }
+        }
+    }
+
+    @Test("a non-string value is rejected, naming the variable but never a value")
+    func rejectsNonStringValues() {
+        do {
+            _ = try SecretEnvInput.parse(#"{"OK":"yes","PORT":9000}"#)
+            Issue.record("expected a numeric value to be rejected")
+        } catch let error as SecretEnvInput.ParseError {
+            #expect(error.message.contains("PORT"))
+            #expect(error.message.contains("must be JSON strings"))
+            // The *other* variable's value must not leak into the diagnostic.
+            #expect(!error.message.contains("yes"))
+            #expect(!error.message.contains("9000"))
+        } catch {
+            Issue.record("unexpected error \(error)")
+        }
+    }
+
+    @Test("invalid JSON is rejected without echoing the input back")
+    func rejectsInvalidJSON() {
+        do {
+            _ = try SecretEnvInput.parse(#"{"AWS_SECRET_ACCESS_KEY": "super-secret"#)
+            Issue.record("expected invalid JSON to be rejected")
+        } catch let error as SecretEnvInput.ParseError {
+            #expect(error.message == "stdin is not valid JSON")
+            #expect(!error.message.contains("super-secret"))
+        } catch {
+            Issue.record("unexpected error \(error)")
+        }
+    }
+
+    // MARK: - list rendering
+
+    static let destId = UUID(uuidString: "A1B2C3D4-E5F6-4789-A012-3456789ABCDE")!
+    static let otherId = UUID(uuidString: "B1B2C3D4-E5F6-4789-A012-3456789ABCDE")!
+
+    @Test("list shows only destinations that have something stored")
+    func listsOnlyDestinationsWithSecrets() {
+        let lines = SecretListing.format([
+            .init(destId: Self.destId, label: "Primary", setName: "Docs",
+                  hasPassword: true, secretEnvCount: 0),
+            .init(destId: Self.otherId, label: "Nothing here", setName: "Docs",
+                  hasPassword: false, secretEnvCount: 0),
+        ])
+        #expect(lines.count == 1)
+        #expect(lines[0].contains("a1b2c3d4-e5f6-4789-a012-3456789abcde"))
+        #expect(lines[0].contains("Primary"))
+        #expect(lines[0].contains("password"))
+        #expect(!lines.joined().contains("Nothing here"))
+    }
+
+    @Test("list reports secret-env counts, never names or values")
+    func listReportsCountsOnly() {
+        let lines = SecretListing.format([
+            .init(destId: Self.destId, label: "R2 mirror", setName: "Docs",
+                  hasPassword: true, secretEnvCount: 2),
+        ])
+        #expect(lines[0].contains("secret-env (2 variable(s))"))
+        #expect(!lines[0].contains("AWS"))
+    }
+
+    @Test("an empty store says so rather than printing nothing")
+    func listOnEmptyStore() {
+        let lines = SecretListing.format([
+            .init(destId: Self.destId, label: "Primary", setName: "Docs",
+                  hasPassword: false, secretEnvCount: 0),
+        ])
+        #expect(lines == ["no destination has a stored password or secret environment"])
+    }
+
+    /// The output is built only from ids, labels, set names and counts — the
+    /// renderer is never handed a secret at all, which is the structural
+    /// reason `secret list` cannot print one.
+    @Test("no secret value can reach list output, by construction")
+    func listCannotPrintSecrets() {
+        let rows = [
+            SecretListing.Row(destId: Self.destId, label: "Primary", setName: "Docs",
+                              hasPassword: true, secretEnvCount: 3),
+            SecretListing.Row(destId: Self.otherId, label: "Mirror", setName: "Docs",
+                              hasPassword: true, secretEnvCount: 0),
+        ]
+        let output = SecretListing.format(rows).joined(separator: "\n")
+        for forbidden in ["hunter2", "AKIA", "super-secret"] {
+            #expect(!output.contains(forbidden))
+        }
+    }
+}

--- a/Helper/Tests/HelperTests/SubcommandRegistrationTests.swift
+++ b/Helper/Tests/HelperTests/SubcommandRegistrationTests.swift
@@ -32,6 +32,8 @@ import Testing
             "probe-repo",
             "unlock",
             "fda-check",
+            "secret",
+            "print-password",
             "timer",
             "version",
         ]
@@ -46,9 +48,32 @@ import Testing
             "probe-repo",
             "unlock",
             "fda-check",
+            "secret",
+            "print-password",
             "version",
         ]
     )
     #expect(!names.contains("timer"))
     #endif
+}
+
+/// `print-password` is registered but must stay out of `--help`: it is the
+/// machinery behind `RESTIC_PASSWORD_COMMAND`, not a user-facing action.
+@Test func printPasswordIsHiddenFromHelp() {
+    #expect(PrintPassword.configuration.shouldDisplay == false)
+    // Everything else is visible.
+    for subcommand in HelperMain.configuration.subcommands
+    where subcommand.configuration.commandName != "print-password" {
+        #expect(
+            subcommand.configuration.shouldDisplay,
+            "\(subcommand.configuration.commandName ?? "?") should appear in --help"
+        )
+    }
+}
+
+@Test func secretExposesItsFourSubcommands() {
+    let names: [String?] = Secret.configuration.subcommands.map { subcommand in
+        subcommand.configuration.commandName
+    }
+    #expect(names == ["set", "set-env", "rm", "list"])
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -61,7 +61,7 @@ public protocol ProcessRunning: Sendable {
 }
 ```
 
-The production implementation (`DefaultProcessRunner`) wraps `Process` + pipes. Tests inject `FakeProcessRunner` (see `testing.md`). `KeychainClient`, `ResticRunner`, and `Reachability` all take a `ProcessRunning` in their initializers.
+The production implementation (`DefaultProcessRunner`) wraps `Process` + pipes. Tests inject `FakeProcessRunner` (see `testing.md`). `KeychainSecretStore`, `ResticRunner`, and `Reachability` all take a `ProcessRunning` in their initializers. Secret storage itself is behind the `SecretStore` protocol (`KeychainSecretStore` on macOS, `FileSecretStore` elsewhere — see `keychain-and-fda.md`); `ResticRunner` and `BackupEngine` take `any SecretStore`, not a concrete backend.
 
 ## restic discovery
 

--- a/docs/keychain-and-fda.md
+++ b/docs/keychain-and-fda.md
@@ -1,6 +1,17 @@
-# Keychain, Full Disk Access, and SMAppService
+# Secret storage, Full Disk Access, and SMAppService
 
-The three macOS integration points where mistakes don't crash — they make **scheduled headless backups silently stop working**. Read this before touching `KeychainClient`, `LaunchdManager`, or the onboarding UI.
+Where Restic Station keeps repository passwords on each platform, plus the two macOS integration points where mistakes don't crash — they make **scheduled headless backups silently stop working**. Read this before touching any `SecretStore` backend, `LaunchdManager`, or the onboarding UI.
+
+> **Filename note.** This file is still `keychain-and-fda.md` even though §5 now covers a non-keychain backend. The name is referenced from a dozen source comments, task files and the other docs; renaming it would churn all of them for no reader benefit. The title above is the accurate description; treat the filename as a stable id.
+
+Secret storage sits behind `SecretStore` (`Core/Sources/ResticStationCore/Secrets/`), with two backends:
+
+| Backend | Default on | Storage | Password command |
+|---|---|---|---|
+| `KeychainSecretStore` | macOS | login keychain via `/usr/bin/security` | `/usr/bin/security find-generic-password -s restic-station -a <uuid> -w` |
+| `FileSecretStore` | Linux (and everywhere else) | `<AppPaths.root>/secrets.json`, mode `0600` | `<absolute-helper-path> print-password --dest <uuid>` |
+
+`RESTIC_STATION_SECRET_BACKEND=keychain|file` overrides the platform default; an unrecognised value is a hard error, never a silent fallback. Both backends key on the destination UUID lowercased, and on `"<uuid>-env"` for the secret-env JSON blob, so the two are structurally comparable. §1–§4 below are macOS; §5 is the file backend.
 
 ## 1. Keychain: the `security`-CLI ACL strategy
 
@@ -31,7 +42,7 @@ Items (see data-model.md): service `restic-station`, account `<dest-uuid>` (repo
 Passing `-w <password>` puts the secret in `security`'s argv, momentarily visible in `ps` on the local machine. Alternatives (interactive `-w` prompt) don't work programmatically. For a single-user local machine this is acceptable; note it in code comments and README.
 
 ### Login-time edge case
-A `RunAtLoad` tick can fire before the login keychain is unlocked; `find-generic-password` then fails (nonzero exit). This is **retryable** (see architecture.md error taxonomy): the engine must detect "password command failed" (restic exit 1 with keychain-ish stderr, or our own pre-flight `find-generic-password` probe failing) and simply skip the run WITHOUT writing a `.failed` record or updating `lastBackupStart` — the next tick (2 min later, keychain now unlocked) runs normally. Implement as a pre-flight in `BackupEngine.runSet`: read the primary's password via `KeychainClient` first; on failure → log, exit, no state change.
+A `RunAtLoad` tick can fire before the login keychain is unlocked; `find-generic-password` then fails (nonzero exit). This is **retryable** (see architecture.md error taxonomy): the engine must detect "password command failed" (restic exit 1 with keychain-ish stderr, or our own pre-flight `find-generic-password` probe failing) and simply skip the run WITHOUT writing a `.failed` record or updating `lastBackupStart` — the next tick (2 min later, keychain now unlocked) runs normally. Implement as a pre-flight in `BackupEngine.runSet`: read the primary's password via the active `SecretStore` first; on failure → log, exit, no state change. The same pre-flight covers the file backend's equivalent failure (a `secrets.json` whose mode has been widened), which is why `ResticRunnerError` calls the case `secretsUnavailable` rather than naming a backend.
 
 ## 2. Full Disk Access (TCC)
 
@@ -90,3 +101,103 @@ Findings observed during implementation and review — not speculation:
 ## 4. Signing & distribution (v1 posture)
 
 Local builds: ad-hoc/dev signing, works for personal use (with the dev-workflow caveats above). CI: `CODE_SIGNING_ALLOWED=NO`, build-only. Distribution to others (later): Developer ID + hardened runtime + notarization — no entitlement exceptions needed (we load no plugins, no JIT); steps live in `docs/release.md` (T20). The app is **not sandboxed** by design: it must spawn `/usr/bin/security`, an arbitrary user-configured restic binary, `launchctl`, and take `flock`s — all incompatible with App Sandbox. Consequence: no Mac App Store; accepted.
+
+## 5. Linux: the `secrets.json` file backend
+
+`FileSecretStore` (`Core/Sources/ResticStationCore/Secrets/FileSecretStore.swift`) is the default everywhere that is not macOS, and is selectable on macOS with `RESTIC_STATION_SECRET_BACKEND=file`.
+
+### Why a plain file, and not a keyring
+
+The target Linux host is headless: no desktop session, no D-Bus user bus, no keyring daemon, no GPG agent, SSH as the only interactive surface. `gnome-keyring`, `kwallet` and `pass` all need at least one of those. A backup agent whose 03:00 scheduled run depends on a daemon that only exists inside a graphical login is a backup agent that silently stops working — the exact failure mode §1 exists to prevent on macOS. A mode-enforced file has no hidden dependency: its security is the Unix file-permission model and nothing else.
+
+### Shape
+
+```json
+{
+  "version": 1,
+  "secrets": {
+    "<uuid-lowercased>": "the repository password",
+    "<uuid-lowercased>-env": "{\"AWS_ACCESS_KEY_ID\":\"…\"}"
+  }
+}
+```
+
+Deliberately mirrors the keychain account naming (`SecretAccount`), so a destination's storage key is the same string on both platforms and the two backends stay comparable. A `version` newer than this build understands is refused rather than overwritten.
+
+### Threat model
+
+**In scope — what the `0600` file genuinely defends against:**
+- another *user account* on the same host reading the passwords;
+- a service account (a web server, a CI runner) running as a different uid;
+- the file being copied out of a world-readable backup of the host's own filesystem;
+- accidental widening (`chmod -R 755 /opt/restic-station`), which is caught on the next read rather than silently tolerated;
+- symlink swapping: reads use `O_NOFOLLOW` and `fstat` the opened descriptor, so the mode checked is the mode of the exact file read.
+
+**Explicitly out of scope — say so, don't pretend otherwise:**
+- **root.** root reads anything. On a single-admin host this is not a boundary that can exist.
+- **the invoking user themselves.** Anyone who can run the helper can run `print-password`. That is the whole point of a non-interactive backup agent: the passwords must be usable without a human.
+- **an unencrypted disk.** The file is plaintext at rest. Use full-disk encryption (LUKS) if the physical medium is a concern; a keyring would not have helped here either, since it too must be unlockable unattended.
+- **memory scraping / a debugger attached to the process.**
+
+This is a *narrower* guarantee than macOS's, and that is stated rather than papered over: keychain items are encrypted at rest and gated by ACL and by keychain lock state.
+
+### The `0600` rules
+
+- The file is created **at** `0600` via `open(2)`'s mode argument, and the containing directory **at** `0700` via `mkdir(2)`'s. Never create-then-`chmod`: that leaves a window in which the file is world-readable, and a window is all an attacker needs.
+- Writes go through a fixed-name temp file created `O_CREAT|O_EXCL|O_WRONLY, 0600` (any stale temp file is unlinked first, because `open(2)` ignores `mode` for an existing file), `fsync`ed, then `rename(2)`d over the real file — the same atomic pattern as `ConfigStore.save(_:)`. A crash can never truncate `secrets.json`; the worst case is a leftover temp file that the next write removes.
+- **Every read re-verifies the mode** and refuses, naming the file and the exact `chmod` to run, if any group or other permission bit is set. Silently reading a leaked secret file is worse than failing: the failure is retryable and visible, the silent read is neither. `0400` is accepted — the rule is "no group/other bits", not "exactly `0600`".
+- An **existing** `AppPaths.root` is left at whatever mode it has. It holds non-secret state too (`config.json`, `runs/`, `state/`) and may legitimately have been created `0755` by `AppPaths.ensureDirectories()`; the `0600` *file* is what protects the secrets. The `0700` directory is defence in depth for the case where the secret store gets there first.
+
+### Concurrency
+
+A tick and an interactive `secret set` can run at the same time. Every read-modify-write takes `locks/secrets.lock` (the existing `FileLock`, `flock(2)`, released by the kernel on process death) with a 10 s timeout, so a concurrent `secret set` cannot lose the other writer's entry. Reads take **no** lock: `rename(2)` is atomic, so a reader always sees one complete generation of the file.
+
+### How the password reaches restic
+
+Same seam as macOS — `RESTIC_PASSWORD_COMMAND` / `RESTIC_FROM_PASSWORD_COMMAND`, deliberately *not* a plain `RESTIC_PASSWORD` env var (restic's support for a `RESTIC_FROM_PASSWORD` non-`_COMMAND` variant is not something to assume, and the command seam is already proven here). The command is `<absolute-helper-path> print-password --dest <uuid>`; restic runs it as a child and reads the password off its stdout, with no trailing newline.
+
+The helper's own path comes from `/proc/self/exe` on Linux — the kernel's answer, correct even when invoked through a symlink or a `PATH` lookup — and **never** from `CommandLine.arguments[0]`, which is attacker-controlled and would be a straightforward code-execution hole in a string restic is about to execute.
+
+Because `ResticRunner` *replaces* restic's environment, that child would otherwise resolve the default data directory with the platform-default backend. `FileSecretStore.passwordCommandEnvironment` therefore contributes `RESTIC_STATION_DATA_DIR` and `RESTIC_STATION_SECRET_BACKEND=file` to the assembled environment (the keychain backend contributes nothing, which is why macOS's environment is byte-identical to what it was before this abstraction existed).
+
+### No secret in argv — the one place the two backends differ on purpose
+
+macOS's documented, accepted tradeoff is that `security -w <value>` briefly exposes a secret in the process list (§1). That is forced by `security(1)` having no non-interactive alternative. **The file backend has no such constraint and does not reproduce it.** On this path a secret never appears in argv, in a log line, in a run record, or in an error message:
+
+- `secret set` and `secret set-env` read from **stdin** (echo-disabled prompt on a TTY, raw on a pipe, exactly one trailing newline stripped).
+- `print-password` writes to stdout; the value is never an argument.
+- `secret list` prints destination ids, labels and *counts* — its renderer is never handed a secret value at all.
+- `SecretStoreError.backendFailed` may only carry a backend's own diagnostic text (a path, an errno, a JSON key path) — never a value. `ResticRunnerError.secretsUnavailable` carries only a destination id.
+
+`scripts/secret-cli-test.sh` asserts all of this against the real binary, including a `grep -r` of the whole data directory for the password after a real backup run.
+
+### Managing secrets from a terminal
+
+There is no GUI on the Linux host, so the helper is the entry point:
+
+```sh
+# store a password (prompts with echo off on a TTY)
+restic-station-helper secret set --dest <uuid>
+# …or from a password manager, with no secret in argv or shell history
+pass show backups/primary | restic-station-helper secret set --dest <uuid>
+
+# S3-style credentials, as a JSON object of strings
+printf '%s' '{"AWS_ACCESS_KEY_ID":"…","AWS_SECRET_ACCESS_KEY":"…"}' \
+    | restic-station-helper secret set-env --dest <uuid>
+
+# what is stored (never what it is)
+restic-station-helper secret list
+
+# remove (idempotent; --env targets the secret env instead of the password)
+restic-station-helper secret rm --dest <uuid>
+restic-station-helper secret rm --dest <uuid> --env
+```
+
+Exit codes follow the helper contract (`docs/tasks/T10-helper-cli.md`): 0 ok, 1 error. An unknown destination UUID is exit 1. `print-password` exists only for `RESTIC_PASSWORD_COMMAND` and is hidden from `--help`.
+
+### Troubleshooting
+
+- **"refusing to read …/secrets.json: it is group- or world-accessible".** Exactly what it says; run the `chmod 600` the message prints. Then consider *why* it was widened — if something recursively chmod'ed the data directory, other state files were widened too.
+- **restic reports "Resolving password failed" on Linux.** The password command is `<helper> print-password --dest <uuid>`. Run it by hand with the same `RESTIC_STATION_DATA_DIR`/`RESTIC_STATION_SECRET_BACKEND` the agent uses; if it exits 1 with "no stored password", the destination has no password stored (`secret set` it), and if it exits 1 with a permissions message, see above.
+- **A backup that worked from a shell fails from the timer/agent.** Check that the unit's environment carries the same `RESTIC_STATION_DATA_DIR` the interactive shell had, if you set one at all — the helper resolves the store from its own environment on both sides.
+- **`RESTIC_STATION_SECRET_BACKEND=keychain` on Linux.** Hard error, by design: `/usr/bin/security` does not exist there, and a backend that can only fail is worse than no backend.

--- a/docs/keychain-and-fda.md
+++ b/docs/keychain-and-fda.md
@@ -13,6 +13,8 @@ Secret storage sits behind `SecretStore` (`Core/Sources/ResticStationCore/Secret
 
 `RESTIC_STATION_SECRET_BACKEND=keychain|file` overrides the platform default; an unrecognised value is a hard error, never a silent fallback. Both backends key on the destination UUID lowercased, and on `"<uuid>-env"` for the secret-env JSON blob, so the two are structurally comparable. §1–§4 below are macOS; §5 is the file backend.
 
+**Every user-facing string about secret storage is chosen by the backend in use, not by the host OS.** `SecretStore.backend` reports which one a store is, and all the wording (`displayName`, `unavailableSummary`, `unavailableAdvice`, `unavailableProbeReason`) lives on `SecretBackend`. This matters because macOS-with-the-file-backend is a supported configuration: telling that user to "unlock your login keychain" when their `secrets.json` mode was widened sends them down the wrong path during an incident. The one exception is `ResticRunnerError.userFacingMessage`, a property on an error value with no store to ask — it uses `SecretBackend.configured`, which reads the same environment every store is built from.
+
 ## 1. Keychain: the `security`-CLI ACL strategy
 
 ### The trap
@@ -156,7 +158,10 @@ A tick and an interactive `secret set` can run at the same time. Every read-modi
 
 Same seam as macOS — `RESTIC_PASSWORD_COMMAND` / `RESTIC_FROM_PASSWORD_COMMAND`, deliberately *not* a plain `RESTIC_PASSWORD` env var (restic's support for a `RESTIC_FROM_PASSWORD` non-`_COMMAND` variant is not something to assume, and the command seam is already proven here). The command is `<absolute-helper-path> print-password --dest <uuid>`; restic runs it as a child and reads the password off its stdout, with no trailing newline.
 
-The helper's own path comes from `/proc/self/exe` on Linux — the kernel's answer, correct even when invoked through a symlink or a `PATH` lookup — and **never** from `CommandLine.arguments[0]`, which is attacker-controlled and would be a straightforward code-execution hole in a string restic is about to execute.
+**Which binary goes in that command is the caller's decision, not a default.** `SecretStoreFactory.make(paths:runner:helperExecutablePath:environment:)` requires the path, because "this executable" is right only inside the helper. The app process builds a store too — restore browsing, `mount`, primary `init` — and a default there would name the SwiftUI app binary, handing restic a child that cannot print a password and might try to open a UI. So:
+
+- the **helper** passes `FileSecretStore.currentExecutablePath()`, which reads `/proc/self/exe` on Linux (the kernel's answer, correct even when invoked through a symlink or a `PATH` lookup) and `_NSGetExecutablePath` + `realpath` on Darwin. **Never** `CommandLine.arguments[0]`, which is attacker-controlled and would be a straightforward code-execution hole in a string restic is about to execute; and never `Bundle.main.executablePath`, which for a tool inside an `.app` bundle's `Contents/MacOS/` names the *app*.
+- the **app** passes `HelperInvoker.helperURL.path` — the embedded `restic-station-helper`, the same binary the LaunchAgent's `BundleProgram` points at.
 
 Because `ResticRunner` *replaces* restic's environment, that child would otherwise resolve the default data directory with the platform-default backend. `FileSecretStore.passwordCommandEnvironment` therefore contributes `RESTIC_STATION_DATA_DIR` and `RESTIC_STATION_SECRET_BACKEND=file` to the assembled environment (the keychain backend contributes nothing, which is why macOS's environment is byte-identical to what it was before this abstraction existed).
 

--- a/docs/restic-cli.md
+++ b/docs/restic-cli.md
@@ -9,11 +9,28 @@ Everything in this document was **verified against restic 0.18.1 on macOS (arm64
 - Environment assembled per destination, replacing the inherited env with a minimal one:
   - `HOME`, `USER`, `TMPDIR` passed through (restic/keychain need them)
   - `PATH=/usr/bin:/bin:/usr/sbin:/sbin` — fixed, not inherited; restic's `sftp:` backend locates `ssh` via PATH. Overridable per destination via `nonSecretEnv` (e.g. prepend `/opt/homebrew/bin` for an `rclone:` backend)
-  - `RESTIC_PASSWORD_COMMAND=/usr/bin/security find-generic-password -s restic-station -a <dest-uuid-lowercase> -w`
+  - `RESTIC_PASSWORD_COMMAND` — produced by the active `SecretStore` (T23), **not** hard-coded:
+    - keychain backend (macOS default): `/usr/bin/security find-generic-password -s restic-station -a <dest-uuid-lowercase> -w`
+    - file backend (Linux default; opt-in on macOS via `RESTIC_STATION_SECRET_BACKEND=file`): `<absolute-helper-path> print-password --dest <dest-uuid-lowercase>`
+  - the active `SecretStore`'s `passwordCommandEnvironment` — empty for the keychain backend, and `RESTIC_STATION_DATA_DIR` + `RESTIC_STATION_SECRET_BACKEND=file` for the file backend. **This is load-bearing:** we replace restic's environment, restic's password-command child inherits the replaced environment, and that child is another copy of our own helper which resolves its store from its own environment. Without these two variables it would read the *default* data directory with the *platform-default* backend and fail to find a password this process just read successfully.
   - `RESTIC_CACHE_DIR=~/Library/Caches/net.herila.ResticStation/restic` (expanded)
   - `Destination.nonSecretEnv` entries
-  - secret env from keychain item `<uuid>-env` (a JSON dict, fetched by our code and injected as real env vars — restic's password-command mechanism only covers the repo password, not e.g. `AWS_SECRET_ACCESS_KEY`)
-- `RESTIC_PASSWORD_COMMAND` is word-split by restic itself (not `sh -c`); the fixed form above contains no characters needing quoting. Never build it from user input.
+  - secret env from the store's `<uuid>-env` item (a JSON dict, fetched by our code and injected as real env vars — restic's password-command mechanism only covers the repo password, not e.g. `AWS_SECRET_ACCESS_KEY`)
+- `RESTIC_PASSWORD_COMMAND` is word-split by restic itself (not `sh -c`). Never build it from user input.
+
+  **Splitting rules, verified empirically against restic 0.18.1 (T23)** — restic uses its own shell-like splitter, so the exact capabilities matter once a path can contain a space:
+
+  | Form | Result |
+  |---|---|
+  | `/usr/bin/security find-generic-password …` (no metacharacters) | works — this is the keychain backend's fixed form |
+  | `"/path/with spaces/helper" print-password --dest <uuid>` | **works**; a double-quoted argument may contain spaces, single quotes, `$` and `\` literally, and unquoted arguments may follow it |
+  | `'/path/with spaces/helper'` | works — single quotes behave the same |
+  | `/path/with spaces/helper` (unquoted) | fails: `fork/exec /path/with: no such file or directory` |
+  | `'/path/it'\''s/helper'` (POSIX escape) | **fails** — restic's splitter has no backslash escape |
+  | `"/path/with a \" quote/helper"` | fails: `double-quoted string not terminated` — a path containing `"` cannot be expressed at all |
+
+  `FileSecretStore.quoteForRestic(_:)` therefore double-quotes the helper path only when it contains a character outside `[A-Za-z0-9/._+=:,@-]`, so the common case emits the same unquoted shape the keychain backend does. A helper path containing a literal `"` is unrepresentable and is documented as such rather than worked around.
+- restic trims a trailing newline from the password command's output, but `print-password` deliberately emits none: a password that legitimately ends in a newline must round-trip through `secret set` → `print-password` unchanged.
 - Add `--json` to every command that supports it. `check` and `unlock` have no JSON mode — capture text.
 - Never pass `--no-lock`.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -30,7 +30,11 @@ final class FakeProcessRunner: ProcessRunning, @unchecked Sendable {
 }
 ```
 
-Conventions: every ResticRunner/KeychainClient/Engine test asserts BOTH the argv/env sent AND the behavior given the scripted reply. Env assertions always check: `RESTIC_PASSWORD_COMMAND` exact string, secret-env injection, `RESTIC_CACHE_DIR` presence, and that the inherited environment was NOT passed through.
+Conventions: every ResticRunner/SecretStore/Engine test asserts BOTH the argv/env sent AND the behavior given the scripted reply. Env assertions always check: `RESTIC_PASSWORD_COMMAND` exact string, secret-env injection, `RESTIC_CACHE_DIR` presence, and that the inherited environment was NOT passed through.
+
+Secrets are injected as a `FakeSecretStore`, not scripted as `/usr/bin/security` subprocesses: since T23 the store is behind the `SecretStore` protocol, so a runner/engine test's process script contains restic calls and nothing else. The keychain backend's own argv is asserted in `KeychainSecretStoreTests` (macOS only); the shared semantics both backends must honour are in `SecretStoreConformanceTests`, which runs `FileSecretStore` on **every** platform — that is how the Linux secrets path gets real coverage from a macOS run.
+
+`scripts/secret-cli-test.sh` is the Layer-2 test for secrets: it drives the real helper binary with `RESTIC_STATION_SECRET_BACKEND=file`, asserts `secrets.json` is `0600`, asserts `print-password` returns the exact bytes with `cmp`/`od`, and (when restic is on PATH) runs a real backup and then greps the whole data directory to prove the password reached no log, run record or state file.
 
 ### Fixture conventions
 `Core/Tests/ResticStationCoreTests/Fixtures/` — copied verbatim from `docs/fixtures/` (captured from restic 0.18.1; see restic-cli.md). Load via `Bundle.module` (declare `resources: [.copy("Fixtures")]` in Package.swift). Every parser has a test decoding its fixture; NDJSON parsers additionally get a partial-line-buffering test (feed the fixture in random-sized chunks, expect identical parse) and an unknown-`message_type` tolerance test.

--- a/scripts/secret-cli-test.sh
+++ b/scripts/secret-cli-test.sh
@@ -1,0 +1,274 @@
+#!/bin/bash
+# scripts/secret-cli-test.sh — end-to-end verification of the `secret`
+# subcommands and of `FileSecretStore` (T23 / issue #25).
+#
+# Everything here runs against the FILE backend
+# (`RESTIC_STATION_SECRET_BACKEND=file`) on whatever host it is invoked on.
+# That is the point: the file backend is Linux's default, and forcing it on
+# macOS is how this repository verifies the Linux secrets path before T29
+# adds a Linux integration matrix.
+#
+# What it proves:
+#   1. `secret set` reads the password from a PIPE, never from argv.
+#   2. `secrets.json` is 0600 and its directory 0700.
+#   3. `print-password` returns the EXACT bytes, with no trailing newline
+#      (asserted byte-for-byte with `od`, not by string comparison).
+#   4. `secret list` output contains no secret value.
+#   5. `secret rm` is idempotent (exit 0 twice).
+#   6. A widened mode (0644) is refused with an actionable message.
+#   7. real restic authenticates via RESTIC_PASSWORD_COMMAND against
+#      FileSecretStore — both directly and through `helper run-set`.
+#   8. The password appears NOWHERE in the run log, the run index, the
+#      config, or any state file the run produced.
+#
+# Usage:
+#   scripts/secret-cli-test.sh [path-to-restic-station-helper]
+# Defaults to .build/debug/restic-station-helper (built by `swift build`).
+# Steps 7+8 are skipped when restic is not on PATH.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HELPER="${1:-$REPO_ROOT/.build/debug/restic-station-helper}"
+
+SET_ID="00000000-0000-4000-8000-0000000000C0"
+DEST_ID="00000000-0000-4000-8000-0000000000C1"
+DEST_ID_LOWER="$(printf '%s' "$DEST_ID" | tr '[:upper:]' '[:lower:]')"
+
+# Deliberately awkward: spaces, quotes, a dollar sign and a trailing space,
+# so "we read stdin raw" is a real claim and not an artifact of a tame value.
+PASSWORD='p@ss "word" with $spaces and a trailing space '
+
+WORK=""
+cleanup() {
+    local code=$?
+    [[ -n "$WORK" && -d "$WORK" ]] && rm -rf "$WORK"
+    exit "$code"
+}
+trap cleanup EXIT
+
+log()  { printf '\n=== %s ===\n' "$*"; }
+fail() { printf '\nFAILED: %s\n' "$*" >&2; exit 1; }
+ok()   { printf 'ok: %s\n' "$*"; }
+
+[[ -x "$HELPER" ]] || fail "helper not executable at $HELPER (run: swift build)"
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/restic-station-secret.XXXXXX")"
+DATA_DIR="$WORK/data"
+SOURCE_DIR="$WORK/source"
+REPO="$WORK/repo"
+mkdir -p "$DATA_DIR" "$SOURCE_DIR"
+# The data directory has to exist before this script can write config.json
+# into it, so the "created at 0700" half of the contract is asserted by the
+# FileSecretStore unit tests (which start from nothing). What this script
+# asserts is the other half, which those cannot: that a real helper process
+# never *widens* the directory it finds.
+chmod 700 "$DATA_DIR"
+echo "hello" > "$SOURCE_DIR/a.txt"
+
+export RESTIC_STATION_DATA_DIR="$DATA_DIR"
+export RESTIC_STATION_SECRET_BACKEND=file
+
+RESTIC_BIN="$(command -v restic || true)"
+
+cat > "$DATA_DIR/config.json" <<EOF
+{
+  "version": 1,
+  "resticPath": "${RESTIC_BIN:-/usr/bin/false}",
+  "showMenuBarIcon": true,
+  "sets": [
+    {
+      "id": "$SET_ID",
+      "name": "Secret CLI Set",
+      "sources": ["$SOURCE_DIR"],
+      "excludes": [],
+      "schedule": {"kind": "everyMinutes", "minutes": 5},
+      "retention": null,
+      "checkPolicy": null,
+      "stalenessWarningDays": 14,
+      "destinations": [
+        {
+          "id": "$DEST_ID",
+          "label": "Primary",
+          "repoURL": "$REPO",
+          "isPrimary": true,
+          "nonSecretEnv": {}
+        }
+      ]
+    }
+  ]
+}
+EOF
+
+SECRETS_FILE="$DATA_DIR/secrets.json"
+
+# Portable `stat` for the permission bits.
+mode_of() {
+    if stat -f '%Lp' "$1" >/dev/null 2>&1; then
+        stat -f '%Lp' "$1"
+    else
+        stat -c '%a' "$1"
+    fi
+}
+
+# ─────────────────────────────────────────────────────────────────────────
+log "1. secret set reads the password from a pipe (never argv)"
+printf '%s' "$PASSWORD" | "$HELPER" secret set --dest "$DEST_ID"
+[[ -f "$SECRETS_FILE" ]] || fail "no $SECRETS_FILE was created"
+ok "secret set stored a password"
+
+# ─────────────────────────────────────────────────────────────────────────
+log "2. file is 0600, directory is 0700"
+FILE_MODE="$(mode_of "$SECRETS_FILE")"
+DIR_MODE="$(mode_of "$DATA_DIR")"
+[[ "$FILE_MODE" == "600" ]] || fail "expected secrets.json mode 600, got $FILE_MODE"
+[[ "$DIR_MODE" == "700" ]] || fail "expected data dir mode 700, got $DIR_MODE"
+ok "secrets.json=$FILE_MODE data dir=$DIR_MODE"
+
+grep -q "\"$DEST_ID_LOWER\"" "$SECRETS_FILE" \
+    || fail "secrets.json is not keyed on the lowercased destination uuid"
+ok "keyed on the lowercased destination uuid, mirroring the keychain accounts"
+
+# ─────────────────────────────────────────────────────────────────────────
+log "3. print-password returns the exact bytes, with no trailing newline"
+# Compared as hex dumps rather than with `cmp`/`diff`: `od` is coreutils and
+# is present in every container this runs in, diffutils is not guaranteed.
+hexdump_of() { od -An -v -tx1 < "$1" | tr -d ' \n'; }
+
+"$HELPER" print-password --dest "$DEST_ID" > "$WORK/printed"
+printf '%s' "$PASSWORD" > "$WORK/expected"
+PRINTED_HEX="$(hexdump_of "$WORK/printed")"
+EXPECTED_HEX="$(hexdump_of "$WORK/expected")"
+if [[ "$PRINTED_HEX" != "$EXPECTED_HEX" ]]; then
+    echo "printed:  $PRINTED_HEX"
+    echo "expected: $EXPECTED_HEX"
+    fail "print-password did not return the exact bytes"
+fi
+# 0a is LF: the last byte must not be one.
+[[ "${PRINTED_HEX: -2}" != "0a" ]] || fail "print-password emitted a trailing newline"
+ok "byte-identical, $(wc -c < "$WORK/printed" | tr -d ' ') bytes, last byte 0x${PRINTED_HEX: -2}"
+
+# `echo` (which appends a newline) must round-trip to the same value: the
+# implementation strips exactly one trailing newline.
+echo "$PASSWORD" | "$HELPER" secret set --dest "$DEST_ID" >/dev/null
+"$HELPER" print-password --dest "$DEST_ID" > "$WORK/printed2"
+[[ "$(hexdump_of "$WORK/printed2")" == "$EXPECTED_HEX" ]] \
+    || fail "echo-piped input did not round-trip"
+ok "exactly one trailing newline is stripped from piped input"
+
+# ─────────────────────────────────────────────────────────────────────────
+log "4. secret set-env, and secret list never prints a value"
+printf '%s' '{"AWS_ACCESS_KEY_ID":"AKIAEXAMPLE","AWS_SECRET_ACCESS_KEY":"env-secret-value"}' \
+    | "$HELPER" secret set-env --dest "$DEST_ID"
+
+"$HELPER" secret list > "$WORK/list-out" 2>&1
+cat "$WORK/list-out"
+grep -q "$DEST_ID_LOWER" "$WORK/list-out" || fail "secret list did not list the destination"
+grep -q "Primary" "$WORK/list-out" || fail "secret list did not print the label"
+for forbidden in "$PASSWORD" "AKIAEXAMPLE" "env-secret-value"; do
+    if grep -qF -- "$forbidden" "$WORK/list-out"; then
+        fail "secret list leaked a secret value"
+    fi
+done
+ok "secret list names destinations only — no password, no key, no value"
+
+# set-env must reject junk with a clear message and a nonzero exit.
+set +e
+printf '%s' '["not","an","object"]' | "$HELPER" secret set-env --dest "$DEST_ID" >"$WORK/bad-env" 2>&1
+BAD_RC=$?
+set -e
+[[ $BAD_RC -eq 1 ]] || fail "expected exit 1 for a non-object set-env, got $BAD_RC"
+grep -q "array" "$WORK/bad-env" || fail "set-env error did not name the kind it got: $(cat "$WORK/bad-env")"
+ok "set-env rejects a non-object with exit 1"
+
+# ─────────────────────────────────────────────────────────────────────────
+log "5. an unknown destination exits 1"
+set +e
+"$HELPER" secret set --dest "11111111-1111-4111-8111-111111111111" </dev/null >"$WORK/unknown" 2>&1
+UNKNOWN_RC=$?
+set -e
+[[ $UNKNOWN_RC -eq 1 ]] || fail "expected exit 1 for an unknown destination, got $UNKNOWN_RC"
+ok "unknown destination → exit 1"
+
+# ─────────────────────────────────────────────────────────────────────────
+log "6. a widened mode is refused with an actionable message"
+chmod 644 "$SECRETS_FILE"
+set +e
+"$HELPER" print-password --dest "$DEST_ID" >"$WORK/widened" 2>&1
+WIDENED_RC=$?
+set -e
+cat "$WORK/widened"
+[[ $WIDENED_RC -ne 0 ]] || fail "a 0644 secrets file was read instead of refused"
+grep -q "chmod 600" "$WORK/widened" || fail "the refusal did not name the chmod to run"
+grep -qF "$SECRETS_FILE" "$WORK/widened" || fail "the refusal did not name the file"
+if grep -qF -- "$PASSWORD" "$WORK/widened"; then fail "the refusal leaked the password"; fi
+chmod 600 "$SECRETS_FILE"
+ok "0644 refused, naming the file and the fix, without echoing the secret"
+
+# ─────────────────────────────────────────────────────────────────────────
+log "7. real restic authenticates via RESTIC_PASSWORD_COMMAND"
+if [[ -z "$RESTIC_BIN" ]]; then
+    echo "restic not on PATH — skipping the restic half (T29 covers it in the Linux matrix)"
+else
+    "$RESTIC_BIN" version
+
+    # 7a. restic directly, with exactly the command FileSecretStore emits —
+    #     including its quoting rule: double-quote the helper path only when
+    #     it contains a character outside [A-Za-z0-9/._+=:,@-]. The app
+    #     bundle's path ("…/Restic Station.app/…") really does contain a
+    #     space, so this is not a hypothetical.
+    if [[ "$HELPER" =~ ^[A-Za-z0-9/._+=:,@-]+$ ]]; then
+        PWCMD="$HELPER print-password --dest $DEST_ID_LOWER"
+    else
+        PWCMD="\"$HELPER\" print-password --dest $DEST_ID_LOWER"
+    fi
+    echo "RESTIC_PASSWORD_COMMAND=[$PWCMD]"
+    RESTIC_PASSWORD_COMMAND="$PWCMD" "$RESTIC_BIN" -r "$REPO" init --json >/dev/null
+    ok "restic init opened the repo using the helper's print-password"
+
+    # 7b. the whole engine path: ResticRunner assembles the env from
+    #     FileSecretStore and restic authenticates with it.
+    "$HELPER" run-set --set "$SET_ID" --kind backup
+    SNAPSHOTS="$(RESTIC_PASSWORD_COMMAND="$PWCMD" "$RESTIC_BIN" -r "$REPO" snapshots --json)"
+    printf '%s' "$SNAPSHOTS" | grep -q '"short_id"' \
+        || fail "no snapshot after run-set: $SNAPSHOTS"
+    ok "helper run-set produced a snapshot through FileSecretStore"
+
+    # ─────────────────────────────────────────────────────────────────────
+    log "8. the password appears in no log, run record, state file or config"
+    LEAKS="$(grep -rlF -- "$PASSWORD" "$DATA_DIR" 2>/dev/null | grep -v "^$SECRETS_FILE$" || true)"
+    if [[ -n "$LEAKS" ]]; then
+        echo "$LEAKS"
+        fail "the password appeared outside secrets.json"
+    fi
+    ok "the only file containing the password is secrets.json itself"
+
+    LEAKS_ENV="$(grep -rlF "env-secret-value" "$DATA_DIR" 2>/dev/null | grep -v "^$SECRETS_FILE$" || true)"
+    if [[ -n "$LEAKS_ENV" ]]; then
+        echo "$LEAKS_ENV"
+        fail "a secret env value appeared outside secrets.json"
+    fi
+    ok "no secret-env value outside secrets.json either"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────
+log "9. secret rm is idempotent"
+"$HELPER" secret rm --dest "$DEST_ID"
+"$HELPER" secret rm --dest "$DEST_ID"
+"$HELPER" secret rm --dest "$DEST_ID" --env
+"$HELPER" secret rm --dest "$DEST_ID" --env
+ok "two removes of each kind, both exit 0"
+
+set +e
+"$HELPER" print-password --dest "$DEST_ID" >"$WORK/gone" 2>&1
+GONE_RC=$?
+set -e
+[[ $GONE_RC -eq 1 ]] || fail "expected exit 1 reading a removed password, got $GONE_RC"
+ok "the password really is gone"
+
+"$HELPER" secret list | grep -q "no destination has a stored password" \
+    || fail "secret list should report an empty store"
+ok "secret list reports an empty store"
+
+log "ALL SECRET CLI ASSERTIONS PASSED"


### PR DESCRIPTION
Abstracts secret storage behind a `SecretStore` protocol, keeps the macOS keychain backend behaviourally identical, adds a Linux file backend that needs no desktop session / keyring daemon / GPG agent, and adds terminal subcommands so secrets can be entered on a host with no GUI.

Rebased onto `0f48871` (T25), which is current `origin/main`.

## What changed

### Core — `Core/Sources/ResticStationCore/Secrets/`
- **`SecretStore.swift`** — `public protocol SecretStore: Sendable` with the six existing operations (`setPassword`/`password`/`deletePassword`, `setSecretEnv`/`secretEnv`/`deleteSecretEnv`), `passwordCommand(destId:)` promoted from `static` to an instance requirement, and one addition, `passwordCommandEnvironment` (see below). `KeychainError` is gone, replaced by a backend-neutral `SecretStoreError` with `.itemNotFound` / `.backendFailed(String)` — one live error type, no deprecated alias. Shared `SecretAccount` (key naming) and `SecretEnvBlob` (JSON encoding) mean the two backends structurally cannot drift.
- **`KeychainSecretStore.swift`** — the old `KeychainClient`, renamed via `git mv`, gated `#if os(macOS)`. Zero behavioural change: same argv, same delete-then-add, same `-T /usr/bin/security`, same exit-44 mapping, same trailing-newline trim.
- **`FileSecretStore.swift`** — `<AppPaths.root>/secrets.json`.
  - Created **at** `0600` via `open(2)`'s mode and the directory **at** `0700` via `mkdir(2)`'s — never create-then-`chmod`. A `fchmod`/`chmod` immediately after creation pins the mode against the umask; since the file was *created* at `0600` and a umask can only clear bits, it is never wider than `0600` for an instant.
  - Every read re-verifies: `open(O_RDONLY|O_NOFOLLOW)` then `fstat` **on the opened descriptor** (closing both the symlink-swap and the TOCTOU holes), refusing a symlink, a non-regular file, or any group/other permission bit with a message naming the file and the exact `chmod` to run. `0400` is accepted — the rule is "no group/other bits", not "exactly `0600`".
  - Writes: unlink any stale temp file (so `O_CREAT|O_EXCL` really creates, since `open(2)` ignores `mode` for an existing file) → write → `fsync` → `rename(2)`, under `locks/secrets.lock` (the existing `FileLock`, 10 s bounded wait). Reads take no lock — `rename(2)` is atomic. A file whose `version` is newer than this build is refused rather than overwritten.
- **`SecretBackend.swift`** — `SecretBackend` (platform default; `RESTIC_STATION_SECRET_BACKEND=keychain|file` override, unrecognised value is a hard error, empty treated as unset like every other env override here) and `SecretStoreFactory`. `keychain` off macOS is a hard error naming the fix.

### Core — consumers
- `ResticRunner` and `BackupEngine` take `any SecretStore` (parameter renamed `keychain:` → `secrets:`).
- `ResticRunnerError.keychainUnavailable` → `.secretsUnavailable`. No deprecated alias: every call site is in this repo and was updated.
- macOS user-facing strings are preserved **verbatim** behind `#if os(macOS)`: `Reachability`'s `.offline(reason: "keychain locked")` (which `SetsBadges` matches on), `ResticRunnerError.userFacingMessage`'s "Unlock your login keychain…", and `BackupEngine`'s "the login keychain could not be read for destination …". Linux gets its own wording.

### Helper
- **`Commands/Secret.swift`** — `secret set`, `secret set-env`, `secret rm [--env]`, `secret list`, plus a hidden `print-password`. Values are read from **stdin**: echo-disabled `termios` prompt on a TTY (prompt goes to stderr, since stdout may be redirected), raw to EOF from a pipe with **exactly one** trailing newline stripped. `print-password` writes raw bytes with no trailing newline and is `shouldDisplay: false`.
- `HelperContext` selects the backend in one place; a new lightweight `SecretContext` backs the `secret` subcommands so entering a password works before restic is configured (`HelperContext.make()` exits 1 without a restic path). `print-password` loads no config at all — the password path should have as few moving parts as possible.
- Adapted to T25's now-`async` `HelperContext.make()`.

### App
- Constructs the store through `SecretStoreFactory` in all five places; `MountController` mirrors `ResticRunner`'s env assembly including `passwordCommandEnvironment`. `SetsBadges` learned the Linux offline reason.

### Docs
- `docs/keychain-and-fda.md` — retitled *Secret storage, Full Disk Access, and SMAppService*, backend table up front, and a new **§5 Linux: the `secrets.json` file backend** covering why a file rather than a keyring, the on-disk shape, an explicit **threat model with its out-of-scope list spelled out** (root, the invoking user, an unencrypted disk, memory scraping), the `0600` rules, concurrency, how the password reaches restic, why the file backend does *not* reproduce macOS's argv tradeoff, terminal usage, and troubleshooting. **Filename kept** (`keychain-and-fda.md`): it is referenced from a dozen source comments, task files and other docs, and #35 had just edited it; the H1 carries the accurate title and a note explains the choice.
- `docs/restic-cli.md` — the env table now reflects the per-backend password command, documents `passwordCommandEnvironment`, and records the empirically verified `RESTIC_PASSWORD_COMMAND` splitting rules (below).
- `docs/architecture.md`, `docs/testing.md` — updated for the protocol and the new test layout.

## The one non-obvious design decision

`ResticRunner` *replaces* restic's environment, and restic's password-command child inherits that replaced environment. On the file backend that child is **another copy of our own helper**, which re-resolves its store from its own environment — so it would look in the *default* data directory with the *platform-default* backend and fail to find a password this process had just read successfully. Found while running the end-to-end script: with `RESTIC_STATION_SECRET_BACKEND=file` on macOS, `restic init` (which inherited my shell) succeeded while `helper run-set` failed.

Fix: `SecretStore.passwordCommandEnvironment`, merged into the assembled environment just before `RESTIC_PASSWORD_COMMAND` (so `nonSecretEnv` still cannot hijack it). `FileSecretStore` returns `RESTIC_STATION_DATA_DIR` + `RESTIC_STATION_SECRET_BACKEND=file`; the protocol extension returns `[:]`, so `KeychainSecretStore` contributes nothing and **macOS's assembled environment is byte-identical to before**. Both values are non-secret by construction: a path and the word "file".

Related: the helper's own path comes from `/proc/self/exe` (Linux) or `_NSGetExecutablePath` + `realpath` (Darwin) — never `argv[0]` (attacker-controlled, and this string is executed by restic), and never `Bundle.main.executablePath`, which for a tool inside `Contents/MacOS/` names the **app**, not the tool. The app-bundle case is exercised in CI.

## `RESTIC_PASSWORD_COMMAND` splitting — verified, not assumed

The file backend's command names a path that can contain a space (`…/Restic Station.app/Contents/MacOS/restic-station-helper`), so I measured restic 0.18.1's own splitter rather than guessing, and recorded it in `docs/restic-cli.md`:

| Form | Result |
|---|---|
| `"…/with spaces/helper" print-password --dest <uuid>` | works; double-quoted args may contain spaces, `'`, `$`, `\`, and unquoted args may follow |
| `'…/with spaces/helper'` | works |
| `…/with spaces/helper` unquoted | `fork/exec …/with: no such file or directory` |
| `'…/it'\''s/helper'` (POSIX escape) | **fails** — no backslash escapes |
| a path containing `"` | `double-quoted string not terminated` — unrepresentable |

`quoteForRestic(_:)` therefore double-quotes only when the path contains a character outside `[A-Za-z0-9/._+=:,@-]`, so the common case emits the same bare shape the keychain backend does. Also confirmed: restic does **not** use `sh -c`, matching what the doc already claimed.

I did **not** switch Linux to a plain `RESTIC_PASSWORD` env var — the `_COMMAND` seam is kept on both platforms, as the issue directs.

## How this was verified

### Automated (all green locally, all wired into CI)
- `swift build` + `swift test` (root, 22 tests) — includes new `SecretCommandTests` and the updated subcommand registration test.
- `swift test --package-path Core` — **369 tests, 56 suites**, up from 308.
- `./scripts/bootstrap.sh && xcodebuild -scheme "Restic Station" build CODE_SIGNING_ALLOWED=NO` — clean, no warnings.
- `scripts/integration-test.sh` (real keychain, real restic, real helper) — **ALL ASSERTIONS PASSED (27s)**. This is the direct evidence that macOS behaviour is unchanged.
- `RESTIC_STATION_KEYCHAIN_SMOKE=1 swift test --package-path Core --filter KeychainSmoke` — 2/2, real login keychain, prompt-free.

Test-layout changes:
- `ResticRunnerTests`, `ReachabilityTests` and `BackupEngineTests` now inject a `FakeSecretStore` instead of scripting `/usr/bin/security` through `FakeProcessRunner`. Their process scripts contain restic calls **and nothing else**, which both shortens them and makes them platform-independent.
- `KeychainSecretStoreTests` is the old `KeychainClientTests` with only the type name and the error-case name edited (`KeychainClient` → `KeychainSecretStore`, `KeychainError.securityCommandFailed` → `SecretStoreError.backendFailed`), plus `passwordCommand` now being called on an instance. Every assertion is unchanged.
- New `SecretStoreConformanceTests` runs the shared semantics (`.itemNotFound` on a missing password, `[:]` on a missing secret env, idempotent deletes, overwrite-not-append) against **both** backends; `FileSecretStoreTests` and `SecretBackendTests` are **not** gated to Linux. That is deliberate: forcing the file backend on macOS is the only way this repo can genuinely cover the Linux secrets path today.

### The no-secret-leak property — exactly how it was verified

Four independent layers, because "no secret leaks" is the claim most easily asserted and least easily earned:

1. **Structural.** On the Linux path a secret has exactly three legal locations: the bytes of `secrets.json`, the stdin of `secret set`/`set-env`, and the stdout of `print-password`. `secret list`'s renderer (`SecretListing.format`) is handed only ids, labels, set names and **counts** — it never receives a secret value, so it cannot print one. `SecretStoreError.backendFailed` may only carry a backend's own diagnostic text (a path, an errno, a JSON key path); `ResticRunnerError.secretsUnavailable` carries only a destination id.
2. **Unit assertions.** `FileSecretStoreTests.errorsAndPathsNeverCarrySecrets` stores a random secret, then asserts it appears in neither the password command, nor the file path, nor the lock path, nor the error raised when the mode is widened. `SecretCommandTests` asserts the `set-env` parser names the offending variable but never any value, and never echoes malformed input back. `ResticRunnerTests.fileBackendEnvironmentAssembly` asserts the password is in neither restic's argv nor its env (only the *command* is), while the secret-env blob is still injected as real variables.
3. **Process-level, against the real binary.** `scripts/secret-cli-test.sh` runs the whole flow with `RESTIC_STATION_SECRET_BACKEND=file` and a deliberately awkward password — `p@ss "word" with $spaces and a trailing space ` — asserting: `secret set` reads a **pipe**; `secrets.json` is `0600`; `print-password` returns the **exact bytes** (hex-dump comparison, not string comparison) with **no trailing newline**; `echo`-piped input round-trips (exactly one newline stripped); `secret list`'s actual stdout is grepped for the password, the access key id and the secret env value and contains **none of them**; a `0644` file is refused with a message that names the file and the `chmod` and does **not** echo the secret.
4. **Whole-data-directory scan after a real run.** After `helper run-set --kind backup` completes against a real restic repo, the script runs `grep -rlF "$PASSWORD" "$DATA_DIR"` and asserts the **only** matching file is `secrets.json` itself — covering `runs/<id>/log.txt`, `runs/index.jsonl`, `runs/<id>/metadata.json` (including `argvRedacted`), every `state/*.json`, and `config.json`. The same scan runs for the secret-env value.

Not covered by these: the macOS keychain backend still exposes `security -w <value>` in argv. That is the pre-existing, documented, accepted tradeoff — untouched, and explicitly **not** reproduced by the file backend.

### The restic-authenticates acceptance criterion

Cannot be run on a Linux host from this environment (no Linux toolchain, no container runtime). Done on macOS with `RESTIC_STATION_SECRET_BACKEND=file` against a real local restic repo, using the helper **inside the built app bundle** — whose path contains a space, so this also exercises the quoting rule and the `_NSGetExecutablePath` resolution:

```
=== 7. real restic authenticates via RESTIC_PASSWORD_COMMAND ===
restic 0.18.1 compiled with go1.25.1 on darwin/arm64
RESTIC_PASSWORD_COMMAND=["/Users/bwh/.../dd/Build/Products/Debug/Restic Station.app/Contents/MacOS/restic-station-helper" print-password --dest 00000000-0000-4000-8000-0000000000c1]
ok: restic init opened the repo using the helper's print-password
backup success (1 run)
ok: helper run-set produced a snapshot through FileSecretStore

=== 8. the password appears in no log, run record, state file or config ===
ok: the only file containing the password is secrets.json itself
ok: no secret-env value outside secrets.json either
```

Full transcript of a run against the SwiftPM-built helper:

```
=== 1. secret set reads the password from a pipe (never argv) ===
stored a password for "Primary"
ok: secret set stored a password

=== 2. file is 0600, directory is 0700 ===
ok: secrets.json=600 data dir=700
ok: keyed on the lowercased destination uuid, mirroring the keychain accounts

=== 3. print-password returns the exact bytes, with no trailing newline ===
ok: byte-identical, 46 bytes, last byte 0x20
ok: exactly one trailing newline is stripped from piped input

=== 4. secret set-env, and secret list never prints a value ===
stored 2 secret environment variable(s) for "Primary": AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
00000000-0000-4000-8000-0000000000c1  "Primary" (set "Secret CLI Set")  password, secret-env (2 variable(s))
ok: secret list names destinations only — no password, no key, no value
ok: set-env rejects a non-object with exit 1

=== 5. an unknown destination exits 1 ===
ok: unknown destination → exit 1

=== 6. a widened mode is refused with an actionable message ===
could not read the password for destination …: refusing to read …/data/secrets.json: it is
group- or world-accessible (mode 0644). Fix it with: chmod 600 …/data/secrets.json
ok: 0644 refused, naming the file and the fix, without echoing the secret

=== 9. secret rm is idempotent ===
"Primary": no password is stored any more
"Primary": no password is stored any more
"Primary": no secret environment is stored any more
"Primary": no secret environment is stored any more
ok: two removes of each kind, both exit 0
ok: the password really is gone
ok: secret list reports an empty store

=== ALL SECRET CLI ASSERTIONS PASSED ===
```

`scripts/secret-cli-test.sh` is wired into **both** CI jobs: the Linux job runs it against the SwiftPM binary (skipping the restic half — restic is not in the `swift:6.1` container), and the macOS job runs it against the app-bundle helper *with* restic, so the transcript above is reproduced on every CI run.

## Acceptance criteria

| Criterion | Status |
|---|---|
| macOS behaviour provably unchanged; existing keychain tests pass with only the type name edited | **Verified locally** — the `KeychainSecretStoreTests` diff is type/error names only; `integration-test.sh` (real keychain + real restic + real helper) fully green; keychain smoke test green |
| `swift test` green on macOS and Linux; keychain backend properly `#if os(macOS)`-scoped | macOS **verified locally** (369 Core + 22 root). Linux **verified in CI** (see checks). Note: T21 added no gates to un-gate — Core already built green on Linux; the new scoping is on `KeychainSecretStore` and its tests only |
| restic authenticates via `RESTIC_PASSWORD_COMMAND` against `FileSecretStore`, with a transcript | **Verified on macOS** with `RESTIC_STATION_SECRET_BACKEND=file` against a real repo (transcript above), and in macOS CI. **Linux-host verification deferred to #31 (T29)** — no Linux toolchain or container runtime is available here |
| No secret in argv, logs, run records, or errors on the Linux path | **Verified** — four layers, detailed above; strongest is the post-run `grep -rlF` of the whole data directory |
| `docs/keychain-and-fda.md` gains a Linux section (file backend, threat model, `0600` enforcement, contrast with the macOS ACL strategy); retitle if the filename misleads | **Done** — §5 added, doc retitled. Filename deliberately kept, with the reason stated in the doc |

### Also deferred
- Linux-host execution of anything beyond compile + unit + CLI tests (the point of #31 / T29). Everything Linux-specific here is verified by (a) the file backend running under macOS CI and locally, and (b) the Linux CI job running the unit and CLI suites.
- `FileSecretStore` under a **non-root uid on Linux with a hostile sibling user** — the threat model is documented, but only the mode enforcement is mechanically tested.
- Interactive TTY behaviour (`secret set` with echo disabled): the pipe path is asserted end to end; the `isatty` branch is exercised by hand only, since CI has no TTY.

## Scope discipline
No change to the config schema (#26), restic discovery (#27), or `AppPaths.swift` (owned elsewhere — read only; `FileSecretStore` composes its lock path from `paths.locksDir` and notes in a comment that it belongs in `AppPaths` later).

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013cEXJJ1cT4nVQAHstEjz7h
