### PR TITLE
Explain current runs for deleted sets

### DIFF
--- a/Helper/Sources/Commands/Status.swift
+++ b/Helper/Sources/Commands/Status.swift
@@ -172,6 +172,24 @@ struct Status: AsyncParsableCommand {
             )
         }
 
+        // A current-run file can outlive the set it belonged to. It still
+        // contributes to app health and the exit code, so omitting it from
+        // the report would make those verdicts impossible to explain.
+        // Reuse the point-in-time liveness snapshot above: this must not
+        // re-probe a process after the scheduler subprocesses have run.
+        let configuredSetIds = Set(scheduled.config.sets.map(\.id))
+        let unattributedRuns: [StatusReport.UnattributedRun] = currentRuns
+            .filter { !configuredSetIds.contains($0.key) }
+            .sorted { $0.key.uuidString < $1.key.uuidString }
+            .map { setId, run in
+                StatusReport.UnattributedRun(
+                    setId: setId,
+                    liveness: isRunAbandoned(run) ? .abandoned : .live,
+                    currentRun: StatusReport.CurrentRunSummary(run),
+                    currentRunFile: paths.currentRunFile(setId: setId).path
+                )
+            }
+
         let excludedHere: [StatusReport.Exclusion] = scheduled.omissions.map { omission in
             StatusReport.Exclusion(omission: omission)
         }
@@ -183,6 +201,7 @@ struct Status: AsyncParsableCommand {
             fullDiskAccessDenied: fdaDenied,
             scheduler: scheduler,
             sets: sets,
+            unattributedRuns: unattributedRuns,
             excludedHere: excludedHere
         )
 
@@ -338,8 +357,7 @@ struct StatusReport: Encodable {
         let filesDone: Int
         let totalFiles: Int
 
-        init?(_ state: CurrentRunState?) {
-            guard let state else { return nil }
+        init(_ state: CurrentRunState) {
             runId = state.runId
             kind = state.kind.rawValue
             phase = state.phase
@@ -349,6 +367,26 @@ struct StatusReport: Encodable {
             filesDone = state.filesDone
             totalFiles = state.totalFiles
         }
+
+        init?(_ state: CurrentRunState?) {
+            guard let state else { return nil }
+            self.init(state)
+        }
+    }
+
+    /// A `current-run-<setId>.json` whose set is absent from this machine's
+    /// resolved configuration. These runs still affect global health; this
+    /// record makes that effect attributable in JSON and human output.
+    struct UnattributedRun: Encodable {
+        enum Liveness: String, Encodable {
+            case live
+            case abandoned
+        }
+
+        let setId: UUID
+        let liveness: Liveness
+        let currentRun: CurrentRunSummary
+        let currentRunFile: String
     }
 
     struct DestinationStatus: Encodable {
@@ -499,10 +537,12 @@ struct StatusReport: Encodable {
     let fullDiskAccessDenied: Bool
     let scheduler: SchedulerStatus?
     let sets: [SetStatus]
+    let unattributedRuns: [UnattributedRun]
     let excludedHere: [Exclusion]
 
     private enum CodingKeys: String, CodingKey {
-        case machineId, generatedAt, health, fullDiskAccessDenied, scheduler, sets, excludedHere
+        case machineId, generatedAt, health, fullDiskAccessDenied, scheduler, sets
+        case unattributedRuns, excludedHere
     }
 
     // Explicit `null` for `scheduler` — see
@@ -517,6 +557,7 @@ struct StatusReport: Encodable {
         try container.encode(fullDiskAccessDenied, forKey: .fullDiskAccessDenied)
         try container.encode(scheduler, forKey: .scheduler)
         try container.encode(sets, forKey: .sets)
+        try container.encode(unattributedRuns, forKey: .unattributedRuns)
         try container.encode(excludedHere, forKey: .excludedHere)
     }
 
@@ -588,6 +629,24 @@ struct StatusReport: Encodable {
                 let error = destination.lastError.map { " (\($0))" } ?? ""
                 let staleFlag = destination.stale ? ", STALE" : ""
                 lines.append("      - \(role) \"\(destination.label)\": \(reach)\(error)\(staleFlag)")
+            }
+        }
+
+        if !unattributedRuns.isEmpty {
+            lines.append("")
+            lines.append("current runs for sets no longer configured:")
+            for item in unattributedRuns {
+                let run = item.currentRun
+                let state = item.liveness == .abandoned ? "ABANDONED" : "LIVE"
+                lines.append(
+                    "  - \(state): \(run.kind) run \(run.runId) for set "
+                        + "\(item.setId.uuidString.lowercased()) "
+                        + "(\(run.phase), \(run.percentDone)%)"
+                )
+                let cleanup = item.liveness == .abandoned
+                    ? "the next tick clears it; to clear it now: "
+                    : "the running helper should clear it when it finishes; to clear it now: "
+                lines.append("    \(cleanup)rm \(ShellQuoting.quoteIfNeeded(item.currentRunFile))")
             }
         }
 

--- a/Helper/Tests/HelperTests/StatusReportTests.swift
+++ b/Helper/Tests/HelperTests/StatusReportTests.swift
@@ -110,7 +110,7 @@ struct StatusReportTests {
     func healthyReportHasNoFlags() {
         let report = StatusReport(
             machineId: "studio-mac", generatedAt: Date(), health: "idle", fullDiskAccessDenied: false, scheduler: nil,
-            sets: [makeSetStatus(needsAttention: false, isRunning: false)], excludedHere: []
+            sets: [makeSetStatus(needsAttention: false, isRunning: false)], unattributedRuns: [], excludedHere: []
         )
         let lines = report.humanLines().joined(separator: "\n")
         #expect(!lines.contains("NEEDS ATTENTION"))
@@ -120,7 +120,7 @@ struct StatusReportTests {
     func warningReportFlagsTheSet() {
         let report = StatusReport(
             machineId: "studio-mac", generatedAt: Date(), health: "warning", fullDiskAccessDenied: false, scheduler: nil,
-            sets: [makeSetStatus(needsAttention: true, isRunning: false)], excludedHere: []
+            sets: [makeSetStatus(needsAttention: true, isRunning: false)], unattributedRuns: [], excludedHere: []
         )
         let lines = report.humanLines().joined(separator: "\n")
         #expect(lines.contains("NEEDS ATTENTION"))
@@ -134,7 +134,7 @@ struct StatusReportTests {
         let omission = ResolvedOmission(subject: .backupSet, id: setId, name: "Photos", reason: .disabledForMachine)
         let report = StatusReport(
             machineId: "mirror-box", generatedAt: Date(), health: "idle", fullDiskAccessDenied: false, scheduler: nil,
-            sets: [], excludedHere: [StatusReport.Exclusion(omission: omission)]
+            sets: [], unattributedRuns: [], excludedHere: [StatusReport.Exclusion(omission: omission)]
         )
         let lines = report.humanLines().joined(separator: "\n")
         #expect(lines.contains("excluded here, and why"))
@@ -148,7 +148,7 @@ struct StatusReportTests {
         let report = StatusReport(
             machineId: "studio-mac", generatedAt: Date(timeIntervalSince1970: 0), health: "idle",
             fullDiskAccessDenied: false, scheduler: nil, sets: [makeSetStatus(needsAttention: false, isRunning: false)],
-            excludedHere: []
+            unattributedRuns: [], excludedHere: []
         )
         let data = try ConfigStore.makeEncoder().encode(report)
         let text = String(decoding: data, as: UTF8.self)
@@ -157,9 +157,35 @@ struct StatusReportTests {
         #expect(text.contains("\"lastPrune\" : null"))
         #expect(text.contains("\"currentRun\" : null"))
         #expect(text.contains("\"lastSyncedAt\" : null"))
+        #expect(text.contains("\"unattributedRuns\" : ["))
         // `reachable: false` is a real, known value here — not null — but
         // "not yet probed" (nil) must still round-trip as explicit null
         // elsewhere; covered by encoding a destination with no repo-status.
+    }
+
+    @Test("an unattributed abandoned run renders with a named, shell-quoted cleanup path")
+    func unattributedRunsRender() {
+        let run = CurrentRunState(
+            runId: "orphaned-run", kind: .backup, phase: "backing-up-primary", percentDone: 0.5,
+            bytesDone: 1, totalBytes: 2, filesDone: 1, totalFiles: 2, currentFiles: [], updatedAt: Date()
+        )
+        let path = "/tmp/status state;safe/current-run.json"
+        let report = StatusReport(
+            machineId: "studio-mac", generatedAt: Date(), health: "warning",
+            fullDiskAccessDenied: false, scheduler: nil, sets: [],
+            unattributedRuns: [
+                StatusReport.UnattributedRun(
+                    setId: setId, liveness: .abandoned,
+                    currentRun: StatusReport.CurrentRunSummary(run), currentRunFile: path
+                ),
+            ],
+            excludedHere: []
+        )
+
+        let lines = report.humanLines().joined(separator: "\n")
+        #expect(lines.contains("current runs for sets no longer configured"))
+        #expect(lines.contains("ABANDONED: backup run orphaned-run"))
+        #expect(lines.contains("rm '/tmp/status state;safe/current-run.json'"))
     }
 
     @Test("a never-probed destination's reachable/lastSyncedAt/lastError all encode null, not false/omitted")

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -510,11 +510,14 @@ Two things `status` will **not** do quietly, both of which used to make it repor
       ]
     }
   ],
+  "unattributedRuns": [],
   "excludedHere": []
 }
 ```
 
 `health`: `"idle"` | `"running"` | `"warning"` (`AppHealth.rawValue`). Exit code: **0** for `idle`/`running`, **1** for `warning` — usable directly as a Nagios/Icinga-style check. `lastBackup`/`lastCheck`/`lastPrune` are `null` before any attempt of that kind; `reachable` is `null` — never `false` — for a destination that has not been probed yet (`state/repo-status-<destId>.json` absent), the same "absent means not yet known, never a definite negative" rule `fda-check.json` uses. `excludedHere` has the same shape as `config show`'s.
+
+`unattributedRuns` contains any `current-run-<setId>.json` whose set is no longer in this machine's resolved configuration. Each entry carries the missing `setId`, `liveness` (`"live"` or `"abandoned"`), the usual `currentRun` summary, and the exact `currentRunFile`. These runs still determine top-level health and the exit code, so an empty `sets` array never leaves their effect unexplained. Human output names the same run and prints a shell-quoted cleanup command.
 
 ### `sets list --json`
 

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -857,6 +857,9 @@ $ restic-station-helper status --json
       "needsAttention" : false,
       "nextDue" : "2026-08-06T23:08:33.941Z"
     }
+  ],
+  "unattributedRuns" : [
+
   ]
 }
 (exit 1)
@@ -1001,6 +1004,9 @@ $ restic-station-helper status --json; echo "exit $?"
       "needsAttention" : false,
       "nextDue" : "2026-08-06T23:10:01.983Z"
     }
+  ],
+  "unattributedRuns" : [
+
   ]
 }
 exit 1

--- a/scripts/headless-cli-test.sh
+++ b/scripts/headless-cli-test.sh
@@ -339,6 +339,44 @@ echo "$(cat "$OUT_FILE")" | jq -e '.sets[0].abandonedRun.runId == "r-dead"' >/de
     || fail "abandoned fixture did not name the abandoned run"
 ok "abandoned fixture: status --json exits 1, health=warning, the dead run is named"
 
+# --- unattributed: current-run files whose sets were deleted from config. ---
+# These still determine global health and the exit code, so both a live and
+# an abandoned one must remain visible even though `sets[]` has nowhere to
+# carry them. A punctuation-heavy data dir red-checks the printed rm command.
+UNATTRIBUTED="$WORK/status unattributed; safe"
+make_status_fixture "$UNATTRIBUTED"
+jq '.sets = []' "$UNATTRIBUTED/config.json" > "$UNATTRIBUTED/config.json.tmp"
+mv "$UNATTRIBUTED/config.json.tmp" "$UNATTRIBUTED/config.json"
+UNATTRIBUTED_LIVE_SET_ID="10000000-0000-4000-8000-000000000001"
+UNATTRIBUTED_DEAD_SET_ID="20000000-0000-4000-8000-000000000002"
+mkdir -p "$UNATTRIBUTED/runs/r-unattributed-live"
+cat > "$UNATTRIBUTED/runs/r-unattributed-live/metadata.json" <<EOF
+{"runId":"r-unattributed-live","kind":"backup","setId":"$UNATTRIBUTED_LIVE_SET_ID","destId":"$PRIMARY_ID","groupId":"r-unattributed-live","status":"running","trigger":"manual","start":"$NOW_ISO","end":null,"pid":$$,"resticExitCode":null,"argvRedacted":[],"snapshotId":null,"filesNew":null,"filesChanged":null,"dataAdded":null,"errorSummary":null,"stats":null}
+EOF
+cat > "$UNATTRIBUTED/state/current-run-$UNATTRIBUTED_LIVE_SET_ID.json" <<EOF
+{"runId":"r-unattributed-live","kind":"backup","phase":"backing-up-primary","percentDone":0.25,"bytesDone":1,"totalBytes":4,"filesDone":1,"totalFiles":4,"currentFiles":[],"updatedAt":"$NOW_ISO"}
+EOF
+cat > "$UNATTRIBUTED/state/current-run-$UNATTRIBUTED_DEAD_SET_ID.json" <<EOF
+{"runId":"r-unattributed-dead","kind":"backup","phase":"backing-up-primary","percentDone":0.5,"bytesDone":2,"totalBytes":4,"filesDone":2,"totalFiles":4,"currentFiles":[],"updatedAt":"$NOW_ISO"}
+EOF
+RESTIC_STATION_DATA_DIR="$UNATTRIBUTED" run_helper status --json
+expect_rc 1
+echo "$(cat "$OUT_FILE")" | jq -e '
+    (.sets | length) == 0
+    and (.unattributedRuns | length) == 2
+    and any(.unattributedRuns[]; .currentRun.runId == "r-unattributed-live" and .liveness == "live")
+    and any(.unattributedRuns[]; .currentRun.runId == "r-unattributed-dead" and .liveness == "abandoned")
+' >/dev/null || fail "unattributed live/abandoned runs were not both explained in JSON"
+RESTIC_STATION_DATA_DIR="$UNATTRIBUTED" run_helper status
+expect_rc 1
+grep -qF "LIVE: backup run r-unattributed-live" "$OUT_FILE" \
+    || fail "human status did not name the unattributed live run"
+grep -qF "ABANDONED: backup run r-unattributed-dead" "$OUT_FILE" \
+    || fail "human status did not name the unattributed abandoned run"
+grep -qF "rm '$UNATTRIBUTED/state/current-run-$UNATTRIBUTED_DEAD_SET_ID.json'" "$OUT_FILE" \
+    || fail "human status did not shell-quote the unattributed run cleanup path"
+ok "unattributed fixture: live and abandoned runs explain global health in JSON and human output"
+
 # --- failed: last backup failed. ---
 FAILED="$WORK/status-failed"
 make_status_fixture "$FAILED"


### PR DESCRIPTION
## Summary

- add a top-level `unattributedRuns` array to `status --json` for current-run files whose sets are absent from the resolved configuration
- report both live and abandoned liveness from the single point-in-time snapshot introduced by #64
- render the same runs in human output with their set IDs, state files, and shell-quoted cleanup commands
- document the JSON shape and update the Linux transcript examples

## Root cause

Global health and the exit code intentionally consider every current-run file, including one for a set no longer configured. `sets[]` only contains resolved configured sets, so those runs could affect the verdict without appearing anywhere in the report.

## Validation

- `swift test` — 71 tests passed
- `./scripts/headless-cli-test.sh` — all assertions passed, including live and abandoned unattributed-run fixtures
- `bash -n scripts/headless-cli-test.sh`
- `git diff --check`

Fixes #56