### PR TITLE
Snapshot status liveness once per invocation

### DIFF
--- a/Helper/Sources/Commands/Status.swift
+++ b/Helper/Sources/Commands/Status.swift
@@ -87,6 +87,18 @@ struct Status: AsyncParsableCommand {
                 currentRuns[setId] = state
             }
         }
+
+        // One point-in-time answer per run, captured before the scheduler
+        // probe below can spend time in subprocesses. A run may finish while
+        // that probe is in flight, so this snapshot can intentionally be
+        // stale by the time the report prints. Reusing it is what guarantees
+        // the JSON body, human rendering, health and exit code all describe
+        // the same instant instead of contradicting one another.
+        let isRunAbandoned = Self.abandonedRunPredicate(
+            currentRuns: currentRuns,
+            liveness: runStore.liveness(ofCurrentRun:)
+        )
+
         var repoStatuses: [UUID: RepoStatus] = [:]
         for (_, destination) in scheduled.destinations {
             if let status = stateStore.readRepoStatus(destId: destination.id) {
@@ -94,13 +106,6 @@ struct Status: AsyncParsableCommand {
             }
         }
         let scheduleState = stateStore.readScheduleState()
-
-        // A `current-run-*.json` left behind by a killed process is not a run
-        // in flight. Passed to both derivations so the two halves of the
-        // health decision cannot disagree — see `RunStore.liveness`.
-        let isRunAbandoned: (CurrentRunState) -> Bool = {
-            runStore.liveness(ofCurrentRun: $0) == .abandoned
-        }
 
         let setHealths = HealthDerivation.setHealths(
             config: scheduled.config,
@@ -203,6 +208,23 @@ struct Status: AsyncParsableCommand {
             isRunAbandoned: isRunAbandoned
         )
         HelperExit.code(needsAttention ? 1 : 0)
+    }
+
+    /// Captures one liveness answer per run ID and returns the predicate all
+    /// health derivations in one `status` invocation share. Keying by run ID
+    /// also avoids repeating the process probe if malformed state contains
+    /// the same run under more than one set ID.
+    static func abandonedRunPredicate(
+        currentRuns: [UUID: CurrentRunState],
+        liveness: (CurrentRunState) -> CurrentRunLiveness
+    ) -> (CurrentRunState) -> Bool {
+        var livenessByRunId: [String: CurrentRunLiveness] = [:]
+        for run in currentRuns.values where livenessByRunId[run.runId] == nil {
+            livenessByRunId[run.runId] = liveness(run)
+        }
+        return { run in
+            livenessByRunId[run.runId] == .abandoned
+        }
     }
 
     /// Is anything actually going to fire the tick on this host?

--- a/Helper/Tests/HelperTests/StatusLivenessTests.swift
+++ b/Helper/Tests/HelperTests/StatusLivenessTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Testing
+
+import ResticStationCore
+@testable import restic_station_helper
+
+@Suite("status liveness snapshot")
+struct StatusLivenessTests {
+    @Test("one liveness answer is reused across every health consumer")
+    func oneAnswerIsReused() {
+        let setId = UUID(uuidString: "6F9619FF-8B86-D011-B42D-00C04FC964FF")!
+        let duplicateSetId = UUID(uuidString: "0A1B2C3D-4E5F-4A1B-8C1D-000000000001")!
+        let run = CurrentRunState(
+            runId: "run-that-finishes-during-the-scheduler-probe",
+            kind: .backup,
+            phase: "backing-up-primary",
+            percentDone: 0.5,
+            bytesDone: 1,
+            totalBytes: 2,
+            filesDone: 1,
+            totalFiles: 2,
+            currentFiles: [],
+            updatedAt: Date()
+        )
+        var evaluations = 0
+        let isRunAbandoned = Status.abandonedRunPredicate(
+            currentRuns: [setId: run, duplicateSetId: run]
+        ) { _ in
+            evaluations += 1
+            // Model a process that is live at snapshot time and gone on every
+            // later query. The old predicate re-ran this check three times.
+            return evaluations == 1 ? .live : .abandoned
+        }
+
+        #expect(evaluations == 1)
+        #expect(!isRunAbandoned(run)) // setHealths
+        #expect(!isRunAbandoned(run)) // appHealth
+        #expect(!isRunAbandoned(run)) // hasWarningConditions / exit code
+        #expect(evaluations == 1)
+    }
+}


### PR DESCRIPTION
## Summary

- evaluate each current run's process liveness once, immediately after loading the current-run files
- reuse that point-in-time snapshot for set health, overall health, rendering, and the exit-code warning decision
- key the snapshot by run ID so duplicate malformed state does not repeat the process probe
- document the intentional tradeoff: a run that finishes during the scheduler probe may appear live in this invocation, but every output from the invocation remains self-consistent

## Root cause

`Status.run()` passed a closure that called `RunStore.liveness` afresh into three health decisions around the asynchronous Linux scheduler probe. If a run finished during that window, the report could preserve `isRunning: true` and `health: "running"` from the first evaluation while the later exit-code evaluation saw an abandoned run and exited 1.

## Test

The regression test uses a liveness evaluator that returns `.live` once and `.abandoned` thereafter, modeling a process that exits during the scheduler probe. It verifies that snapshot construction evaluates once and that all later health consumers reuse the live answer.

Red-check: temporarily restored the old live predicate. The test failed with zero evaluations at snapshot construction, three later evaluations, and the answer changing to abandoned. Restored the snapshot and reran the final suites.

## Validation

The host has no Swift executable, so validation used the oldest-supported `swift:6.1` container:

- `swift test` — 113 Helper tests passed
- `swift test --package-path Core` — 551 Core tests passed
- `git diff --check` — passed

Fixes #57