### PR TITLE
Warn when the first backup is overdue

### DIFF
--- a/App/Sources/ViewModels/AppModel.swift
+++ b/App/Sources/ViewModels/AppModel.swift
@@ -380,6 +380,7 @@ final class AppModel: ObservableObject {
             scheduleState: stateWatcher.scheduleState,
             now: currentDate,
             calendar: calendar,
+            visibleSince: paths.configurationVisibleSince(),
             isRunAbandoned: isRunAbandoned
         )
         appHealth = HealthDerivation.appHealth(

--- a/Core/Sources/ResticStationCore/Config/AppPaths.swift
+++ b/Core/Sources/ResticStationCore/Config/AppPaths.swift
@@ -99,6 +99,20 @@ public struct AppPaths: Equatable, Sendable {
         root.appendingPathComponent("machine.json", isDirectory: false)
     }
 
+    /// When this machine could first have seen its current configuration,
+    /// approximated by the later mtime of the shared config and host-local
+    /// machine files. Missing or unreadable mtimes are ignored; `nil` means
+    /// callers must not derive an age-based warning from filesystem state
+    /// they could not establish.
+    public func configurationVisibleSince(fileManager: FileManager = .default) -> Date? {
+        [configFile, machineFile].compactMap { file in
+            guard let attributes = try? fileManager.attributesOfItem(atPath: file.path) else {
+                return nil
+            }
+            return attributes[.modificationDate] as? Date
+        }.max()
+    }
+
     // MARK: - runs/
 
     public var runsDir: URL {

--- a/Core/Sources/ResticStationCore/Scheduling/ScheduleMath.swift
+++ b/Core/Sources/ResticStationCore/Scheduling/ScheduleMath.swift
@@ -11,6 +11,22 @@ import Foundation
 /// Linux-safe.
 public enum ScheduleMath {
 
+    /// Approximate elapsed period used only for the first-backup grace
+    /// window. Wall-clock schedules still use `Calendar` for their actual
+    /// due instants; here a stable duration is deliberately sufficient.
+    public static func approximatePeriod(of schedule: Schedule) -> TimeInterval {
+        switch schedule {
+        case .everyMinutes(let minutes):
+            return TimeInterval(minutes) * 60
+        case .hourly:
+            return 60 * 60
+        case .daily:
+            return 24 * 60 * 60
+        case .weekly:
+            return 7 * 24 * 60 * 60
+        }
+    }
+
     // MARK: nextDue
 
     /// The first instant strictly after `lastRunStart` at which `schedule`

--- a/Core/Sources/ResticStationCore/Support/HealthDerivation.swift
+++ b/Core/Sources/ResticStationCore/Support/HealthDerivation.swift
@@ -16,8 +16,9 @@ public enum AppHealth: String, Equatable, Sendable, CaseIterable {
     case running
     /// Last run of any set failed, OR any destination is stale, OR a run was
     /// killed and left its `current-run-*.json` behind, OR the Full Disk
-    /// Access probe came back denied, OR the scheduler is known not to be
-    /// registered (so scheduled backups are not actually happening).
+    /// Access probe came back denied, OR a first backup is overdue, OR the
+    /// scheduler is known not to be registered (so scheduled backups are not
+    /// actually happening).
     case warning
 }
 
@@ -57,6 +58,12 @@ public struct SetHealth: Identifiable, Equatable, Sendable {
     /// it. The tick clears it on its next pass (`RunStore.recoverInterrupted`
     /// + `Tick` step 3), so on a healthy host this is transient.
     public let abandonedRun: CurrentRunState?
+    /// This set has no run history, no recorded backup attempt and no run in
+    /// flight, and has remained visible on this machine beyond the larger of
+    /// one schedule period and 24 hours. It closes the fresh-install hole
+    /// where an absent scheduler or unusable restic could otherwise leave a
+    /// never-run set healthy forever.
+    public let firstBackupOverdue: Bool
     /// Destinations of this set that are stale per `docs/scheduling.md`
     /// §Staleness, in the set's configured destination order.
     public let staleDestinationIds: [UUID]
@@ -73,7 +80,8 @@ public struct SetHealth: Identifiable, Equatable, Sendable {
         currentRun: CurrentRunState?,
         staleDestinationIds: [UUID],
         nextDue: Date,
-        abandonedRun: CurrentRunState? = nil
+        abandonedRun: CurrentRunState? = nil,
+        firstBackupOverdue: Bool = false
     ) {
         self.setId = setId
         self.name = name
@@ -83,6 +91,7 @@ public struct SetHealth: Identifiable, Equatable, Sendable {
         self.staleDestinationIds = staleDestinationIds
         self.nextDue = nextDue
         self.abandonedRun = abandonedRun
+        self.firstBackupOverdue = firstBackupOverdue
     }
 
     public var isRunning: Bool { currentRun != nil }
@@ -106,7 +115,9 @@ public struct SetHealth: Identifiable, Equatable, Sendable {
     public var hasAbandonedRun: Bool { abandonedRun != nil }
 
     /// This set contributes `.warning` to the global `AppHealth`.
-    public var needsAttention: Bool { lastRunFailed || hasStaleDestination || hasAbandonedRun }
+    public var needsAttention: Bool {
+        lastRunFailed || hasStaleDestination || hasAbandonedRun || firstBackupOverdue
+    }
 
     /// 0...100, rounded, clamped — restic reports `percent_done` as a 0...1
     /// fraction (`docs/data-model.md` §current-run). `nil` when not running.
@@ -142,6 +153,8 @@ public enum HealthDerivation {
     ///     is what tells the two apart.
     ///   - repoStatuses: destination status keyed by `Destination.id`.
     ///   - scheduleState: `state/schedule-state.json`, or `nil` if absent.
+    ///   - visibleSince: later mtime of `config.json` and `machine.json`, or
+    ///     `nil` when unavailable. Injected to keep this derivation pure.
     ///   - isRunAbandoned: `RunStore.liveness(ofCurrentRun:) == .abandoned`
     ///     in production. Injected rather than called directly because this
     ///     type is pure by contract (no clock, no filesystem) and the answer
@@ -154,6 +167,7 @@ public enum HealthDerivation {
         scheduleState: ScheduleState?,
         now: Date,
         calendar: Calendar,
+        visibleSince: Date? = nil,
         isRunAbandoned: (CurrentRunState) -> Bool = { _ in false }
     ) -> [SetHealth] {
         config.sets.map { set in
@@ -165,6 +179,7 @@ public enum HealthDerivation {
                 setScheduleState: scheduleState?.sets[set.id],
                 now: now,
                 calendar: calendar,
+                visibleSince: visibleSince,
                 isRunAbandoned: isRunAbandoned
             )
         }
@@ -180,6 +195,7 @@ public enum HealthDerivation {
         setScheduleState: SetScheduleState?,
         now: Date,
         calendar: Calendar,
+        visibleSince: Date? = nil,
         isRunAbandoned: (CurrentRunState) -> Bool = { _ in false }
     ) -> SetHealth {
         // `recentRuns` is newest-first, so the first match in each filter is
@@ -215,6 +231,21 @@ public enum HealthDerivation {
         // `currentRun`, and none of them can be fooled by wreckage again.
         let abandonedRun = currentRun.flatMap { isRunAbandoned($0) ? $0 : nil }
 
+        let neverAttempted = setScheduleState?.lastBackupStart == nil
+            && runsForSet.isEmpty
+            && currentRun == nil
+        let firstBackupOverdue: Bool
+        if neverAttempted, let visibleSince {
+            // A future mtime is clock skew, not evidence that the set has
+            // been visible for a negative or wraparound duration.
+            let boundedVisibleSince = min(visibleSince, now)
+            let minimumGrace: TimeInterval = 24 * 60 * 60
+            let grace = max(ScheduleMath.approximatePeriod(of: set.schedule), minimumGrace)
+            firstBackupOverdue = now.timeIntervalSince(boundedVisibleSince) > grace
+        } else {
+            firstBackupOverdue = false
+        }
+
         return SetHealth(
             setId: set.id,
             name: set.name,
@@ -228,7 +259,8 @@ public enum HealthDerivation {
                 now: now,
                 calendar: calendar
             ),
-            abandonedRun: abandonedRun
+            abandonedRun: abandonedRun,
+            firstBackupOverdue: firstBackupOverdue
         )
     }
 

--- a/Core/Tests/ResticStationCoreTests/Config/AppPathsTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Config/AppPathsTests.swift
@@ -231,6 +231,25 @@ struct AppPathsEnvTests {
         #expect(paths.mountsDir(destId: destId).path == "\(rootPath)/mounts/\(destId.uuidString)")
     }
 
+    @Test func configurationVisibleSinceUsesTheNewestReadableMtimeAndFailsOpen() throws {
+        let (paths, root) = makeTempPaths()
+        let fileManager = FileManager.default
+        defer { try? fileManager.removeItem(at: root) }
+
+        #expect(paths.configurationVisibleSince(fileManager: fileManager) == nil)
+
+        try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+        try Data("{}".utf8).write(to: paths.configFile)
+        let configDate = Date(timeIntervalSince1970: 1_700_000_000)
+        try fileManager.setAttributes([.modificationDate: configDate], ofItemAtPath: paths.configFile.path)
+        #expect(paths.configurationVisibleSince(fileManager: fileManager) == configDate)
+
+        try Data("{}".utf8).write(to: paths.machineFile)
+        let machineDate = configDate.addingTimeInterval(3_600)
+        try fileManager.setAttributes([.modificationDate: machineDate], ofItemAtPath: paths.machineFile.path)
+        #expect(paths.configurationVisibleSince(fileManager: fileManager) == machineDate)
+    }
+
     /// Guards requirement 3 against future drift: every member other than
     /// `root` itself must be a pure function of `root`, so two roots yield the
     /// same relative sub-paths. Written as literal relative strings so a

--- a/Core/Tests/ResticStationCoreTests/Scheduling/ScheduleMathTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Scheduling/ScheduleMathTests.swift
@@ -42,6 +42,15 @@ private func date(
     return calendar.date(from: components)!
 }
 
+@Suite struct ScheduleMathApproximatePeriodTests {
+    @Test func everyScheduleHasTheDocumentedFirstBackupGracePeriod() {
+        #expect(ScheduleMath.approximatePeriod(of: .everyMinutes(30)) == 30 * 60)
+        #expect(ScheduleMath.approximatePeriod(of: .hourly(minute: 15)) == 60 * 60)
+        #expect(ScheduleMath.approximatePeriod(of: .daily(hour: 2, minute: 30)) == 24 * 60 * 60)
+        #expect(ScheduleMath.approximatePeriod(of: .weekly(weekday: 1, hour: 3, minute: 0)) == 7 * 24 * 60 * 60)
+    }
+}
+
 // MARK: - Rule 1: never-run is immediately due
 
 @Suite struct ScheduleMathNeverRunTests {

--- a/Core/Tests/ResticStationCoreTests/Support/HealthDerivationTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Support/HealthDerivationTests.swift
@@ -89,6 +89,68 @@ private func currentRun(percentDone: Double, phase: String = "backing-up-primary
     )
 }
 
+// MARK: - First backup overdue
+
+@Suite struct SetHealthFirstBackupOverdueTests {
+    private let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+    private func derive(
+        schedule: Schedule = .daily(hour: 2, minute: 30),
+        recentRuns: [RunIndexEntry] = [],
+        currentRunState: CurrentRunState? = nil,
+        setScheduleState: SetScheduleState? = nil,
+        visibleSince: Date?
+    ) -> SetHealth {
+        HealthDerivation.setHealth(
+            set: makeSet(schedule: schedule),
+            recentRuns: recentRuns,
+            currentRun: currentRunState,
+            repoStatuses: [:],
+            setScheduleState: setScheduleState,
+            now: now,
+            calendar: utcCalendar(),
+            visibleSince: visibleSince
+        )
+    }
+
+    @Test("daily and shorter schedules warn only after the 24-hour floor")
+    func dailyUsesTwentyFourHourFloor() {
+        let boundary = now.addingTimeInterval(-24 * 60 * 60)
+        #expect(!derive(visibleSince: boundary).firstBackupOverdue)
+
+        let overdue = derive(visibleSince: boundary.addingTimeInterval(-1))
+        #expect(overdue.firstBackupOverdue)
+        #expect(overdue.needsAttention)
+    }
+
+    @Test("weekly schedules use one full schedule period")
+    func weeklyUsesSevenDays() {
+        let schedule = Schedule.weekly(weekday: 1, hour: 3, minute: 0)
+        let boundary = now.addingTimeInterval(-7 * 24 * 60 * 60)
+        #expect(!derive(schedule: schedule, visibleSince: boundary).firstBackupOverdue)
+        #expect(derive(schedule: schedule, visibleSince: boundary.addingTimeInterval(-1)).firstBackupOverdue)
+    }
+
+    @Test("an unavailable or future visibility clock cannot warn")
+    func unavailableOrFutureVisibilityFailsOpen() {
+        #expect(!derive(visibleSince: nil).firstBackupOverdue)
+        #expect(!derive(visibleSince: now.addingTimeInterval(60 * 60)).firstBackupOverdue)
+    }
+
+    @Test("any attempt, run history, or current run suppresses the first-backup warning")
+    func evidenceOfAnAttemptSuppressesWarning() {
+        let old = now.addingTimeInterval(-30 * 24 * 60 * 60)
+        #expect(!derive(
+            setScheduleState: SetScheduleState(lastBackupStart: now.addingTimeInterval(-60)),
+            visibleSince: old
+        ).firstBackupOverdue)
+
+        let priorRun = run(start: now.addingTimeInterval(-120), end: now.addingTimeInterval(-60))
+        #expect(!derive(recentRuns: [priorRun], visibleSince: old).firstBackupOverdue)
+        #expect(!derive(currentRunState: currentRun(percentDone: 0.1), visibleSince: old).firstBackupOverdue)
+    }
+}
+
 // MARK: - Last run selection
 
 @Suite struct SetHealthLastRunTests {
@@ -421,7 +483,8 @@ private func currentRun(percentDone: Double, phase: String = "backing-up-primary
     private func health(
         running: Bool = false,
         failed: Bool = false,
-        stale: Bool = false
+        stale: Bool = false,
+        firstBackupOverdue: Bool = false
     ) -> SetHealth {
         let now = Date(timeIntervalSince1970: 1_800_000_000)
         return SetHealth(
@@ -433,7 +496,8 @@ private func currentRun(percentDone: Double, phase: String = "backing-up-primary
                 : nil,
             currentRun: running ? currentRun(percentDone: 0.5) : nil,
             staleDestinationIds: stale ? [secondaryId] : [],
-            nextDue: .distantPast
+            nextDue: .distantPast,
+            firstBackupOverdue: firstBackupOverdue
         )
     }
 
@@ -485,6 +549,15 @@ private func currentRun(percentDone: Double, phase: String = "backing-up-primary
     @Test func staleDestinationIsAWarning() {
         #expect(HealthDerivation.appHealth(
             setHealths: [health(stale: true)],
+            runsInFlight: [],
+            fullDiskAccessDenied: false,
+            backgroundAgentEnabled: true
+        ) == .warning)
+    }
+
+    @Test func overdueFirstBackupIsAWarning() {
+        #expect(HealthDerivation.appHealth(
+            setHealths: [health(firstBackupOverdue: true)],
             runsInFlight: [],
             fullDiskAccessDenied: false,
             backgroundAgentEnabled: true

--- a/Helper/Sources/Commands/Status.swift
+++ b/Helper/Sources/Commands/Status.swift
@@ -52,6 +52,7 @@ struct Status: AsyncParsableCommand {
 
         let now = Date()
         let calendar = Calendar.current
+        let configurationVisibleSince = paths.configurationVisibleSince()
         // The full index, not a capped window. `HealthDerivation.setHealths`
         // derives each set's `needsAttention` from that set's own most
         // recent run — but a shared, global cap applied *before* the
@@ -115,6 +116,7 @@ struct Status: AsyncParsableCommand {
             scheduleState: scheduleState,
             now: now,
             calendar: calendar,
+            visibleSince: configurationVisibleSince,
             isRunAbandoned: isRunAbandoned
         )
 
@@ -159,6 +161,7 @@ struct Status: AsyncParsableCommand {
                 name: setHealth.name,
                 needsAttention: setHealth.needsAttention,
                 isRunning: setHealth.isRunning,
+                firstBackupOverdue: setHealth.firstBackupOverdue,
                 abandonedRun: StatusReport.CurrentRunSummary(setHealth.abandonedRun),
                 abandonedRunFile: setHealth.hasAbandonedRun
                     ? paths.currentRunFile(setId: setHealth.setId).path
@@ -462,6 +465,9 @@ struct StatusReport: Encodable {
         let name: String
         let needsAttention: Bool
         let isRunning: Bool
+        /// No backup has ever been attempted and the first-run grace window
+        /// derived from the configuration mtimes has elapsed.
+        let firstBackupOverdue: Bool
         /// Live progress from a run that was killed and never cleaned up.
         /// Mutually exclusive with `currentRun`: a `current-run` file is
         /// either one or the other (`RunStore.liveness(ofCurrentRun:)`).
@@ -478,7 +484,7 @@ struct StatusReport: Encodable {
         let destinations: [DestinationStatus]
 
         private enum CodingKeys: String, CodingKey {
-            case id, name, needsAttention, isRunning, lastBackup, lastCheck, lastPrune
+            case id, name, needsAttention, isRunning, firstBackupOverdue, lastBackup, lastCheck, lastPrune
             case currentRun, nextDue, destinations, abandonedRun, abandonedRunFile
         }
 
@@ -490,6 +496,7 @@ struct StatusReport: Encodable {
             try container.encode(name, forKey: .name)
             try container.encode(needsAttention, forKey: .needsAttention)
             try container.encode(isRunning, forKey: .isRunning)
+            try container.encode(firstBackupOverdue, forKey: .firstBackupOverdue)
             try container.encode(abandonedRun, forKey: .abandonedRun)
             try container.encode(abandonedRunFile, forKey: .abandonedRunFile)
             try container.encode(lastBackup, forKey: .lastBackup)
@@ -600,6 +607,9 @@ struct StatusReport: Encodable {
             let suffix = flags.isEmpty ? "" : " — \(flags.joined(separator: ", "))"
             lines.append("set \"\(set.name)\" (\(set.id.uuidString.lowercased()))\(suffix)")
             lines.append("    last backup: \(Self.describe(set.lastBackup))")
+            if set.firstBackupOverdue {
+                lines.append("                  FIRST BACKUP OVERDUE — no backup attempt since this set became visible")
+            }
             lines.append("    last check:  \(Self.describe(set.lastCheck))")
             lines.append("    last prune:  \(Self.describe(set.lastPrune))")
             lines.append("    next due:    \(ConfigStore.makeISO8601Formatter().string(from: set.nextDue))")

--- a/Helper/Tests/HelperTests/StatusReportTests.swift
+++ b/Helper/Tests/HelperTests/StatusReportTests.swift
@@ -91,9 +91,14 @@ struct StatusReportTests {
 
     // MARK: - humanLines
 
-    private func makeSetStatus(needsAttention: Bool, isRunning: Bool) -> StatusReport.SetStatus {
+    private func makeSetStatus(
+        needsAttention: Bool,
+        isRunning: Bool,
+        firstBackupOverdue: Bool = false
+    ) -> StatusReport.SetStatus {
         StatusReport.SetStatus(
             id: setId, name: "Projects", needsAttention: needsAttention, isRunning: isRunning,
+            firstBackupOverdue: firstBackupOverdue,
             abandonedRun: nil, abandonedRunFile: nil,
             lastBackup: nil, lastCheck: nil, lastPrune: nil, currentRun: nil,
             nextDue: Date(timeIntervalSince1970: 0),
@@ -129,6 +134,19 @@ struct StatusReportTests {
         #expect(lines.contains("volume not mounted"))
     }
 
+    @Test("an overdue first backup is explicit next to the never-backed-up status")
+    func overdueFirstBackupIsExplicit() {
+        let report = StatusReport(
+            machineId: "studio-mac", generatedAt: Date(), health: "warning",
+            fullDiskAccessDenied: false, scheduler: nil,
+            sets: [makeSetStatus(needsAttention: true, isRunning: false, firstBackupOverdue: true)],
+            unattributedRuns: [], excludedHere: []
+        )
+        let lines = report.humanLines().joined(separator: "\n")
+        #expect(lines.contains("last backup: never"))
+        #expect(lines.contains("FIRST BACKUP OVERDUE"))
+    }
+
     @Test("excludedHere renders its own section")
     func excludedHereSection() {
         let omission = ResolvedOmission(subject: .backupSet, id: setId, name: "Photos", reason: .disabledForMachine)
@@ -156,6 +174,7 @@ struct StatusReportTests {
         #expect(text.contains("\"lastCheck\" : null"))
         #expect(text.contains("\"lastPrune\" : null"))
         #expect(text.contains("\"currentRun\" : null"))
+        #expect(text.contains("\"firstBackupOverdue\" : false"))
         #expect(text.contains("\"lastSyncedAt\" : null"))
         #expect(text.contains("\"unattributedRuns\" : ["))
         // `reachable: false` is a real, known value here — not null — but

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -466,10 +466,11 @@ Reads only existing state (`state/schedule-state.json`, `state/current-run-*.jso
 
 On Linux it also inspects the scheduler, through the same `SystemdTimerManager` `timer status` exits on — see `scheduling.md` §`status` and the scheduler for the three-valued `scheduler` key and why `null` (macOS, or a host with no systemd) is not the same as `"healthy": false`. Only a definite `false` contributes a warning.
 
-Two things `status` will **not** do quietly, both of which used to make it report healthy for the wrong reason:
+Three things `status` will **not** do quietly, all of which used to make it report healthy for the wrong reason:
 
 - An **unreadable `runs/index.jsonl`** (wrong owner, wrong mode, I/O error) exits non-zero naming the file, instead of reading as "no runs recorded" — which derives to idle, which exits 0. A corrupt or truncated *line* stays survivable: `RunStore.recentRuns` skips it with a warning, as documented above.
 - An **abandoned `current-run-*.json`** (see §state/current-run) reports `warning` with `abandonedRun` populated and `isRunning: false`, instead of `running`.
+- A set whose **first backup was never attempted** reports `firstBackupOverdue: true` after the larger of one schedule period and 24 hours from the later `config.json`/`machine.json` mtime. Missing mtimes disable this condition; a live run, any run history, or `lastBackupStart` proves setup progressed and disables it.
 
 ```json
 {
@@ -484,6 +485,7 @@ Two things `status` will **not** do quietly, both of which used to make it repor
       "name": "Projects",
       "needsAttention": true,
       "isRunning": false,
+      "firstBackupOverdue": false,
       "abandonedRun": null,
       "abandonedRunFile": null,
       "lastBackup": {
@@ -515,7 +517,7 @@ Two things `status` will **not** do quietly, both of which used to make it repor
 }
 ```
 
-`health`: `"idle"` | `"running"` | `"warning"` (`AppHealth.rawValue`). Exit code: **0** for `idle`/`running`, **1** for `warning` — usable directly as a Nagios/Icinga-style check. `lastBackup`/`lastCheck`/`lastPrune` are `null` before any attempt of that kind; `reachable` is `null` — never `false` — for a destination that has not been probed yet (`state/repo-status-<destId>.json` absent), the same "absent means not yet known, never a definite negative" rule `fda-check.json` uses. `excludedHere` has the same shape as `config show`'s.
+`health`: `"idle"` | `"running"` | `"warning"` (`AppHealth.rawValue`). Exit code: **0** for `idle`/`running`, **1** for `warning` — usable directly as a Nagios/Icinga-style check. `lastBackup`/`lastCheck`/`lastPrune` are `null` before any attempt of that kind; `reachable` is `null` — never `false` — for a destination that has not been probed yet (`state/repo-status-<destId>.json` absent), the same "absent means not yet known, never a definite negative" rule `fda-check.json` uses. `firstBackupOverdue` explains the otherwise-empty warning for a never-attempted set. `excludedHere` has the same shape as `config show`'s.
 
 `unattributedRuns` contains any `current-run-<setId>.json` whose set is no longer in this machine's resolved configuration. Each entry carries the missing `setId`, `liveness` (`"live"` or `"abandoned"`), the usual `currentRun` summary, and the exact `currentRunFile`. These runs still determine top-level health and the exit code, so an empty `sets` array never leaves their effect unexplained. Human output names the same run and prints a shell-quoted cleanup command.
 

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -842,6 +842,7 @@ $ restic-station-helper status --json
           "stale" : false
         }
       ],
+      "firstBackupOverdue" : false,
       "id" : "F1000000-0000-4000-8000-000000000001",
       "isRunning" : false,
       "lastBackup" : {
@@ -989,6 +990,7 @@ $ restic-station-helper status --json; echo "exit $?"
           "stale" : false
         }
       ],
+      "firstBackupOverdue" : false,
       "id" : "E1000000-0000-4000-8000-000000000001",
       "isRunning" : false,
       "lastBackup" : {

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -250,6 +250,9 @@ public enum ScheduleMath {
     public static func isDue(schedule: Schedule, lastRunStart: Date?,
                              now: Date, calendar: Calendar) -> Bool
     // isDue ⟺ nextDue(after: lastRunStart) <= now
+
+    /// Stable elapsed duration used by the first-backup health grace only.
+    public static func approximatePeriod(of schedule: Schedule) -> TimeInterval
 }
 ```
 
@@ -266,6 +269,8 @@ Rules (anacron semantics):
 5. **Clock skew:** if `lastRunStart > now` (clock moved backwards), treat as due at the next grid point after `now` (i.e. clamp lastRunStart to now); never go into a fire-loop.
 
 `lastBackupStart` records **attempt** starts (success or failure) — a failing backup retries at the next grid slot, not every 2 minutes. Manual runs also set it.
+
+**A first backup cannot remain silently overdue forever.** A resolved set with no run history, no `lastBackupStart`, and no current run becomes a health warning after `max(approximatePeriod(schedule), 24 hours)`: 24 hours for every-minutes/hourly/daily schedules and seven days for weekly. The grace is measured from the later mtime of `config.json` and host-local `machine.json`, clamped to `now` for clock skew. If neither mtime can be read, the condition stays off rather than manufacturing a warning. Any attempted or in-flight run disables this first-run condition; ordinary run outcome and destination-staleness rules take over from there.
 
 **Check scheduling:** fixed weekly cadence. `checkIsDue` = `lastCheckStart == nil || now − lastCheckStart ≥ 7 days`, evaluated only when no backup for the same set is due in the same tick (backup wins; check runs on a later tick). Each scheduled check uses `--read-data-subset=<cursor+1 mod t>/<t>` against the **primary**, advancing `checkSliceCursor` on success only. Secondaries are checked structure-only (no `--read-data-subset`) every 4th check *if reachable*.
 

--- a/docs/ui-spec.md
+++ b/docs/ui-spec.md
@@ -15,7 +15,7 @@ This spec fixes **information architecture, controls, states, and copy**. Visual
 Icon (template, SF Symbols):
 - Idle/healthy: `externaldrive.badge.checkmark`
 - Running: `externaldrive.badge.timemachine` (any run in flight)
-- Warning: `externaldrive.badge.exclamationmark` (last run of any set failed, OR any destination stale, OR FDA/agent problem)
+- Warning: `externaldrive.badge.exclamationmark` (last run of any set failed, OR any destination stale, OR a first backup is overdue, OR FDA/agent problem)
 
 Menu content (top to bottom):
 1. One line per set (disabled item): `"<SetName> — <relative last backup> <✓|⚠|✕>"`, e.g. "Projects — 2 hours ago ✓". Never run: "Projects — never backed up".

--- a/scripts/headless-cli-test.sh
+++ b/scripts/headless-cli-test.sh
@@ -295,6 +295,30 @@ expect_rc 0
 echo "$(cat "$OUT_FILE")" | jq -e '.health == "idle"' >/dev/null || fail "healthy fixture did not report idle"
 ok "healthy fixture: status --json exits 0, health=idle"
 
+# --- first backup grace: fresh config stays quiet; old never-run config warns. ---
+FIRST_BACKUP_FRESH="$WORK/status-first-backup-fresh"
+make_status_fixture "$FIRST_BACKUP_FRESH"
+RESTIC_STATION_DATA_DIR="$FIRST_BACKUP_FRESH" run_helper status --json
+expect_rc 0
+echo "$(cat "$OUT_FILE")" | jq -e '.sets[0].firstBackupOverdue == false' >/dev/null \
+    || fail "a fresh never-run set warned before its first-backup grace elapsed"
+
+FIRST_BACKUP_OVERDUE="$WORK/status-first-backup-overdue"
+make_status_fixture "$FIRST_BACKUP_OVERDUE"
+# First load creates machine.json; aging both files exercises the exact mtime
+# anchor production uses. POSIX `touch -t` works on macOS and Linux.
+RESTIC_STATION_DATA_DIR="$FIRST_BACKUP_OVERDUE" run_helper config validate
+expect_rc 0
+touch -t 202001010000 "$FIRST_BACKUP_OVERDUE/config.json" "$FIRST_BACKUP_OVERDUE/machine.json"
+RESTIC_STATION_DATA_DIR="$FIRST_BACKUP_OVERDUE" run_helper status --json
+expect_rc 1
+echo "$(cat "$OUT_FILE")" | jq -e '
+    .health == "warning"
+    and .sets[0].lastBackup == null
+    and .sets[0].firstBackupOverdue == true
+' >/dev/null || fail "an old never-attempted set did not report its overdue first backup"
+ok "first-backup grace: fresh config stays healthy; old never-attempted config warns"
+
 # --- in-flight: a live current-run file, backed by a live run record. ---
 # Both halves are required, and that is the point. A current-run file whose
 # `runId` has no `runs/<runId>/metadata.json` with a live `pid` is precisely


### PR DESCRIPTION
## Summary

- derive `firstBackupOverdue` for a resolved set with no run history, no recorded attempt, and no current run
- use a 24-hour minimum grace for every-minutes/hourly/daily schedules and one full week for weekly schedules
- anchor the grace to the later `config.json`/`machine.json` mtime, clamp future mtimes to now, and fail open when neither mtime is readable
- surface the condition through `SetHealth.needsAttention`, the app menu-bar health, `status --json`, human status output, and exit code
- document the rule and update the stable JSON examples

## Design checkpoint

The app writes `config.json` only for an actual changed user edit (`updateConfig` drops no-op drafts); background refreshes and state changes do not rewrite it. `machine.json` similarly writes only on a real machine-config change. The mtime anchor therefore is not reset by periodic app activity.

## Validation

- `swift test` — 72 Helper tests passed
- `swift test --package-path Core` — 557 Core tests passed
- `./scripts/headless-cli-test.sh` — all assertions passed
  - fresh never-run fixture: exit 0 and `firstBackupOverdue: false`
  - same fixture with both mtimes aged: exit 1 and `firstBackupOverdue: true`
- `./scripts/bootstrap.sh`
- `xcodebuild -scheme "Restic Station" build CODE_SIGNING_ALLOWED=NO -quiet`
- `bash -n scripts/headless-cli-test.sh`
- `git diff --check`

Fixes #58