### PR TITLE
Preserve cron paths containing backslashes and percents

### DIFF
--- a/Core/Sources/ResticStationCore/Support/SchedulerCommand.swift
+++ b/Core/Sources/ResticStationCore/Support/SchedulerCommand.swift
@@ -306,7 +306,9 @@ public enum SystemdCommand {
     /// the whole command to `/bin/sh`, where `VAR=value cmd` is ordinary
     /// one-command-scoped assignment. A crontab-level `VAR=value` line would
     /// also work but applies to every job in the file, which is not ours to
-    /// change.
+    /// change. Percent signs do not require that global escape hatch:
+    /// ``cronEscaped(_:)`` encodes the complete command field before cron
+    /// passes it to the shell.
     public static func cronFallbackLine(
         helperPath: String,
         intervalMinutes: Int = defaultIntervalMinutes,
@@ -356,14 +358,24 @@ public enum SystemdCommand {
         ShellQuoting.quoteIfNeeded(value)
     }
 
-    /// `crontab(5)`: an unescaped `%` in the command field is replaced by a
-    /// newline and everything after the first one is fed to the job on stdin.
-    /// A `%` anywhere in a path would therefore truncate the command and
-    /// schedule something that is not what it looks like — silently, since
-    /// the truncated prefix is still a valid-ish command line. cron itself
-    /// strips the backslash, so `sh` sees a plain `%`.
+    /// Encodes a shell command for Vixie cron's command-field scanner.
+    ///
+    /// The scanner in Vixie cron 3.0pl1's `do_command.c` turns `\\` into `\`,
+    /// turns `\%` into `%`, and splits the command at an unescaped `%`. Both
+    /// characters therefore need encoding: double every literal backslash
+    /// and prefix every literal percent with a backslash. Encoding only `%`
+    /// is insufficient when the shell-quoted command already has a backslash
+    /// immediately before it: the resulting `\\%` is decoded as one literal
+    /// backslash followed by an unescaped delimiter.
     static func cronEscaped(_ command: String) -> String {
-        command.replacingOccurrences(of: "%", with: "\\%")
+        var escaped = ""
+        for character in command {
+            if character == "\\" || character == "%" {
+                escaped.append("\\")
+            }
+            escaped.append(character)
+        }
+        return escaped
     }
 }
 

--- a/Core/Tests/ResticStationCoreTests/Support/SchedulerCommandTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Support/SchedulerCommandTests.swift
@@ -289,21 +289,44 @@ import Testing
             dataDirectory: "/srv/it's"
         )
         #expect(quoted.contains("'/opt/restic station/helper' tick"))
-        // The `'\''` dance: close, escaped literal quote, reopen.
-        #expect(quoted.contains("'/srv/it'\\''s'"))
+        // The `'\''` shell-quoting dance, with its backslash doubled for
+        // cron so the shell still receives exactly one.
+        #expect(quoted.contains(#"'/srv/it'\\''s'"#))
     }
 
-    @Test("a % in the command is escaped — crontab(5) turns a bare one into a newline")
-    func cronFallbackEscapesPercent() {
-        // An unescaped `%` truncates the command field and feeds the rest to
-        // the job on stdin, so the crontab would silently schedule a
-        // *different, shorter* command than the one printed.
-        let line = SystemdCommand.cronFallbackLine(
+    @Test("Vixie cron encoding preserves backslash runs and protects every percent")
+    func cronFallbackEncodesCommandField() {
+        // Vixie cron's do_command.c scanner decodes `\\` to `\`, `\%` to
+        // `%`, and splits at an unescaped `%`. The encoded command therefore
+        // needs 2n+1 backslashes before a percent that follows n literal
+        // backslashes. These exact strings cover n = 0, 1, and 2.
+        #expect(SystemdCommand.cronFallbackLine(
             helperPath: "/usr/bin/h",
             dataDirectory: "/srv/100%full"
-        )
-        #expect(line.contains("100\\%full"))
-        #expect(!line.contains("100%full"))
+        ) == #"*/2 * * * * RESTIC_STATION_DATA_DIR='/srv/100\%full' /usr/bin/h tick"#)
+
+        #expect(SystemdCommand.cronFallbackLine(
+            helperPath: "/usr/bin/h",
+            dataDirectory: #"/srv/a\%b"#
+        ) == #"*/2 * * * * RESTIC_STATION_DATA_DIR='/srv/a\\\%b' /usr/bin/h tick"#)
+
+        #expect(SystemdCommand.cronFallbackLine(
+            helperPath: "/usr/bin/h",
+            dataDirectory: #"/srv/a\\%b"#
+        ) == #"*/2 * * * * RESTIC_STATION_DATA_DIR='/srv/a\\\\\%b' /usr/bin/h tick"#)
+
+        // The encoding applies to the complete command field, not just the
+        // data-directory assignment. There is no command-field position in
+        // which a literal percent should remain unescaped.
+        #expect(SystemdCommand.cronFallbackLine(
+            helperPath: "/opt/100%/helper",
+            dataDirectory: "/srv/plain"
+        ) == #"*/2 * * * * RESTIC_STATION_DATA_DIR=/srv/plain '/opt/100\%/helper' tick"#)
+
+        // Backslashes are decoded by the same scanner even when no percent
+        // follows, so they must be doubled everywhere to reach /bin/sh
+        // unchanged.
+        #expect(SystemdCommand.cronEscaped(#"/srv/a\\b"#) == #"/srv/a\\\\b"#)
     }
 }
 


### PR DESCRIPTION
## Evidence first

I verified the rule by reading the maintained Debian Vixie cron 3.0pl1 source, not by inferring from the man page and not on a live cron host. The command scanner is in [`do_command.c` lines 201–217](https://sources.debian.org/src/cron/3.0pl1-197/do_command.c/#L201), rather than `load_entry()`.

The scanner uses a one-character escape state:

- `\\` followed by `\\` is collapsed to one literal backslash
- `\\` followed by `%` is collapsed to one literal percent
- an unescaped `%` terminates the command and starts stdin data

Therefore preserving an arbitrary intended shell command requires encoding both scanner-significant characters: every literal backslash becomes `\\\\`, and every literal percent becomes `\\%`. For a percent following n intended backslashes, the crontab contains 2n+1 backslashes, which decodes back to the original n backslashes plus a literal percent.

## What changed

- encode all literal backslashes as well as all literal percents in the complete cron command field
- add exact regression cases for ordinary paths, `%`, `\\%`, `\\\\%`, percent in the helper path, backslashes away from percent, and the existing shell single-quote escape
- document the verified Vixie scanner behavior next to the encoder

Scheduler behavior outside the Linux-gated cron fallback is unchanged.

## Inline assignment vs crontab-level assignment

This keeps `RESTIC_STATION_DATA_DIR=... helper tick` inline and one-command-scoped. The existing objection to a crontab-level assignment remains valid: such a line changes the environment of every later job in a user's crontab, which is broader than Restic Station owns.

A conditional crontab-level escape hatch is unnecessary because the source-verified command-field encoding is complete and reversible for both backslashes and percents. Every percent in the generated command field is intended literally, including one in the helper path, so there is no positional case where this encoder should leave a percent unescaped.

## Validation

The host has no Swift executable (`swift --version` returned `command not found`). I used the exact oldest-supported `swift:6.1` CI image:

- root `swift build` — passed
- root `swift test` — 112 tests passed
- `swift test --package-path Core` — 542 tests passed

Red-check: I temporarily restored the old blind `%` replacement and ran the focused regression test. It failed in three places: one-backslash-before-percent, two-backslashes-before-percent, and a backslash run away from percent. I then restored the fix and reran the full suites above successfully.

`Helper/Sources/Commands/Status.swift` and `Core/Sources/ResticStationCore/Support/HealthDerivation.swift` were not touched.

Fixes #53