### PR TITLE
Detect stalled runs and LaunchAgent failures

### DIFF
--- a/App/Sources/ViewModels/AppModel+Runs.swift
+++ b/App/Sources/ViewModels/AppModel+Runs.swift
@@ -20,9 +20,12 @@ extension AppModel {
     /// run has no index line yet; see `currentRuns`).
     var recentRuns: [RunIndexEntry] { stateWatcher.recentRuns }
 
-    /// In-flight run progress keyed by `BackupSet.id`
-    /// (`state/current-run-<setId>.json`).
-    var currentRuns: [UUID: CurrentRunState] { stateWatcher.currentRuns }
+    /// In-flight, heartbeating run progress keyed by `BackupSet.id`.
+    /// Abandoned and stalled state still contributes to health, but neither
+    /// is rendered as useful live progress in the Runs screen.
+    var currentRuns: [UUID: CurrentRunState] {
+        stateWatcher.currentRuns.filter { runStore.liveness(ofCurrentRun: $0.value) == .live }
+    }
 
     // MARK: - Naming
 
@@ -89,6 +92,9 @@ extension AppModel {
     func backUpNowUnavailableReason(setId: UUID) -> String? {
         guard isBusy(setId: setId) else { return nil }
         let name = setName(for: setId)
+        if let run = stateWatcher.currentRuns[setId], runStore.liveness(ofCurrentRun: run) == .stalled {
+            return "\(name)'s helper appears stalled. Inspect its run log before terminating it."
+        }
         if let phase = currentRuns[setId]?.phase {
             return "\(name) is busy — \(RunPhase.describe(phase)). Wait for it to finish, then try again."
         }

--- a/App/Sources/ViewModels/AppModel.swift
+++ b/App/Sources/ViewModels/AppModel.swift
@@ -111,6 +111,11 @@ final class AppModel: ObservableObject {
     private let now: @Sendable () -> Date
     private var cancellables: Set<AnyCancellable> = []
     private var hasStarted = false
+    private var healthRefreshTask: Task<Void, Never>?
+    /// A stopped heartbeat creates no filesystem event. Re-evaluate against
+    /// uptime often enough for the menu bar to turn yellow at the same bound
+    /// as the CLI without polling or rewriting any state.
+    private static let healthRefreshIntervalNanoseconds: UInt64 = 30_000_000_000
 
     // MARK: - Init
 
@@ -204,12 +209,22 @@ final class AppModel: ObservableObject {
         stateWatcher.start()
         launchd.refreshStatus()
         recomputeDerivedState()
+        healthRefreshTask = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: Self.healthRefreshIntervalNanoseconds)
+                guard !Task.isCancelled else { return }
+                guard let self else { return }
+                self.recomputeDerivedState()
+            }
+        }
         Task { await refreshResticInfo() }
     }
 
     func stop() {
         guard hasStarted else { return }
         hasStarted = false
+        healthRefreshTask?.cancel()
+        healthRefreshTask = nil
         stateWatcher.stop()
     }
 
@@ -365,12 +380,12 @@ final class AppModel: ObservableObject {
         // Resolved, not raw: a set this machine does not run has no health
         // to report here, and a destination disabled on this machine must
         // not raise a staleness warning for a repo it never writes to.
-        // A `current-run-*.json` whose process is gone is not a run in
-        // flight. Same predicate for both derivations, and the same one
-        // `restic-station-helper status` uses, so the menu bar and the CLI
-        // cannot disagree about whether this machine is busy.
-        let isRunAbandoned: (CurrentRunState) -> Bool = { [runStore] in
-            runStore.liveness(ofCurrentRun: $0) == .abandoned
+        // A `current-run-*.json` whose process is gone or whose heartbeat is
+        // stale is not healthy in-flight work. The menu bar and CLI share
+        // this predicate, so they cannot disagree about whether the machine
+        // is busy.
+        let runLiveness: (CurrentRunState) -> CurrentRunLiveness = { [runStore] in
+            runStore.liveness(ofCurrentRun: $0)
         }
         setHealths = HealthDerivation.setHealths(
             config: resolvedConfig,
@@ -381,7 +396,7 @@ final class AppModel: ObservableObject {
             now: currentDate,
             calendar: calendar,
             visibleSince: paths.configurationVisibleSince(),
-            isRunAbandoned: isRunAbandoned
+            runLiveness: runLiveness
         )
         appHealth = HealthDerivation.appHealth(
             setHealths: setHealths,
@@ -393,7 +408,7 @@ final class AppModel: ObservableObject {
             // Core so the Linux build is held to it too (T25).
             fullDiskAccessDenied: HealthDerivation.fullDiskAccessDenied(from: stateWatcher.fdaCheck),
             backgroundAgentEnabled: launchd.isEnabled,
-            isRunAbandoned: isRunAbandoned
+            runLiveness: runLiveness
         )
     }
 

--- a/Core/Sources/ResticStationCore/Engine/BackupEngine.swift
+++ b/Core/Sources/ResticStationCore/Engine/BackupEngine.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Dispatch
 
 // MARK: - RestoreRequest
 
@@ -113,6 +114,11 @@ public final class BackupEngine: Sendable {
     /// (`docs/architecture.md` §Process model: "≤ 1 write per 1–2 s").
     static let progressWriteInterval: TimeInterval = 1.5
 
+    /// Independent liveness write cadence. This is intentionally much slower
+    /// than progress updates: its only job is to prove the helper can still
+    /// execute, including during restic phases that emit no output for hours.
+    static let currentRunHeartbeatInterval: TimeInterval = 30
+
     /// Structure-only checks of the secondaries run on every Nth successful
     /// check of the primary (`docs/scheduling.md` §Check scheduling).
     static let secondaryCheckEveryNChecks = 4
@@ -129,6 +135,7 @@ public final class BackupEngine: Sendable {
     private let stateStore: StateStore
     private let reachability: Reachability
     private let now: @Sendable () -> Date
+    private let uptime: @Sendable () -> TimeInterval
 
     public init(
         config: AppConfig,
@@ -138,7 +145,8 @@ public final class BackupEngine: Sendable {
         runStore: RunStore,
         stateStore: StateStore,
         reachability: Reachability,
-        now: @escaping @Sendable () -> Date = Date.init
+        now: @escaping @Sendable () -> Date = Date.init,
+        uptime: @escaping @Sendable () -> TimeInterval = { ProcessInfo.processInfo.systemUptime }
     ) {
         self.config = config
         self.paths = paths
@@ -148,6 +156,7 @@ public final class BackupEngine: Sendable {
         self.stateStore = stateStore
         self.reachability = reachability
         self.now = now
+        self.uptime = uptime
     }
 
     // MARK: - runSet
@@ -687,9 +696,11 @@ public final class BackupEngine: Sendable {
         defer { logWriter?.close() }
         logWriter?.appendLine("$ \(run.argvRedacted.joined(separator: " "))")
 
-        if let preflightPhase {
-            progressReporter(setId: setId, run: run, phase: preflightPhase).writePhaseMarker()
-        }
+        let reporter = progressReporter(setId: setId, run: run, phase: preflightPhase ?? phase)
+        reporter.writePhaseMarker()
+        reporter.startHeartbeat()
+        defer { reporter.stopHeartbeat() }
+
         if let preflight, let reason = await preflight(logWriter) {
             logWriter?.appendLine("aborted: \(reason)")
             finish(run, status: .failed, errorSummary: reason)
@@ -699,8 +710,9 @@ public final class BackupEngine: Sendable {
             )
         }
 
-        let reporter = progressReporter(setId: setId, run: run, phase: phase)
-        reporter.writePhaseMarker()
+        if preflightPhase != nil {
+            reporter.beginPhase(phase)
+        }
 
         let result = await execute(
             command,
@@ -876,7 +888,9 @@ public final class BackupEngine: Sendable {
             runId: run.runId,
             kind: run.kind,
             phase: phase,
-            now: now
+            now: now,
+            uptime: uptime,
+            heartbeatInterval: Self.currentRunHeartbeatInterval
         )
     }
 
@@ -1037,9 +1051,9 @@ public final class BackupEngine: Sendable {
 ///
 /// One instance per child run: the throttle window is per phase, so the
 /// first `status` line of every phase lands immediately and the UI never
-/// waits for progress to appear. `@unchecked Sendable` because the restic
-/// stdout callback runs on the process runner's reader queue — the mutable
-/// timestamp is guarded by the lock.
+/// waits for progress to appear. An independent timer refreshes only the
+/// heartbeat fields. `@unchecked Sendable` because the restic stdout callback
+/// and timer run on different queues; all mutable state is guarded by `lock`.
 ///
 /// Internal rather than private so the throttle can be exercised directly by
 /// `BackupEngineTests` (a set run deletes `current-run` when it ends, so the
@@ -1049,11 +1063,17 @@ final class ProgressReporter: @unchecked Sendable {
     private let setId: UUID
     private let runId: String
     private let kind: RunKind
-    private let phase: String
     private let now: @Sendable () -> Date
+    private let uptime: @Sendable () -> TimeInterval
+    private let heartbeatInterval: TimeInterval
+    private let heartbeatQueue: DispatchQueue
 
     private let lock = NSLock()
-    private var lastWriteAt: Date?
+    private var phase: String
+    private var lastProgressWriteAt: Date?
+    private var latestState: CurrentRunState?
+    private var heartbeatTimer: DispatchSourceTimer?
+    private var heartbeatActive = false
 
     init(
         stateStore: StateStore,
@@ -1061,7 +1081,9 @@ final class ProgressReporter: @unchecked Sendable {
         runId: String,
         kind: RunKind,
         phase: String,
-        now: @escaping @Sendable () -> Date
+        now: @escaping @Sendable () -> Date,
+        uptime: @escaping @Sendable () -> TimeInterval = { ProcessInfo.processInfo.systemUptime },
+        heartbeatInterval: TimeInterval = BackupEngine.currentRunHeartbeatInterval
     ) {
         self.stateStore = stateStore
         self.setId = setId
@@ -1069,11 +1091,29 @@ final class ProgressReporter: @unchecked Sendable {
         self.kind = kind
         self.phase = phase
         self.now = now
+        self.uptime = uptime
+        self.heartbeatInterval = heartbeatInterval
+        self.heartbeatQueue = DispatchQueue(label: "net.herila.ResticStation.current-run-heartbeat.\(setId)")
+    }
+
+    deinit {
+        heartbeatTimer?.cancel()
     }
 
     /// One unthrottled write announcing the phase, with zeroed counters.
     /// Deliberately does not arm the throttle.
     func writePhaseMarker() {
+        beginPhase(phase)
+    }
+
+    /// Announces a new child phase immediately and resets its progress. The
+    /// same reporter (and heartbeat) spans preflight and the restic command,
+    /// so a wedged probe is detectable too.
+    func beginPhase(_ newPhase: String) {
+        let at = now()
+        let heartbeatUptime = uptime()
+        lock.lock()
+        phase = newPhase
         write(
             percentDone: 0,
             bytesDone: 0,
@@ -1081,21 +1121,78 @@ final class ProgressReporter: @unchecked Sendable {
             filesDone: 0,
             totalFiles: 0,
             currentFiles: [],
-            at: now()
+            at: at,
+            heartbeatUptime: heartbeatUptime
         )
+        lock.unlock()
+    }
+
+    /// Starts a dedicated dispatch timer rather than a child Swift task. A
+    /// restic await or a wedged cooperative task must not stop the evidence
+    /// that tells health checks whether this helper can still execute.
+    func startHeartbeat() {
+        lock.lock()
+        guard !heartbeatActive else {
+            lock.unlock()
+            return
+        }
+        heartbeatActive = true
+        let timer = DispatchSource.makeTimerSource(queue: heartbeatQueue)
+        heartbeatTimer = timer
+        lock.unlock()
+
+        timer.schedule(
+            deadline: .now() + heartbeatInterval,
+            repeating: heartbeatInterval,
+            leeway: .seconds(1)
+        )
+        timer.setEventHandler { [weak self] in
+            self?.writeHeartbeat()
+        }
+        timer.resume()
+    }
+
+    /// Cancels future writes and waits for any write already in flight to
+    /// leave the lock. The set-level cleanup can then delete current-run
+    /// without a late heartbeat recreating it.
+    func stopHeartbeat() {
+        lock.lock()
+        heartbeatActive = false
+        let timer = heartbeatTimer
+        heartbeatTimer = nil
+        lock.unlock()
+        timer?.cancel()
+    }
+
+    /// Internal for deterministic tests; the production timer calls the same
+    /// path. A heartbeat changes only its own timestamps, never the visible
+    /// progress fields or `updatedAt`.
+    func writeHeartbeat() {
+        let at = now()
+        let heartbeatUptime = uptime()
+        lock.lock()
+        defer { lock.unlock() }
+        guard heartbeatActive, var state = latestState else { return }
+        state.heartbeatAt = at
+        state.heartbeatUptime = heartbeatUptime
+        latestState = state
+        persist(state)
     }
 
     /// Writes one streamed `status` line, at most once per
     /// `BackupEngine.progressWriteInterval`.
     func record(_ status: BackupStatus) {
         let at = now()
+        let heartbeatUptime = uptime()
         lock.lock()
-        let shouldWrite = BackupEngine.shouldWriteProgress(lastWriteAt: lastWriteAt, now: at)
+        let shouldWrite = BackupEngine.shouldWriteProgress(lastWriteAt: lastProgressWriteAt, now: at)
         if shouldWrite {
-            lastWriteAt = at
+            lastProgressWriteAt = at
         }
-        lock.unlock()
-        guard shouldWrite else { return }
+        guard shouldWrite else {
+            lock.unlock()
+            return
+        }
 
         write(
             percentDone: status.percentDone,
@@ -1104,8 +1201,10 @@ final class ProgressReporter: @unchecked Sendable {
             filesDone: status.filesDone ?? 0,
             totalFiles: status.totalFiles ?? 0,
             currentFiles: status.currentFiles ?? [],
-            at: at
+            at: at,
+            heartbeatUptime: heartbeatUptime
         )
+        lock.unlock()
     }
 
     private func write(
@@ -1115,7 +1214,8 @@ final class ProgressReporter: @unchecked Sendable {
         filesDone: Int,
         totalFiles: Int,
         currentFiles: [String],
-        at: Date
+        at: Date,
+        heartbeatUptime: TimeInterval
     ) {
         let state = CurrentRunState(
             runId: runId,
@@ -1127,8 +1227,17 @@ final class ProgressReporter: @unchecked Sendable {
             filesDone: filesDone,
             totalFiles: totalFiles,
             currentFiles: currentFiles,
+            heartbeatAt: at,
+            heartbeatUptime: heartbeatUptime,
             updatedAt: at
         )
+        latestState = state
+        persist(state)
+    }
+
+    /// Caller holds `lock`, serializing progress and heartbeat writes so an
+    /// older heartbeat snapshot can never overwrite newer progress.
+    private func persist(_ state: CurrentRunState) {
         do {
             try stateStore.writeCurrentRun(setId: setId, state)
         } catch {

--- a/Core/Sources/ResticStationCore/Engine/StateStore.swift
+++ b/Core/Sources/ResticStationCore/Engine/StateStore.swift
@@ -123,6 +123,15 @@ public struct CurrentRunState: Codable, Equatable, Sendable {
     public var filesDone: Int
     public var totalFiles: Int
     public var currentFiles: [String]
+    /// Wall-clock time of the helper's most recent liveness heartbeat. This
+    /// advances even while restic emits no progress; `updatedAt` remains the
+    /// time the visible progress fields last changed.
+    public var heartbeatAt: Date?
+    /// System uptime, in seconds, at `heartbeatAt`. Unlike wall time this
+    /// clock pauses while the machine sleeps, so a laptop does not wake to a
+    /// false "stalled" warning. Optional for compatibility with current-run
+    /// files written by releases before heartbeats existed.
+    public var heartbeatUptime: TimeInterval?
     public var updatedAt: Date
 
     public init(
@@ -135,6 +144,8 @@ public struct CurrentRunState: Codable, Equatable, Sendable {
         filesDone: Int,
         totalFiles: Int,
         currentFiles: [String],
+        heartbeatAt: Date? = nil,
+        heartbeatUptime: TimeInterval? = nil,
         updatedAt: Date
     ) {
         self.runId = runId
@@ -146,6 +157,8 @@ public struct CurrentRunState: Codable, Equatable, Sendable {
         self.filesDone = filesDone
         self.totalFiles = totalFiles
         self.currentFiles = currentFiles
+        self.heartbeatAt = heartbeatAt
+        self.heartbeatUptime = heartbeatUptime
         self.updatedAt = updatedAt
     }
 }

--- a/Core/Sources/ResticStationCore/Runs/RunStore.swift
+++ b/Core/Sources/ResticStationCore/Runs/RunStore.swift
@@ -53,9 +53,13 @@ public struct RecoveredRun: Equatable, Sendable {
 /// health check reports green for a machine that has stopped backing up.
 /// That is the exact failure this type exists to make impossible.
 public enum CurrentRunLiveness: String, Equatable, Sendable {
-    /// The run's `runs/<runId>/metadata.json` is still `.running` and its
-    /// `pid` answers `kill(pid, 0)`.
+    /// The recorded `pid` answers `kill(pid, 0)` and, when written by a new
+    /// helper, its independent awake-time heartbeat is still fresh.
     case live
+    /// The process still exists, but its independent heartbeat has not
+    /// advanced for the bounded awake-time threshold. It may be stopped or
+    /// deadlocked and must not be presented as useful progress.
+    case stalled
     /// The process that wrote it is gone. Nothing will ever update or delete
     /// this file: it is wreckage, not progress.
     case abandoned
@@ -93,6 +97,13 @@ public enum RunStoreError: Error, Equatable, Sendable, CustomStringConvertible {
 public struct RunStore: Sendable {
     public let paths: AppPaths
     private let now: @Sendable () -> Date
+    private let uptime: @Sendable () -> TimeInterval
+
+    /// Five minutes is ten missed 30-second heartbeats: long enough to absorb
+    /// scheduling pressure, short enough for a monitoring check to catch a
+    /// wedged helper before another two-minute scheduler tick is mistaken for
+    /// useful work. The uptime clock excludes system sleep.
+    public static let currentRunHeartbeatStaleAfter: TimeInterval = 5 * 60
 
     /// How long `finish`/`recoverInterrupted` will retry for the index
     /// companion lock before giving up with `RunStoreError.indexLockTimeout`.
@@ -102,15 +113,24 @@ public struct RunStore: Sendable {
     private static let indexLockPollInterval: UInt32 = 5_000 // microseconds
 
     public init(paths: AppPaths) {
-        self.init(paths: paths, now: { Date() })
+        self.init(
+            paths: paths,
+            now: { Date() },
+            uptime: { ProcessInfo.processInfo.systemUptime }
+        )
     }
 
     /// Clock-injecting initializer, so `runId` generation (which embeds a
     /// UTC timestamp) is deterministic in tests. `init(paths:)` is the
     /// production entry point and simply forwards to this with `Date()`.
-    public init(paths: AppPaths, now: @escaping @Sendable () -> Date) {
+    public init(
+        paths: AppPaths,
+        now: @escaping @Sendable () -> Date,
+        uptime: @escaping @Sendable () -> TimeInterval = { ProcessInfo.processInfo.systemUptime }
+    ) {
         self.paths = paths
         self.now = now
+        self.uptime = uptime
     }
 
     // MARK: - begin / finish
@@ -259,8 +279,8 @@ public struct RunStore: Sendable {
         return recovered
     }
 
-    /// Is this `state/current-run-<setId>.json` still backed by a live
-    /// process? (`docs/data-model.md` §current-run.json)
+    /// Is this `state/current-run-<setId>.json` live, stalled, or abandoned?
+    /// (`docs/data-model.md` §current-run.json)
     ///
     /// Decided from the run's own `runs/<runId>/metadata.json` — the same
     /// `pid` + `kill(pid, 0)` evidence `recoverInterrupted()` uses, so the
@@ -268,20 +288,21 @@ public struct RunStore: Sendable {
     ///
     /// Deliberately **not** a timestamp heuristic on `updatedAt`. Progress is
     /// only written when restic emits a `status` line (throttled), and some
-    /// phases legitimately emit nothing for hours — a `check --read-data` on
-    /// a large repository writes one phase marker and then goes quiet. Any
-    /// "no progress for N minutes ⟹ dead" rule either cries wolf on those
-    /// runs or is set so high it stops being a health check. Process
-    /// liveness has neither failure mode.
+    /// phases legitimately emit nothing for hours. New helpers write a
+    /// separate, unconditional heartbeat; its uptime value is the only age
+    /// considered here. Uptime pauses during sleep, so a laptop wake is not a
+    /// false stall. Older current-run files have no heartbeat and retain the
+    /// previous process-only behavior until their run finishes.
     ///
     /// Missing or undecodable metadata counts as `.abandoned`: `begin(...)`
     /// writes `metadata.json` *before* the first progress write, so a
     /// current-run file pointing at a run directory that is not there
     /// describes a run this data directory has no record of.
     ///
-    /// Inherits one known limitation from `recoverInterrupted()`: a recycled
-    /// pid can make a dead run look live. The window is a whole pid-space
-    /// wrap and the consequence is a delayed warning, not a wrong backup.
+    /// A pre-heartbeat legacy file inherits one known limitation from
+    /// `recoverInterrupted()`: a recycled pid can make a dead run look live.
+    /// Heartbeat-bearing files detect the usual reboot/pid-reuse case because
+    /// their recorded uptime is greater than the new boot's uptime.
     public func liveness(ofCurrentRun state: CurrentRunState) -> CurrentRunLiveness {
         guard let metadata = try? metadata(runId: state.runId) else { return .abandoned }
         // The pid alone, deliberately — **not** `metadata.status == .running`
@@ -300,7 +321,15 @@ public struct RunStore: Sendable {
         //
         // Process liveness has no such window. The process is either there
         // to finish the job and clean up, or it is not.
-        return Self.isProcessAlive(pid: metadata.pid) ? .live : .abandoned
+        guard Self.isProcessAlive(pid: metadata.pid) else { return .abandoned }
+        guard let heartbeatUptime = state.heartbeatUptime else { return .live }
+
+        let heartbeatAge = uptime() - heartbeatUptime
+        // A negative age means the uptime clock reset, normally because this
+        // current-run file survived a reboot and its pid was recycled. The
+        // recorded process cannot be the process that wrote this heartbeat.
+        if heartbeatAge < 0 { return .abandoned }
+        return heartbeatAge > Self.currentRunHeartbeatStaleAfter ? .stalled : .live
     }
 
     static func isProcessAlive(pid: Int32) -> Bool {

--- a/Core/Sources/ResticStationCore/Support/HealthDerivation.swift
+++ b/Core/Sources/ResticStationCore/Support/HealthDerivation.swift
@@ -14,11 +14,10 @@ public enum AppHealth: String, Equatable, Sendable, CaseIterable {
     /// `.warning`: while restic is working, "working" is the more
     /// informative state.
     case running
-    /// Last run of any set failed, OR any destination is stale, OR a run was
-    /// killed and left its `current-run-*.json` behind, OR the Full Disk
-    /// Access probe came back denied, OR a first backup is overdue, OR the
-    /// scheduler is known not to be registered (so scheduled backups are not
-    /// actually happening).
+    /// Last run of any set failed, OR any destination is stale, OR a run is
+    /// stalled/abandoned, OR the Full Disk Access probe came back denied, OR
+    /// a first backup is overdue, OR the scheduler is known not to be
+    /// registered (so scheduled backups are not actually happening).
     case warning
 }
 
@@ -42,7 +41,8 @@ public struct SetHealth: Identifiable, Equatable, Sendable {
     public let lastRun: RunIndexEntry?
     /// Live progress, from `state/current-run-<setId>.json`. Non-`nil` ⟺
     /// a run is in flight for this set **and the process running it is still
-    /// alive** — see `abandonedRun` for the other case.
+    /// alive and heartbeating** — see `stalledRun` and `abandonedRun` for the
+    /// other cases.
     public let currentRun: CurrentRunState?
     /// A `state/current-run-<setId>.json` whose process is gone
     /// (`RunStore.liveness(ofCurrentRun:) == .abandoned`): a run that was
@@ -58,6 +58,11 @@ public struct SetHealth: Identifiable, Equatable, Sendable {
     /// it. The tick clears it on its next pass (`RunStore.recoverInterrupted`
     /// + `Tick` step 3), so on a healthy host this is transient.
     public let abandonedRun: CurrentRunState?
+    /// A run whose process still exists but whose independent heartbeat has
+    /// stopped. It is not safe to call this progress, and unlike abandoned
+    /// wreckage the current-run file must not be deleted while the process
+    /// still owns the set lock.
+    public let stalledRun: CurrentRunState?
     /// This set has no run history, no recorded backup attempt and no run in
     /// flight, and has remained visible on this machine beyond the larger of
     /// one schedule period and 24 hours. It closes the fresh-install hole
@@ -81,6 +86,7 @@ public struct SetHealth: Identifiable, Equatable, Sendable {
         staleDestinationIds: [UUID],
         nextDue: Date,
         abandonedRun: CurrentRunState? = nil,
+        stalledRun: CurrentRunState? = nil,
         firstBackupOverdue: Bool = false
     ) {
         self.setId = setId
@@ -91,6 +97,7 @@ public struct SetHealth: Identifiable, Equatable, Sendable {
         self.staleDestinationIds = staleDestinationIds
         self.nextDue = nextDue
         self.abandonedRun = abandonedRun
+        self.stalledRun = stalledRun
         self.firstBackupOverdue = firstBackupOverdue
     }
 
@@ -114,9 +121,11 @@ public struct SetHealth: Identifiable, Equatable, Sendable {
 
     public var hasAbandonedRun: Bool { abandonedRun != nil }
 
+    public var hasStalledRun: Bool { stalledRun != nil }
+
     /// This set contributes `.warning` to the global `AppHealth`.
     public var needsAttention: Bool {
-        lastRunFailed || hasStaleDestination || hasAbandonedRun || firstBackupOverdue
+        lastRunFailed || hasStaleDestination || hasAbandonedRun || hasStalledRun || firstBackupOverdue
     }
 
     /// 0...100, rounded, clamped — restic reports `percent_done` as a 0...1
@@ -149,14 +158,14 @@ public enum HealthDerivation {
     ///   - recentRuns: `RunStore.recentRuns` output, **newest first**
     ///     (as published by the app's `StateWatcher`).
     ///   - currentRuns: every `state/current-run-<setId>.json` that exists,
-    ///     keyed by `BackupSet.id` — live *and* abandoned; `isRunAbandoned`
-    ///     is what tells the two apart.
+    ///     keyed by `BackupSet.id` — live, stalled and abandoned;
+    ///     `runLiveness` tells the three apart.
     ///   - repoStatuses: destination status keyed by `Destination.id`.
     ///   - scheduleState: `state/schedule-state.json`, or `nil` if absent.
     ///   - visibleSince: later mtime of `config.json` and `machine.json`, or
     ///     `nil` when unavailable. Injected to keep this derivation pure.
-    ///   - isRunAbandoned: `RunStore.liveness(ofCurrentRun:) == .abandoned`
-    ///     in production. Injected rather than called directly because this
+    ///   - runLiveness: `RunStore.liveness(ofCurrentRun:)` in production.
+    ///     Injected rather than called directly because this
     ///     type is pure by contract (no clock, no filesystem) and the answer
     ///     needs to read `runs/<runId>/metadata.json`.
     public static func setHealths(
@@ -168,7 +177,7 @@ public enum HealthDerivation {
         now: Date,
         calendar: Calendar,
         visibleSince: Date? = nil,
-        isRunAbandoned: (CurrentRunState) -> Bool = { _ in false }
+        runLiveness: (CurrentRunState) -> CurrentRunLiveness = { _ in .live }
     ) -> [SetHealth] {
         config.sets.map { set in
             setHealth(
@@ -180,7 +189,7 @@ public enum HealthDerivation {
                 now: now,
                 calendar: calendar,
                 visibleSince: visibleSince,
-                isRunAbandoned: isRunAbandoned
+                runLiveness: runLiveness
             )
         }
     }
@@ -196,7 +205,7 @@ public enum HealthDerivation {
         now: Date,
         calendar: Calendar,
         visibleSince: Date? = nil,
-        isRunAbandoned: (CurrentRunState) -> Bool = { _ in false }
+        runLiveness: (CurrentRunState) -> CurrentRunLiveness = { _ in .live }
     ) -> SetHealth {
         // `recentRuns` is newest-first, so the first match in each filter is
         // the most recent one. `.running` entries are skipped: an in-flight
@@ -225,11 +234,13 @@ public enum HealthDerivation {
             }
             .map(\.id)
 
-        // One progress file, two possible meanings. Splitting it here — the
+        // One progress file, three possible meanings. Splitting it here — the
         // single place that reads it — is what keeps every consumer honest:
         // `isRunning`, `progressPercent` and `AppHealth.running` all follow
         // `currentRun`, and none of them can be fooled by wreckage again.
-        let abandonedRun = currentRun.flatMap { isRunAbandoned($0) ? $0 : nil }
+        let liveness = currentRun.map(runLiveness)
+        let abandonedRun = liveness == .abandoned ? currentRun : nil
+        let stalledRun = liveness == .stalled ? currentRun : nil
 
         let neverAttempted = setScheduleState?.lastBackupStart == nil
             && runsForSet.isEmpty
@@ -251,7 +262,7 @@ public enum HealthDerivation {
             name: set.name,
             lastBackup: lastBackup,
             lastRun: lastRun,
-            currentRun: abandonedRun == nil ? currentRun : nil,
+            currentRun: liveness == .live ? currentRun : nil,
             staleDestinationIds: staleDestinationIds,
             nextDue: nextDue(
                 schedule: set.schedule,
@@ -260,6 +271,7 @@ public enum HealthDerivation {
                 calendar: calendar
             ),
             abandonedRun: abandonedRun,
+            stalledRun: stalledRun,
             firstBackupOverdue: firstBackupOverdue
         )
     }
@@ -328,9 +340,9 @@ public enum HealthDerivation {
     /// The menu bar icon's state.
     ///
     /// `.running` still outranks `.warning` — while restic is working,
-    /// "working" is the more informative state — but only a *live* run
-    /// counts. Before `isRunAbandoned` existed, one `SIGKILL`ed run left a
-    /// `current-run-*.json` that nothing ever deleted, and this function
+    /// "working" is the more informative state — but only a *live,
+    /// heartbeating* run counts. Before liveness was derived, one `SIGKILL`ed
+    /// run left a `current-run-*.json` that nothing ever deleted, and this function
     /// returned `.running` from then until the end of time: green menu bar,
     /// `status` exit 0, no backups. The precedence is unchanged; what
     /// changed is that "in flight" now has to be true.
@@ -341,7 +353,7 @@ public enum HealthDerivation {
     ///     before the set was deleted is still running, and its wreckage is
     ///     still wreckage). `setHealths` only covers configured sets, which
     ///     is why this is a separate parameter rather than derived from it.
-    ///   - isRunAbandoned: see `setHealths(…)`. Must be the same predicate
+    ///   - runLiveness: see `setHealths(…)`. Must be the same predicate
     ///     passed there, or the two halves of this decision disagree.
     ///   - fullDiskAccessDenied: from `state/fda-check.json`, via
     ///     `fullDiskAccessDenied(from:)` — "not yet known" (or "not
@@ -360,9 +372,9 @@ public enum HealthDerivation {
         runsInFlight: [CurrentRunState],
         fullDiskAccessDenied: Bool,
         backgroundAgentEnabled: Bool?,
-        isRunAbandoned: (CurrentRunState) -> Bool = { _ in false }
+        runLiveness: (CurrentRunState) -> CurrentRunLiveness = { _ in .live }
     ) -> AppHealth {
-        let liveRuns = runsInFlight.filter { !isRunAbandoned($0) }
+        let liveRuns = runsInFlight.filter { runLiveness($0) == .live }
         if !liveRuns.isEmpty || setHealths.contains(where: \.isRunning) {
             return .running
         }
@@ -371,7 +383,7 @@ public enum HealthDerivation {
             runsInFlight: runsInFlight,
             fullDiskAccessDenied: fullDiskAccessDenied,
             backgroundAgentEnabled: backgroundAgentEnabled,
-            isRunAbandoned: isRunAbandoned
+            runLiveness: runLiveness
         ) {
             return .warning
         }
@@ -397,15 +409,15 @@ public enum HealthDerivation {
         runsInFlight: [CurrentRunState],
         fullDiskAccessDenied: Bool,
         backgroundAgentEnabled: Bool?,
-        isRunAbandoned: (CurrentRunState) -> Bool = { _ in false }
+        runLiveness: (CurrentRunState) -> CurrentRunLiveness = { _ in .live }
     ) -> Bool {
-        // An abandoned run for a set that is no longer configured has no
+        // An unhealthy run for a set that is no longer configured has no
         // `SetHealth` to carry it, so it is counted here directly — otherwise
         // deleting a set would be a way to silence the warning about the run
         // it was killed in the middle of.
-        let abandonedRuns = runsInFlight.filter(isRunAbandoned).count
+        let unhealthyRuns = runsInFlight.filter { runLiveness($0) != .live }.count
         return setHealths.contains(where: \.needsAttention)
-            || abandonedRuns > 0
+            || unhealthyRuns > 0
             || fullDiskAccessDenied
             || backgroundAgentEnabled == false
     }

--- a/Core/Sources/ResticStationCore/Support/SchedulerCommand.swift
+++ b/Core/Sources/ResticStationCore/Support/SchedulerCommand.swift
@@ -66,6 +66,16 @@ public enum LaunchctlCommand {
         argv.append("gui/\(uid)/\(label)")
         return argv
     }
+
+    /// `print gui/<uid>/<label>` — exits zero only while launchd has the
+    /// agent loaded. This is the helper CLI's scheduler-health probe; unlike
+    /// `SMAppService.status`, it does not require running inside the app.
+    public static func printArgv(
+        label: String = helperLabel,
+        uid: UInt32
+    ) -> [String] {
+        ["print", "gui/\(uid)/\(label)"]
+    }
 }
 
 #endif

--- a/Core/Tests/ResticStationCoreTests/Engine/BackupEngineTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Engine/BackupEngineTests.swift
@@ -901,6 +901,51 @@ struct BackupEngineTests {
         #expect(stateStore.readCurrentRun(setId: Self.setId)?.updatedAt == Self.t0.addingTimeInterval(1.5))
     }
 
+    @Test("heartbeat advances liveness without changing visible progress")
+    func heartbeatPreservesProgress() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("restic-station-heartbeat-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let stateStore = StateStore(paths: AppPaths(root: root))
+        let clock = TestClock(Self.t0)
+        let uptime = Box(100.0)
+        let reporter = ProgressReporter(
+            stateStore: stateStore,
+            setId: Self.setId,
+            runId: "heartbeat-run",
+            kind: .check,
+            phase: "checking",
+            now: clock.now,
+            uptime: { uptime.value },
+            heartbeatInterval: 3_600
+        )
+
+        reporter.writePhaseMarker()
+        reporter.startHeartbeat()
+        defer { reporter.stopHeartbeat() }
+        let initial = try #require(stateStore.readCurrentRun(setId: Self.setId))
+        #expect(initial.updatedAt == Self.t0)
+        #expect(initial.heartbeatAt == Self.t0)
+        #expect(initial.heartbeatUptime == 100)
+
+        clock.advance(60)
+        uptime.value = 160
+        reporter.writeHeartbeat()
+
+        let heartbeating = try #require(stateStore.readCurrentRun(setId: Self.setId))
+        #expect(heartbeating.updatedAt == initial.updatedAt)
+        #expect(heartbeating.percentDone == initial.percentDone)
+        #expect(heartbeating.phase == initial.phase)
+        #expect(heartbeating.heartbeatAt == Self.t0.addingTimeInterval(60))
+        #expect(heartbeating.heartbeatUptime == 160)
+
+        reporter.stopHeartbeat()
+        clock.advance(60)
+        uptime.value = 220
+        reporter.writeHeartbeat()
+        #expect(stateStore.readCurrentRun(setId: Self.setId)?.heartbeatUptime == 160)
+    }
+
     @Test("shouldWriteProgress: first write allowed, window enforced, backwards clock does not stall")
     func throttlePredicate() {
         #expect(BackupEngine.shouldWriteProgress(lastWriteAt: nil, now: Self.t0))

--- a/Core/Tests/ResticStationCoreTests/Engine/StateStoreTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Engine/StateStoreTests.swift
@@ -81,6 +81,8 @@ struct StateStoreTests {
           "filesDone": 120,
           "totalFiles": 4000,
           "currentFiles": ["/Users/user/proj/big.dat"],
+          "heartbeatAt": "2026-07-26T20:57:31Z",
+          "heartbeatUptime": 12345.5,
           "updatedAt": "2026-07-26T20:57:30Z"
         }
         """
@@ -94,11 +96,34 @@ struct StateStoreTests {
         #expect(decoded.filesDone == 120)
         #expect(decoded.totalFiles == 4000)
         #expect(decoded.currentFiles == ["/Users/user/proj/big.dat"])
+        #expect(decoded.heartbeatAt == Self.date("2026-07-26T20:57:31Z"))
+        #expect(decoded.heartbeatUptime == 12_345.5)
         #expect(decoded.updatedAt == Self.date("2026-07-26T20:57:30Z"))
 
         let reEncoded = try StateStore.makeEncoder().encode(decoded)
         let reDecoded = try StateStore.makeDecoder().decode(CurrentRunState.self, from: reEncoded)
         #expect(reDecoded == decoded)
+    }
+
+    @Test("current-run files from before heartbeats remain decodable")
+    func decodesLegacyCurrentRunWithoutHeartbeat() throws {
+        let json = """
+        {
+          "runId": "legacy",
+          "kind": "check",
+          "phase": "checking",
+          "percentDone": 0,
+          "bytesDone": 0,
+          "totalBytes": 0,
+          "filesDone": 0,
+          "totalFiles": 0,
+          "currentFiles": [],
+          "updatedAt": "2026-07-26T20:57:30Z"
+        }
+        """
+        let decoded = try StateStore.makeDecoder().decode(CurrentRunState.self, from: Data(json.utf8))
+        #expect(decoded.heartbeatAt == nil)
+        #expect(decoded.heartbeatUptime == nil)
     }
 
     @Test("decodes the documented state/fda-check.json literal")

--- a/Core/Tests/ResticStationCoreTests/Runs/RunStoreTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Runs/RunStoreTests.swift
@@ -260,7 +260,7 @@ private final class TickCounter: @unchecked Sendable {
 
     /// A `state/current-run-<setId>.json` for `runId`. Only `runId` matters
     /// to `liveness(ofCurrentRun:)`; the rest is filler.
-    private func progress(runId: String) -> CurrentRunState {
+    private func progress(runId: String, heartbeatUptime: TimeInterval? = nil) -> CurrentRunState {
         CurrentRunState(
             runId: runId,
             kind: .backup,
@@ -271,6 +271,8 @@ private final class TickCounter: @unchecked Sendable {
             filesDone: 1,
             totalFiles: 2,
             currentFiles: [],
+            heartbeatAt: heartbeatUptime.map { _ in Date(timeIntervalSince1970: 100) },
+            heartbeatUptime: heartbeatUptime,
             updatedAt: Date(timeIntervalSince1970: 0)
         )
     }
@@ -285,6 +287,54 @@ private final class TickCounter: @unchecked Sendable {
         let run = try store.begin(kind: .backup, setId: UUID(), destId: UUID(), trigger: .scheduled)
 
         #expect(store.liveness(ofCurrentRun: progress(runId: run.runId)) == .live)
+    }
+
+    @Test("a live process with a fresh heartbeat is live")
+    func livenessOfAHeartbeatingProcess() throws {
+        let paths = makePaths()
+        defer { cleanup(paths) }
+
+        let store = RunStore(paths: paths, now: { Date() }, uptime: { 1_000 })
+        let run = try store.begin(kind: .backup, setId: UUID(), destId: UUID(), trigger: .scheduled)
+
+        #expect(store.liveness(ofCurrentRun: progress(runId: run.runId, heartbeatUptime: 999)) == .live)
+    }
+
+    @Test("a live process with a stale heartbeat is stalled")
+    func livenessOfAStalledProcess() throws {
+        let paths = makePaths()
+        defer { cleanup(paths) }
+
+        let nowUptime = 1_000.0
+        let store = RunStore(paths: paths, now: { Date() }, uptime: { nowUptime })
+        let run = try store.begin(kind: .backup, setId: UUID(), destId: UUID(), trigger: .scheduled)
+        let stale = nowUptime - RunStore.currentRunHeartbeatStaleAfter - 1
+
+        #expect(store.liveness(ofCurrentRun: progress(runId: run.runId, heartbeatUptime: stale)) == .stalled)
+    }
+
+    @Test("exactly five minutes without a heartbeat is still inside the grace bound")
+    func heartbeatThresholdIsStrict() throws {
+        let paths = makePaths()
+        defer { cleanup(paths) }
+
+        let nowUptime = 1_000.0
+        let store = RunStore(paths: paths, now: { Date() }, uptime: { nowUptime })
+        let run = try store.begin(kind: .backup, setId: UUID(), destId: UUID(), trigger: .scheduled)
+        let boundary = nowUptime - RunStore.currentRunHeartbeatStaleAfter
+
+        #expect(store.liveness(ofCurrentRun: progress(runId: run.runId, heartbeatUptime: boundary)) == .live)
+    }
+
+    @Test("an uptime reset proves a recycled pid did not write this heartbeat")
+    func heartbeatFromAPriorBootIsAbandoned() throws {
+        let paths = makePaths()
+        defer { cleanup(paths) }
+
+        let store = RunStore(paths: paths, now: { Date() }, uptime: { 100 })
+        let run = try store.begin(kind: .backup, setId: UUID(), destId: UUID(), trigger: .scheduled)
+
+        #expect(store.liveness(ofCurrentRun: progress(runId: run.runId, heartbeatUptime: 200)) == .abandoned)
     }
 
     @Test("a run whose process is gone is abandoned, however recent its progress")

--- a/Core/Tests/ResticStationCoreTests/Support/HealthDerivationTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Support/HealthDerivationTests.swift
@@ -641,7 +641,7 @@ private func currentRun(percentDone: Double, phase: String = "backing-up-primary
             runsInFlight: [wreckage],
             fullDiskAccessDenied: false,
             backgroundAgentEnabled: true,
-            isRunAbandoned: { _ in true }
+            runLiveness: { _ in .abandoned }
         ) == .warning)
     }
 
@@ -654,8 +654,20 @@ private func currentRun(percentDone: Double, phase: String = "backing-up-primary
             runsInFlight: [wreckage, live],
             fullDiskAccessDenied: false,
             backgroundAgentEnabled: true,
-            isRunAbandoned: { $0.phase == "checking" }
+            runLiveness: { $0.phase == "checking" ? .abandoned : .live }
         ) == .running)
+    }
+
+    @Test("a stalled run is a warning, not useful progress")
+    func stalledRunIsAWarningNotRunning() {
+        let stalled = currentRun(percentDone: 0.5)
+        #expect(HealthDerivation.appHealth(
+            setHealths: [health()],
+            runsInFlight: [stalled],
+            fullDiskAccessDenied: false,
+            backgroundAgentEnabled: true,
+            runLiveness: { _ in .stalled }
+        ) == .warning)
     }
 
     // MARK: The exit code is not the glyph (@codex review on #51)
@@ -733,7 +745,7 @@ private func currentRun(percentDone: Double, phase: String = "backing-up-primary
             runsInFlight: [currentRun(percentDone: 0.5)],
             fullDiskAccessDenied: false,
             backgroundAgentEnabled: true,
-            isRunAbandoned: { _ in true }
+            runLiveness: { _ in .abandoned }
         ) == .warning)
     }
 }
@@ -750,7 +762,7 @@ private func currentRun(percentDone: Double, phase: String = "backing-up-primary
             setScheduleState: nil,
             now: Date(timeIntervalSince1970: 1_800_000_000),
             calendar: utcCalendar(),
-            isRunAbandoned: { _ in abandoned }
+            runLiveness: { _ in abandoned ? .abandoned : .live }
         )
     }
 
@@ -774,6 +786,27 @@ private func currentRun(percentDone: Double, phase: String = "backing-up-primary
         #expect(health.hasAbandonedRun)
         // Nothing is in flight, so there is no progress to report — a
         // half-finished percentage from a dead process is worse than none.
+        #expect(health.progressPercent == nil)
+        #expect(health.needsAttention)
+    }
+
+    @Test("a stalled current-run is retained as a warning, not rendered as progress")
+    func stalledRunNeedsAttention() {
+        let health = HealthDerivation.setHealth(
+            set: makeSet(),
+            recentRuns: [],
+            currentRun: currentRun(percentDone: 0.5),
+            repoStatuses: [:],
+            setScheduleState: nil,
+            now: Date(timeIntervalSince1970: 1_800_000_000),
+            calendar: utcCalendar(),
+            runLiveness: { _ in .stalled }
+        )
+        #expect(!health.isRunning)
+        #expect(health.currentRun == nil)
+        #expect(health.abandonedRun == nil)
+        #expect(health.stalledRun?.runId == "run")
+        #expect(health.hasStalledRun)
         #expect(health.progressPercent == nil)
         #expect(health.needsAttention)
     }

--- a/Core/Tests/ResticStationCoreTests/Support/SchedulerCommandTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Support/SchedulerCommandTests.swift
@@ -44,6 +44,11 @@ import Testing
         #expect(argv.last == "gui/\(uid)/net.herila.ResticStation.helper")
     }
 
+    @Test func printUsesCallerUIDAndExactLabel() {
+        #expect(LaunchctlCommand.printArgv(uid: 502)
+            == ["print", "gui/502/net.herila.ResticStation.helper"])
+    }
+
     @Test func executablePathIsAbsolute() {
         // Absolute so nothing depends on the app's inherited PATH.
         #expect(LaunchctlCommand.executablePath == "/bin/launchctl")

--- a/Helper/Sources/Commands/Status.swift
+++ b/Helper/Sources/Commands/Status.swift
@@ -2,6 +2,10 @@ import ArgumentParser
 import Foundation
 import ResticStationCore
 
+#if canImport(Darwin)
+import Darwin
+#endif
+
 /// `status [--json]` — the headless equivalent of the menu bar
 /// (`docs/tasks/T27`). Reads only existing state (`state/schedule-state.json`,
 /// `state/current-run-*.json`, `state/repo-status-*.json`, `runs/index.jsonl`)
@@ -17,8 +21,8 @@ struct Status: AsyncParsableCommand {
         commandName: "status",
         abstract: "The headless menu bar: per set, last run outcome+age, next due time, any "
             + "in-flight run's live progress, per-destination reachability+staleness, and last "
-            + "check/prune. On Linux it also reports whether the systemd --user timer will "
-            + "actually fire. Reads only existing state — no restic invocation. --json for "
+            + "check/prune. It also reports whether launchd (macOS) or the systemd --user "
+            + "timer (Linux) will actually fire. Reads state and the host scheduler — no restic invocation. --json for "
             + "scripting (e.g. a Nagios/Icinga check). Exit 0 healthy (including a run in "
             + "flight), 1 if any set needs attention or the scheduler is broken."
     )
@@ -95,7 +99,7 @@ struct Status: AsyncParsableCommand {
         // stale by the time the report prints. Reusing it is what guarantees
         // the JSON body, human rendering, health and exit code all describe
         // the same instant instead of contradicting one another.
-        let isRunAbandoned = Self.abandonedRunPredicate(
+        let runLiveness = Self.runLivenessPredicate(
             currentRuns: currentRuns,
             liveness: runStore.liveness(ofCurrentRun:)
         )
@@ -117,19 +121,16 @@ struct Status: AsyncParsableCommand {
             now: now,
             calendar: calendar,
             visibleSince: configurationVisibleSince,
-            isRunAbandoned: isRunAbandoned
+            runLiveness: runLiveness
         )
 
         let fdaCheck = stateStore.readFdaCheck()
         let fdaDenied = HealthDerivation.fullDiskAccessDenied(from: fdaCheck)
         // `backgroundAgentEnabled` asks "is the scheduler actually going to
-        // fire?" On Linux that is answerable and this command now answers it
-        // (`scheduler(paths:)`); on macOS it is `SMAppService` state, which
-        // is app-only and has no CLI surface, so the honest answer is `nil`
-        // — unknown, contributing nothing. It used to pass `true`
-        // unconditionally on both platforms, which reads as "the scheduler is
-        // fine" and meant `status --json` could not see a Linux host whose
-        // timer had been uninstalled.
+        // fire?" On Linux we inspect systemd; on macOS we ask launchd whether
+        // the SMAppService agent is loaded. It used to pass `true`
+        // unconditionally, which reads as "the scheduler is fine" and hid a
+        // host whose timer or LaunchAgent had stopped firing.
         let scheduler = await Self.scheduler(paths: paths)
         let health = HealthDerivation.appHealth(
             setHealths: setHealths,
@@ -139,7 +140,7 @@ struct Status: AsyncParsableCommand {
             runsInFlight: Array(currentRuns.values),
             fullDiskAccessDenied: fdaDenied,
             backgroundAgentEnabled: scheduler.flatMap(\.healthy),
-            isRunAbandoned: isRunAbandoned
+            runLiveness: runLiveness
         )
 
         let sets: [StatusReport.SetStatus] = setHealths.map { setHealth in
@@ -166,6 +167,8 @@ struct Status: AsyncParsableCommand {
                 abandonedRunFile: setHealth.hasAbandonedRun
                     ? paths.currentRunFile(setId: setHealth.setId).path
                     : nil,
+                stalledRun: StatusReport.CurrentRunSummary(setHealth.stalledRun),
+                stalledRunLog: setHealth.stalledRun.map { paths.runLogFile(runId: $0.runId).path },
                 lastBackup: StatusReport.RunSummary(setHealth.lastBackup, now: now),
                 lastCheck: StatusReport.RunSummary(try? runStore.lastRun(setId: setHealth.setId, kind: .check), now: now),
                 lastPrune: StatusReport.RunSummary(try? runStore.lastRun(setId: setHealth.setId, kind: .prune), now: now),
@@ -187,7 +190,13 @@ struct Status: AsyncParsableCommand {
             .map { setId, run in
                 StatusReport.UnattributedRun(
                     setId: setId,
-                    liveness: isRunAbandoned(run) ? .abandoned : .live,
+                    liveness: {
+                        switch runLiveness(run) {
+                        case .live: return .live
+                        case .stalled: return .stalled
+                        case .abandoned: return .abandoned
+                        }
+                    }(),
                     currentRun: StatusReport.CurrentRunSummary(run),
                     currentRunFile: paths.currentRunFile(setId: setId).path
                 )
@@ -227,7 +236,7 @@ struct Status: AsyncParsableCommand {
             runsInFlight: Array(currentRuns.values),
             fullDiskAccessDenied: fdaDenied,
             backgroundAgentEnabled: scheduler.flatMap(\.healthy),
-            isRunAbandoned: isRunAbandoned
+            runLiveness: runLiveness
         )
         HelperExit.code(needsAttention ? 1 : 0)
     }
@@ -236,28 +245,25 @@ struct Status: AsyncParsableCommand {
     /// health derivations in one `status` invocation share. Keying by run ID
     /// also avoids repeating the process probe if malformed state contains
     /// the same run under more than one set ID.
-    static func abandonedRunPredicate(
+    static func runLivenessPredicate(
         currentRuns: [UUID: CurrentRunState],
         liveness: (CurrentRunState) -> CurrentRunLiveness
-    ) -> (CurrentRunState) -> Bool {
+    ) -> (CurrentRunState) -> CurrentRunLiveness {
         var livenessByRunId: [String: CurrentRunLiveness] = [:]
         for run in currentRuns.values where livenessByRunId[run.runId] == nil {
             livenessByRunId[run.runId] = liveness(run)
         }
         return { run in
-            livenessByRunId[run.runId] == .abandoned
+            livenessByRunId[run.runId] ?? .abandoned
         }
     }
 
     /// Is anything actually going to fire the tick on this host?
     ///
-    /// `nil` = this platform cannot answer from a CLI. On macOS the scheduler
-    /// is a `SMAppService`-registered LaunchAgent whose status only the app
-    /// can read, so `status` says "unknown" rather than assuming; on Linux
-    /// the systemd `--user` timer is fully inspectable and the answer is the
-    /// same one `timer status` exits on — deliberately the same code path,
-    /// so the two commands can never disagree about whether this host is
-    /// scheduled.
+    /// On macOS, `launchctl print gui/<uid>/<label>` answers whether the
+    /// `SMAppService`-registered agent is actually loaded. On Linux the
+    /// systemd `--user` timer is fully inspectable and the answer is the same
+    /// one `timer status` exits on — deliberately the same code path.
     ///
     /// This is the one place `status` spawns subprocesses (three short
     /// `systemctl --user` queries, each bounded by
@@ -265,8 +271,14 @@ struct Status: AsyncParsableCommand {
     /// cannot see the scheduler reports a machine as healthy for as long as
     /// its last recorded run stays inside the staleness window, which for a
     /// quiet set is days.
-    static func scheduler(paths: AppPaths) async -> StatusReport.SchedulerStatus? {
+    static func scheduler(
+        paths: AppPaths,
+        runner: any ProcessRunning = DefaultProcessRunner(),
+        uid: UInt32? = nil
+    ) async -> StatusReport.SchedulerStatus? {
         #if os(Linux)
+        _ = runner
+        _ = uid
         // No activity lines and no activity problems: this call is only for
         // the verdict, and `run()` has already loaded the config itself (and
         // exited non-zero if it could not).
@@ -306,7 +318,39 @@ struct Status: AsyncParsableCommand {
         )
         #else
         _ = paths
-        return nil
+        let resolvedUID = uid ?? getuid()
+        let argv = [LaunchctlCommand.executablePath] + LaunchctlCommand.printArgv(uid: resolvedUID)
+        do {
+            let result = try await runner.run(
+                argv,
+                env: nil,
+                currentDirectory: nil,
+                onStdoutLine: nil,
+                onStderrLine: nil,
+                timeout: 5
+            )
+            if result.exitCode == 0 {
+                return StatusReport.SchedulerStatus(
+                    kind: "launchd-agent",
+                    healthy: true,
+                    problems: [],
+                    summaries: []
+                )
+            }
+            return StatusReport.SchedulerStatus(
+                kind: "launchd-agent",
+                healthy: false,
+                problems: ["agentNotLoaded"],
+                summaries: ["launchd does not have \(LaunchctlCommand.helperLabel) loaded for user \(resolvedUID)"]
+            )
+        } catch {
+            return StatusReport.SchedulerStatus(
+                kind: "launchd-agent",
+                healthy: nil,
+                problems: ["launchctlProbeFailed"],
+                summaries: ["could not query launchd: \(error)"]
+            )
+        }
         #endif
     }
 }
@@ -383,6 +427,7 @@ struct StatusReport: Encodable {
     struct UnattributedRun: Encodable {
         enum Liveness: String, Encodable {
             case live
+            case stalled
             case abandoned
         }
 
@@ -425,18 +470,15 @@ struct StatusReport: Encodable {
 
     /// Whether anything is going to fire the tick on this host.
     ///
-    /// Two different kinds of "don't know", and neither is `false`:
-    /// - the whole object is `null` — this platform has no CLI-readable
-    ///   scheduler at all (macOS, where it is `SMAppService` state);
-    /// - the object is present with `healthy: null` — this host has no
-    ///   systemd, so the documented scheduler is a cron line nothing here
-    ///   can inspect.
+    /// `healthy: null` means the platform's scheduler probe could not give a
+    /// definite answer: no systemd on Linux, or `launchctl print` itself
+    /// failed on macOS. That is distinct from a definite `false`.
     ///
     /// Only `healthy: false` is a finding, and only it makes `status` exit 1.
     struct SchedulerStatus: Encodable {
-        /// `"systemd-timer"`, or `"unknown"` when no scheduler could be
-        /// inspected. Present so a script can tell *which* scheduler
-        /// answered without inferring it from the platform.
+        /// `"systemd-timer"`, `"launchd-agent"`, or `"unknown"`. Present so
+        /// a script can tell which scheduler answered without inferring it
+        /// from the platform.
         let kind: String
         let healthy: Bool?
         /// `TimerProblem.rawValue`s — stable identifiers to branch on.
@@ -476,6 +518,12 @@ struct StatusReport: Encodable {
         /// `rm <this>`, and a message that does not name it makes the reader
         /// go and derive the path from a UUID.
         let abandonedRunFile: String?
+        /// Process still exists, but its awake-time heartbeat is stale.
+        let stalledRun: CurrentRunSummary?
+        /// Run log to inspect before deciding whether to terminate a stalled
+        /// process. Unlike abandoned wreckage, its current-run file is not a
+        /// safe cleanup target while the process owns the set lock.
+        let stalledRunLog: String?
         let lastBackup: RunSummary?
         let lastCheck: RunSummary?
         let lastPrune: RunSummary?
@@ -486,6 +534,7 @@ struct StatusReport: Encodable {
         private enum CodingKeys: String, CodingKey {
             case id, name, needsAttention, isRunning, firstBackupOverdue, lastBackup, lastCheck, lastPrune
             case currentRun, nextDue, destinations, abandonedRun, abandonedRunFile
+            case stalledRun, stalledRunLog
         }
 
         // Explicit `null` for every optional — see
@@ -499,6 +548,8 @@ struct StatusReport: Encodable {
             try container.encode(firstBackupOverdue, forKey: .firstBackupOverdue)
             try container.encode(abandonedRun, forKey: .abandonedRun)
             try container.encode(abandonedRunFile, forKey: .abandonedRunFile)
+            try container.encode(stalledRun, forKey: .stalledRun)
+            try container.encode(stalledRunLog, forKey: .stalledRunLog)
             try container.encode(lastBackup, forKey: .lastBackup)
             try container.encode(lastCheck, forKey: .lastCheck)
             try container.encode(lastPrune, forKey: .lastPrune)
@@ -591,7 +642,11 @@ struct StatusReport: Encodable {
                 lines.append("  - \(summary)")
             }
             if scheduler.healthy == false {
-                lines.append("  detail: restic-station-helper timer status")
+                if scheduler.kind == "launchd-agent" {
+                    lines.append("  detail: open Restic Station → Settings → General → Background backups")
+                } else {
+                    lines.append("  detail: restic-station-helper timer status")
+                }
             }
         }
         lines.append("")
@@ -633,6 +688,16 @@ struct StatusReport: Encodable {
                         + "rm \(ShellQuoting.quoteIfNeeded(file))")
                 }
             }
+            if let stalled = set.stalledRun {
+                lines.append(
+                    "    STALLED:     \(stalled.kind) run \(stalled.runId) still has a process, "
+                        + "but no heartbeat for more than 5 minutes of awake time "
+                        + "(stopped at \(stalled.phase), \(stalled.percentDone)%)"
+                )
+                if let log = set.stalledRunLog {
+                    lines.append("                 inspect the run log before terminating it: \(log)")
+                }
+            }
             for destination in set.destinations {
                 let role = destination.isPrimary ? "primary" : "secondary"
                 let reach = destination.reachable.map { $0 ? "reachable" : "UNREACHABLE" } ?? "not yet probed"
@@ -647,16 +712,21 @@ struct StatusReport: Encodable {
             lines.append("current runs for sets no longer configured:")
             for item in unattributedRuns {
                 let run = item.currentRun
-                let state = item.liveness == .abandoned ? "ABANDONED" : "LIVE"
+                let state = item.liveness.rawValue.uppercased()
                 lines.append(
                     "  - \(state): \(run.kind) run \(run.runId) for set "
                         + "\(item.setId.uuidString.lowercased()) "
                         + "(\(run.phase), \(run.percentDone)%)"
                 )
-                let cleanup = item.liveness == .abandoned
-                    ? "the next tick clears it; to clear it now: "
-                    : "the running helper should clear it when it finishes; to clear it now: "
-                lines.append("    \(cleanup)rm \(ShellQuoting.quoteIfNeeded(item.currentRunFile))")
+                switch item.liveness {
+                case .abandoned:
+                    lines.append("    the next tick clears it; to clear it now: rm "
+                        + ShellQuoting.quoteIfNeeded(item.currentRunFile))
+                case .stalled:
+                    lines.append("    the process still owns this run; inspect it before terminating it")
+                case .live:
+                    lines.append("    the running helper should clear it when it finishes")
+                }
             }
         }
 

--- a/Helper/Sources/Commands/Tick.swift
+++ b/Helper/Sources/Commands/Tick.swift
@@ -166,8 +166,8 @@ struct Tick: AsyncParsableCommand {
         clearAbandonedProgress(runStore: runStore, stateStore: stateStore, paths: paths)
     }
 
-    /// Deletes every `state/current-run-<setId>.json` that no live process
-    /// stands behind.
+    /// Deletes every `state/current-run-<setId>.json` whose recorded process
+    /// is gone. A stalled process still owns the set lock and is never swept.
     ///
     /// **Driven by `currentRunSetIDs()` rather than by what
     /// `recoverInterrupted()` returned**, which is not a refactor but the

--- a/Helper/Tests/HelperTests/StatusLivenessTests.swift
+++ b/Helper/Tests/HelperTests/StatusLivenessTests.swift
@@ -23,7 +23,7 @@ struct StatusLivenessTests {
             updatedAt: Date()
         )
         var evaluations = 0
-        let isRunAbandoned = Status.abandonedRunPredicate(
+        let runLiveness = Status.runLivenessPredicate(
             currentRuns: [setId: run, duplicateSetId: run]
         ) { _ in
             evaluations += 1
@@ -33,9 +33,9 @@ struct StatusLivenessTests {
         }
 
         #expect(evaluations == 1)
-        #expect(!isRunAbandoned(run)) // setHealths
-        #expect(!isRunAbandoned(run)) // appHealth
-        #expect(!isRunAbandoned(run)) // hasWarningConditions / exit code
+        #expect(runLiveness(run) == .live) // setHealths
+        #expect(runLiveness(run) == .live) // appHealth
+        #expect(runLiveness(run) == .live) // hasWarningConditions / exit code
         #expect(evaluations == 1)
     }
 }

--- a/Helper/Tests/HelperTests/StatusReportTests.swift
+++ b/Helper/Tests/HelperTests/StatusReportTests.swift
@@ -94,12 +94,15 @@ struct StatusReportTests {
     private func makeSetStatus(
         needsAttention: Bool,
         isRunning: Bool,
-        firstBackupOverdue: Bool = false
+        firstBackupOverdue: Bool = false,
+        stalledRun: StatusReport.CurrentRunSummary? = nil,
+        stalledRunLog: String? = nil
     ) -> StatusReport.SetStatus {
         StatusReport.SetStatus(
             id: setId, name: "Projects", needsAttention: needsAttention, isRunning: isRunning,
             firstBackupOverdue: firstBackupOverdue,
             abandonedRun: nil, abandonedRunFile: nil,
+            stalledRun: stalledRun, stalledRunLog: stalledRunLog,
             lastBackup: nil, lastCheck: nil, lastPrune: nil, currentRun: nil,
             nextDue: Date(timeIntervalSince1970: 0),
             destinations: [
@@ -174,12 +177,39 @@ struct StatusReportTests {
         #expect(text.contains("\"lastCheck\" : null"))
         #expect(text.contains("\"lastPrune\" : null"))
         #expect(text.contains("\"currentRun\" : null"))
+        #expect(text.contains("\"stalledRun\" : null"))
+        #expect(text.contains("\"stalledRunLog\" : null"))
         #expect(text.contains("\"firstBackupOverdue\" : false"))
         #expect(text.contains("\"lastSyncedAt\" : null"))
         #expect(text.contains("\"unattributedRuns\" : ["))
         // `reachable: false` is a real, known value here — not null — but
         // "not yet probed" (nil) must still round-trip as explicit null
         // elsewhere; covered by encoding a destination with no repo-status.
+    }
+
+    @Test("a stalled run is explicit and points at its log, never a cleanup command")
+    func stalledRunRenders() {
+        let run = CurrentRunState(
+            runId: "stalled-run", kind: .check, phase: "checking", percentDone: 0.25,
+            bytesDone: 1, totalBytes: 4, filesDone: 1, totalFiles: 4, currentFiles: [], updatedAt: Date()
+        )
+        let report = StatusReport(
+            machineId: "studio-mac", generatedAt: Date(), health: "warning",
+            fullDiskAccessDenied: false, scheduler: nil,
+            sets: [makeSetStatus(
+                needsAttention: true,
+                isRunning: false,
+                stalledRun: StatusReport.CurrentRunSummary(run),
+                stalledRunLog: "/tmp/run log.txt"
+            )],
+            unattributedRuns: [], excludedHere: []
+        )
+
+        let lines = report.humanLines().joined(separator: "\n")
+        #expect(lines.contains("STALLED:     check run stalled-run"))
+        #expect(lines.contains("inspect the run log"))
+        #expect(lines.contains("/tmp/run log.txt"))
+        #expect(!lines.contains("rm "))
     }
 
     @Test("an unattributed abandoned run renders with a named, shell-quoted cleanup path")

--- a/Helper/Tests/HelperTests/StatusSchedulerTests.swift
+++ b/Helper/Tests/HelperTests/StatusSchedulerTests.swift
@@ -1,0 +1,104 @@
+#if os(macOS)
+
+import Foundation
+import Testing
+
+import ResticStationCore
+@testable import restic_station_helper
+
+@Suite("status launchd scheduler probe")
+struct StatusSchedulerTests {
+    final class Runner: ProcessRunning, @unchecked Sendable {
+        private let lock = NSLock()
+        private let result: Result<ProcessResult, ProcessRunnerError>
+        private var recordedArgv: [String] = []
+        private var recordedTimeout: TimeInterval?
+
+        init(result: Result<ProcessResult, ProcessRunnerError>) {
+            self.result = result
+        }
+
+        var argv: [String] {
+            withLock { recordedArgv }
+        }
+
+        var timeout: TimeInterval? {
+            withLock { recordedTimeout }
+        }
+
+        func run(
+            _ argv: [String],
+            env: [String: String]?,
+            currentDirectory: String?,
+            onStdoutLine: (@Sendable (String) -> Void)?,
+            onStderrLine: (@Sendable (String) -> Void)?,
+            timeout: TimeInterval?
+        ) async throws -> ProcessResult {
+            withLock {
+                recordedArgv = argv
+                recordedTimeout = timeout
+            }
+            return try result.get()
+        }
+
+        private func withLock<T>(_ body: () -> T) -> T {
+            lock.lock()
+            defer { lock.unlock() }
+            return body()
+        }
+    }
+
+    private func result(exitCode: Int32) -> ProcessResult {
+        ProcessResult(exitCode: exitCode, stdout: Data(), stderr: Data())
+    }
+
+    @Test("exit zero means the LaunchAgent is loaded")
+    func loadedAgentIsHealthy() async throws {
+        let runner = Runner(result: .success(result(exitCode: 0)))
+
+        let scheduler = try #require(await Status.scheduler(
+            paths: AppPaths(root: FileManager.default.temporaryDirectory),
+            runner: runner,
+            uid: 502
+        ))
+
+        #expect(scheduler.kind == "launchd-agent")
+        #expect(scheduler.healthy == true)
+        #expect(scheduler.problems.isEmpty)
+        #expect(runner.argv == [
+            "/bin/launchctl", "print", "gui/502/net.herila.ResticStation.helper",
+        ])
+        #expect(runner.timeout == 5)
+    }
+
+    @Test("nonzero means scheduled backups will not happen")
+    func missingAgentIsUnhealthy() async throws {
+        let runner = Runner(result: .success(result(exitCode: 113)))
+
+        let scheduler = try #require(await Status.scheduler(
+            paths: AppPaths(root: FileManager.default.temporaryDirectory),
+            runner: runner,
+            uid: 501
+        ))
+
+        #expect(scheduler.healthy == false)
+        #expect(scheduler.problems == ["agentNotLoaded"])
+        #expect(scheduler.summaries.first?.contains("net.herila.ResticStation.helper") == true)
+    }
+
+    @Test("a failed probe stays unknown instead of claiming the scheduler is broken")
+    func probeFailureIsUnknown() async throws {
+        let runner = Runner(result: .failure(.timeout))
+
+        let scheduler = try #require(await Status.scheduler(
+            paths: AppPaths(root: FileManager.default.temporaryDirectory),
+            runner: runner,
+            uid: 501
+        ))
+
+        #expect(scheduler.healthy == nil)
+        #expect(scheduler.problems == ["launchctlProbeFailed"])
+    }
+}
+
+#endif

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -136,7 +136,7 @@ State — not config — is the right XDG base dir for `root`: `config.json` is 
 | `runs/<runId>/log.txt` | full streamed log of the run |
 | `runs/index.jsonl` | append-only, one summary JSON line per finished run |
 | `state/schedule-state.json` | last-start times + check-slice cursors per set |
-| `state/current-run-<setId>.json` | live progress of an in-flight run (deleted on completion) |
+| `state/current-run-<setId>.json` | live progress plus an independent 30-second awake-time heartbeat (deleted on completion) |
 | `state/repo-status-<destId>.json` | reachability + last-synced info per destination |
 | `state/fda-check.json` | result of the helper's Full Disk Access probe |
 | `locks/tick.lock`, `locks/set-<setId>.lock` | flock files (see `scheduling.md`) |

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -336,6 +336,8 @@ Superset of the index line, plus: `pid`, `resticExitCode`, `argvRedacted` (argv 
   "filesDone": 120,
   "totalFiles": 4000,
   "currentFiles": ["/Users/user/proj/big.dat"],
+  "heartbeatAt": "2026-07-26T20:57:29Z",
+  "heartbeatUptime": 84721.4,
   "updatedAt": "2026-07-26T20:57:30Z"
 }
 ```
@@ -349,10 +351,12 @@ unconditionally-trusted leftover pins a machine green forever: menu bar blue,
 `status` exit 0, no backups. Every reader therefore checks whether the run is
 still alive before treating it as in flight —
 `RunStore.liveness(ofCurrentRun:)`, which reads the run's own
-`runs/<runId>/metadata.json` and applies the same `pid` + `kill(pid, 0)` test
-`recoverInterrupted()` uses, so the two can never disagree about whether a run
-died. Not alive ⟹ the set reports `needsAttention` with the file named, not
-`isRunning`.
+`runs/<runId>/metadata.json`, verifies the pid with `kill(pid, 0)`, and checks
+the independent heartbeat. A missing process is **abandoned**; a present
+process whose heartbeat is more than five minutes old is **stalled**. Both
+report `needsAttention` and `isRunning: false`. An abandoned file can be
+cleared; a stalled run still owns the set lock, so status names its log for
+diagnosis instead of suggesting deletion.
 
 **The pid alone decides it — deliberately not the recorded `status` as well.**
 A set run is several child runs under one `current-run` file: `performChild`
@@ -364,12 +368,14 @@ A missing run directory is still abandonment: `begin(...)` writes
 `metadata.json` before the first progress write, so a `current-run` pointing at
 a run this data directory has no record of describes nothing.
 
-Deliberately **not** a staleness rule on `updatedAt`. Progress is written only
+Liveness is deliberately **not** a staleness rule on `updatedAt`. Progress is written only
 when restic emits a `status` line (throttled), and some phases legitimately
 emit nothing for hours — a `check --read-data` on a large repository writes
-one phase marker and then goes quiet. Any "no progress for N minutes ⟹ dead"
-threshold either cries wolf on those runs or is set so high it stops being a
-health check.
+one phase marker and then goes quiet. The helper therefore writes
+`heartbeatAt` and `heartbeatUptime` every 30 seconds independently of progress.
+The uptime value ages only while the machine is awake, so normal sleep cannot
+create a false stall; `updatedAt` remains the timestamp of visible progress.
+Files written by older releases have no heartbeat and retain pid-only behavior.
 
 The tick clears it: `recoverInterrupted()` returns the `setId` alongside the
 `runId` precisely so step 3 can delete the matching progress file, guarded on
@@ -464,12 +470,13 @@ Never a secret: `nonSecretEnv` is exactly `Destination.nonSecretEnv` (never the 
 
 Reads only existing state (`state/schedule-state.json`, `state/current-run-*.json`, `state/repo-status-*.json`, `runs/index.jsonl`) — no restic invocation. `health` reuses `HealthDerivation.appHealth` verbatim (`Core/Sources/ResticStationCore/Support/HealthDerivation.swift`), so the CLI and the app's menu bar can never disagree about what counts as a warning.
 
-On Linux it also inspects the scheduler, through the same `SystemdTimerManager` `timer status` exits on — see `scheduling.md` §`status` and the scheduler for the three-valued `scheduler` key and why `null` (macOS, or a host with no systemd) is not the same as `"healthy": false`. Only a definite `false` contributes a warning.
+It also inspects the platform scheduler: the same `SystemdTimerManager` used by `timer status` on Linux, and `launchctl print gui/$UID/net.herila.ResticStation.helper` on macOS. See `scheduling.md` §`status` and the scheduler. Only a definite `false` contributes a warning; a failed probe reports `healthy: null`.
 
 Three things `status` will **not** do quietly, all of which used to make it report healthy for the wrong reason:
 
 - An **unreadable `runs/index.jsonl`** (wrong owner, wrong mode, I/O error) exits non-zero naming the file, instead of reading as "no runs recorded" — which derives to idle, which exits 0. A corrupt or truncated *line* stays survivable: `RunStore.recentRuns` skips it with a warning, as documented above.
 - An **abandoned `current-run-*.json`** (see §state/current-run) reports `warning` with `abandonedRun` populated and `isRunning: false`, instead of `running`.
+- A **stalled run** whose process still exists but has stopped heartbeating reports `warning` with `stalledRun` and `stalledRunLog` populated. It is never offered as safe-to-delete wreckage.
 - A set whose **first backup was never attempted** reports `firstBackupOverdue: true` after the larger of one schedule period and 24 hours from the later `config.json`/`machine.json` mtime. Missing mtimes disable this condition; a live run, any run history, or `lastBackupStart` proves setup progressed and disables it.
 
 ```json
@@ -478,7 +485,7 @@ Three things `status` will **not** do quietly, all of which used to make it repo
   "generatedAt": "2026-07-26T20:57:30.000Z",
   "health": "warning",
   "fullDiskAccessDenied": false,
-  "scheduler": null,
+  "scheduler": {"kind": "launchd-agent", "healthy": true, "problems": [], "summaries": []},
   "sets": [
     {
       "id": "6F9619FF-8B86-D011-B42D-00C04FC964FF",
@@ -488,6 +495,8 @@ Three things `status` will **not** do quietly, all of which used to make it repo
       "firstBackupOverdue": false,
       "abandonedRun": null,
       "abandonedRunFile": null,
+      "stalledRun": null,
+      "stalledRunLog": null,
       "lastBackup": {
         "runId": "20260726T205704Z-backup-6f9619ff",
         "status": "failed",
@@ -519,7 +528,7 @@ Three things `status` will **not** do quietly, all of which used to make it repo
 
 `health`: `"idle"` | `"running"` | `"warning"` (`AppHealth.rawValue`). Exit code: **0** for `idle`/`running`, **1** for `warning` — usable directly as a Nagios/Icinga-style check. `lastBackup`/`lastCheck`/`lastPrune` are `null` before any attempt of that kind; `reachable` is `null` — never `false` — for a destination that has not been probed yet (`state/repo-status-<destId>.json` absent), the same "absent means not yet known, never a definite negative" rule `fda-check.json` uses. `firstBackupOverdue` explains the otherwise-empty warning for a never-attempted set. `excludedHere` has the same shape as `config show`'s.
 
-`unattributedRuns` contains any `current-run-<setId>.json` whose set is no longer in this machine's resolved configuration. Each entry carries the missing `setId`, `liveness` (`"live"` or `"abandoned"`), the usual `currentRun` summary, and the exact `currentRunFile`. These runs still determine top-level health and the exit code, so an empty `sets` array never leaves their effect unexplained. Human output names the same run and prints a shell-quoted cleanup command.
+`unattributedRuns` contains any `current-run-<setId>.json` whose set is no longer in this machine's resolved configuration. Each entry carries the missing `setId`, `liveness` (`"live"`, `"stalled"`, or `"abandoned"`), the usual `currentRun` summary, and the exact `currentRunFile`. These runs still determine top-level health and the exit code, so an empty `sets` array never leaves their effect unexplained. Human output names the same run; abandoned entries print a shell-quoted cleanup command, while stalled entries direct the operator to the run log.
 
 ### `sets list --json`
 

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -926,7 +926,9 @@ Three answers, and only one of them is a finding:
 | `{"kind": "systemd-timer", "healthy": true, …}` | the timer will fire | no |
 | `{"kind": "systemd-timer", "healthy": false, …}` | a real finding: exit 1, reason named | **yes — warning** |
 | `{"kind": "unknown", "healthy": null, …}` | no systemd here; the documented fallback is a cron line, which nothing can inspect | no |
-| `null` | macOS: the scheduler is `SMAppService` state, which no CLI can read | no |
+| `{"kind": "launchd-agent", "healthy": true, …}` | macOS: launchd reports the SMAppService agent loaded | no |
+| `{"kind": "launchd-agent", "healthy": false, …}` | macOS: the agent is not loaded | **yes — warning** |
+| `{"kind": "launchd-agent", "healthy": null, …}` | macOS: the launchctl probe failed, so state is unknown | no |
 
 The two "don't know" answers deliberately contribute nothing, exactly as an absent
 `fda-check.json` does — a check that goes permanently red inside every container is a check

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -194,14 +194,17 @@ Only a confirmed `Linger=no` counts.
 ### `status` and the scheduler
 
 `restic-station-helper status [--json]` reports the same verdict under a
-`scheduler` key, from the same code path, so the two commands cannot
-disagree. Three distinct answers, and only one of them is a finding:
+`scheduler` key. Linux uses the same code path as `timer status`; macOS asks
+launchd directly whether the SMAppService agent is loaded. A definite `false`
+is a finding, while an unavailable probe remains unknown:
 
 | `scheduler` | meaning |
 |---|---|
-| `null` | this platform has no CLI-readable scheduler (macOS: `SMAppService` state is app-only) |
 | `{"kind": "unknown", "healthy": null, …}` | no systemd here; the documented fallback is a cron line, which nothing can inspect |
 | `{"kind": "systemd-timer", "healthy": false, "problems": [...], …}` | a real finding — `status` exits 1 |
+| `{"kind": "launchd-agent", "healthy": true, …}` | macOS launchd reports the SMAppService agent loaded |
+| `{"kind": "launchd-agent", "healthy": false, "problems": ["agentNotLoaded"], …}` | macOS launchd cannot find the agent — `status` exits 1 |
+| `{"kind": "launchd-agent", "healthy": null, "problems": ["launchctlProbeFailed"], …}` | the launchctl probe failed; state is unknown and does not fail status |
 
 `status`'s **exit code is not `health == "warning"`.** `AppHealth` is a single
 glyph for a menu bar, so `running` outranks `warning` there — correctly: while

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -114,7 +114,8 @@ out (the job's own session never ends mid-run). Both remain genuinely open, trac
 
 ## Layer 3 — manual checklists (docs/tasks reference these; run before tagging a release)
 
-**SMAppService** (app copied to /Applications): register → status Enabled (or approval flow via System Settings) → `launchctl print gui/$UID/net.herila.ResticStation.helper` shows agent → wait ≤2 min → tick ran (state files touched) → quit app → tick still runs → unregister → agent gone.
+**SMAppService** (app copied to /Applications): register → status Enabled (or approval flow via System Settings) → `launchctl print gui/$UID/net.herila.ResticStation.helper` shows agent and `restic-station-helper status --json` reports `scheduler.kind == "launchd-agent"`, `healthy == true` → wait ≤2 min → tick ran (state files touched) → quit app → tick still runs → unregister → agent gone and CLI scheduler health becomes `false`/`agentNotLoaded`.
+**Stall detection**: start a backup against disposable data, wait for `heartbeatUptime` to appear in its current-run file, `kill -STOP <metadata pid>`, and confirm the app and `status --json` change from running/live to warning/stalled after five minutes of awake time; `kill -CONT`, then terminate or let the run finish. Confirm sleep time did not consume the threshold.
 **FDA**: revoke in System Settings → both badges show denied → app probe correct; grant to app → app badge granted; Re-check → agent badge granted (if not: fallback path per keychain-and-fda.md verifies).
 **Keychain**: create destination with password → run scheduled backup with app closed → no GUI prompt appears, backup succeeds.
 **Sleep/catch-up**: schedule daily at a time while Mac will be asleep; wake after → backup runs within ~2 min of wake.

--- a/scripts/headless-cli-test.sh
+++ b/scripts/headless-cli-test.sh
@@ -80,6 +80,19 @@ expect_rc() {
     }
 }
 
+# A fixture can prove its backup state is healthy without controlling the
+# host scheduler. On macOS the status command now probes the real LaunchAgent;
+# on Linux it probes the real user timer. A definite scheduler failure makes
+# status exit 1, while healthy or unknown scheduler state contributes 0.
+CLEAN_STATUS_RC=0
+capture_clean_status_rc() {
+    if jq -e '.scheduler.healthy == false' "$OUT_FILE" >/dev/null; then
+        CLEAN_STATUS_RC=1
+    else
+        CLEAN_STATUS_RC=0
+    fi
+}
+
 SECRET_PASSWORD='h34dl3ss "cli" $ecret with spaces '
 
 # ─────────────────────────────────────────────────────────────────────────
@@ -291,15 +304,21 @@ cat > "$HEALTHY/runs/r-healthy/metadata.json" <<EOF
 {"runId":"r-healthy","kind":"backup","setId":"$SET_ID","destId":"$PRIMARY_ID","groupId":"r-healthy","status":"success","trigger":"scheduled","start":"$ONE_HOUR_AGO_ISO","end":"$ONE_HOUR_AGO_ISO","pid":1,"resticExitCode":0,"argvRedacted":["restic","backup"],"snapshotId":"abc123","filesNew":1,"filesChanged":0,"dataAdded":100,"errorSummary":null,"stats":null}
 EOF
 RESTIC_STATION_DATA_DIR="$HEALTHY" run_helper status --json
-expect_rc 0
-echo "$(cat "$OUT_FILE")" | jq -e '.health == "idle"' >/dev/null || fail "healthy fixture did not report idle"
-ok "healthy fixture: status --json exits 0, health=idle"
+capture_clean_status_rc
+expect_rc "$CLEAN_STATUS_RC"
+jq -e '
+    .sets[0].needsAttention == false
+    and .sets[0].lastBackup.status == "success"
+    and .health == (if .scheduler.healthy == false then "warning" else "idle" end)
+' "$OUT_FILE" >/dev/null || fail "healthy fixture was not healthy apart from an independently reported scheduler finding"
+ok "healthy fixture: backup state is idle; exit reflects the host scheduler"
 
 # --- first backup grace: fresh config stays quiet; old never-run config warns. ---
 FIRST_BACKUP_FRESH="$WORK/status-first-backup-fresh"
 make_status_fixture "$FIRST_BACKUP_FRESH"
 RESTIC_STATION_DATA_DIR="$FIRST_BACKUP_FRESH" run_helper status --json
-expect_rc 0
+capture_clean_status_rc
+expect_rc "$CLEAN_STATUS_RC"
 echo "$(cat "$OUT_FILE")" | jq -e '.sets[0].firstBackupOverdue == false' >/dev/null \
     || fail "a fresh never-run set warned before its first-backup grace elapsed"
 
@@ -336,13 +355,44 @@ cat > "$INFLIGHT/state/current-run-$SET_ID.json" <<EOF
 {"runId":"r-live","kind":"backup","phase":"backing-up-primary","percentDone":0.42,"bytesDone":1234,"totalBytes":9999,"filesDone":3,"totalFiles":10,"currentFiles":["/tmp/src/big.dat"],"updatedAt":"$NOW_ISO"}
 EOF
 RESTIC_STATION_DATA_DIR="$INFLIGHT" run_helper status --json
-expect_rc 0
+capture_clean_status_rc
+expect_rc "$CLEAN_STATUS_RC"
 echo "$(cat "$OUT_FILE")" | jq -e '.health == "running"' >/dev/null || fail "in-flight fixture did not report running"
 echo "$(cat "$OUT_FILE")" | jq -e '.sets[0].currentRun.phase == "backing-up-primary"' >/dev/null \
     || fail "in-flight fixture did not surface live progress"
 echo "$(cat "$OUT_FILE")" | jq -e '.sets[0].abandonedRun == null' >/dev/null \
     || fail "a live run was misreported as abandoned"
-ok "in-flight fixture: status --json exits 0, health=running, live progress surfaced"
+ok "in-flight fixture: health=running, live progress surfaced; exit reflects the host scheduler"
+
+# --- stalled: the pid still exists, but the independent awake-time heartbeat
+#     is stale. A negative fixture value is intentionally older than every
+#     possible system uptime, keeping this test deterministic on fresh CI VMs. ---
+STALLED="$WORK/status-stalled"
+make_status_fixture "$STALLED"
+mkdir -p "$STALLED/runs/r-stalled"
+cat > "$STALLED/runs/r-stalled/metadata.json" <<EOF
+{"runId":"r-stalled","kind":"backup","setId":"$SET_ID","destId":"$PRIMARY_ID","groupId":"r-stalled","status":"running","trigger":"manual","start":"$NOW_ISO","end":null,"pid":$$,"resticExitCode":null,"argvRedacted":[],"snapshotId":null,"filesNew":null,"filesChanged":null,"dataAdded":null,"errorSummary":null,"stats":null}
+EOF
+cat > "$STALLED/state/current-run-$SET_ID.json" <<EOF
+{"runId":"r-stalled","kind":"backup","phase":"backing-up-primary","percentDone":0.42,"bytesDone":1234,"totalBytes":9999,"filesDone":3,"totalFiles":10,"currentFiles":["/tmp/src/big.dat"],"heartbeatAt":"$NOW_ISO","heartbeatUptime":-301,"updatedAt":"$NOW_ISO"}
+EOF
+RESTIC_STATION_DATA_DIR="$STALLED" run_helper status --json
+expect_rc 1
+jq -e '
+    .health == "warning"
+    and .sets[0].isRunning == false
+    and .sets[0].currentRun == null
+    and .sets[0].stalledRun.runId == "r-stalled"
+    and (.sets[0].stalledRunLog | endswith("/runs/r-stalled/log.txt"))
+' "$OUT_FILE" >/dev/null || fail "stalled fixture was not reported as warning with its diagnostic log"
+RESTIC_STATION_DATA_DIR="$STALLED" run_helper status
+expect_rc 1
+grep -qF "STALLED:     backup run r-stalled" "$OUT_FILE" \
+    || fail "human status did not name the stalled run"
+if grep -qF "current-run-$SET_ID.json" "$OUT_FILE"; then
+    fail "human status suggested deleting a current-run file still owned by a stalled process"
+fi
+ok "stalled fixture: a live pid with a stale heartbeat is warning, not progress or safe wreckage"
 
 # --- abandoned: the same progress file, with no live run behind it. ---
 # The counterpart, and the regression this pairing guards: one SIGKILL'd run
@@ -467,8 +517,11 @@ ok "a quiet set's failed last run survives 200+ newer runs from another set — 
 # ─────────────────────────────────────────────────────────────────────────
 log "5. --json output is parseable JSON with nothing else on stdout"
 
-RESTIC_STATION_DATA_DIR="$HEALTHY" "$HELPER" status --json | jq -e '.machineId | length > 0' >/dev/null \
-    || fail "status --json did not pipe cleanly through jq"
+RESTIC_STATION_DATA_DIR="$HEALTHY" run_helper status --json
+capture_clean_status_rc
+expect_rc "$CLEAN_STATUS_RC"
+jq -e '.machineId | length > 0' "$OUT_FILE" >/dev/null \
+    || fail "status --json did not produce clean JSON"
 RESTIC_STATION_DATA_DIR="$HEALTHY" "$HELPER" sets list --json | jq -e 'type == "array"' >/dev/null \
     || fail "sets list --json did not pipe cleanly through jq"
 RESTIC_STATION_DATA_DIR="$HEALTHY" "$HELPER" runs list --json | jq -e 'type == "array"' >/dev/null \
@@ -507,12 +560,12 @@ ok "an unloadable config.json → exit 1 for config validate, status, sets list"
 RESTIC_STATION_DATA_DIR="$HEALTHY" run_helper config validate
 expect_rc 0
 RESTIC_STATION_DATA_DIR="$HEALTHY" run_helper status
-expect_rc 0
+expect_rc "$CLEAN_STATUS_RC"
 RESTIC_STATION_DATA_DIR="$HEALTHY" run_helper sets list
 expect_rc 0
 RESTIC_STATION_DATA_DIR="$HEALTHY" run_helper runs list
 expect_rc 0
-ok "a healthy, well-formed setup → exit 0 for config validate, status, sets list, runs list"
+ok "a healthy, well-formed setup → commands succeed; status exit independently reflects the host scheduler"
 
 # ─────────────────────────────────────────────────────────────────────────
 # The real-restic half: secret set/list, a real run-set, status reflecting
@@ -589,7 +642,8 @@ EOF
     expect_rc 0
 
     RESTIC_STATION_DATA_DIR="$REAL_DATA" run_helper status --json
-    expect_rc 0
+    capture_clean_status_rc
+    expect_rc "$CLEAN_STATUS_RC"
     echo "$(cat "$OUT_FILE")" | jq -e '.sets[0].lastBackup.status == "success"' >/dev/null \
         || fail "status did not reflect the real backup that just ran"
     ok "a real run-set backup is reflected by status --json"

--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -1146,10 +1146,9 @@ assert_fixture_flow() {
     # Nothing has installed a timer for this data directory, so on Linux
     # `status` correctly reports the scheduler as unhealthy and exits 1 —
     # that is issues #46/#48 working, not a failure of this scenario. On
-    # macOS the scheduler is `SMAppService` state, which no CLI can read, so
-    # the field is null, contributes nothing, and the same call exits 0.
-    # Asserted per platform rather than tolerated, so a *wrong* answer on
-    # either side is still a failure.
+    # macOS probes the LaunchAgent directly. Its state belongs to the host,
+    # not this fixture: a developer may have the real app enabled while CI
+    # will not. Assert the answer is internally consistent in either state.
     if [[ "$OS_NAME" == "Linux" ]]; then
         [[ $status_rc -eq 1 ]] || fail "$step" "expected exit 1 with no timer installed, got $status_rc"
         echo "$status_json" | jq -e '.scheduler.healthy == false' >/dev/null \
@@ -1157,9 +1156,26 @@ assert_fixture_flow() {
         echo "$status_json" | jq -e '.scheduler.problems | index("unitsMissing")' >/dev/null \
             || fail "$step" "expected scheduler.problems to name unitsMissing: $status_json"
     else
-        [[ $status_rc -eq 0 ]] || fail "$step" "expected exit 0 on a healthy host, got $status_rc: $status_json"
-        echo "$status_json" | jq -e '.scheduler == null' >/dev/null \
-            || fail "$step" "expected a null scheduler on macOS (SMAppService is app-only): $status_json"
+        echo "$status_json" | jq -e '.scheduler.kind == "launchd-agent"' >/dev/null \
+            || fail "$step" "expected a launchd-agent scheduler probe on macOS: $status_json"
+        local scheduler_health
+        scheduler_health="$(echo "$status_json" | jq -r '.scheduler.healthy')"
+        case "$scheduler_health" in
+            true)
+                [[ $status_rc -eq 0 ]] || fail "$step" "healthy LaunchAgent should exit 0, got $status_rc: $status_json"
+                ;;
+            false)
+                [[ $status_rc -eq 1 ]] || fail "$step" "missing LaunchAgent should exit 1, got $status_rc: $status_json"
+                echo "$status_json" | jq -e '.scheduler.problems | index("agentNotLoaded")' >/dev/null \
+                    || fail "$step" "missing LaunchAgent did not name agentNotLoaded: $status_json"
+                ;;
+            null)
+                [[ $status_rc -eq 0 ]] || fail "$step" "unknown LaunchAgent state should not fail status: $status_json"
+                echo "$status_json" | jq -e '.scheduler.problems | index("launchctlProbeFailed")' >/dev/null \
+                    || fail "$step" "unknown LaunchAgent state did not name launchctlProbeFailed: $status_json"
+                ;;
+            *) fail "$step" "unexpected LaunchAgent health '$scheduler_health': $status_json" ;;
+        esac
     fi
     echo "$status_json" | jq -e '.sets | length == 1' >/dev/null \
         || fail "$step" "expected exactly one set in status --json (the disabled-here set must not appear): $status_json"


### PR DESCRIPTION
## Summary

- write an independent 30-second per-run heartbeat using system uptime and classify live, stalled, and abandoned runs after a five-minute awake-time threshold
- surface stalled runs consistently in Core health, the app, human status, and JSON without presenting them as progress or safe-to-delete wreckage
- query `launchctl print gui/$UID/net.herila.ResticStation.helper` so macOS status reports loaded, missing, or unknown LaunchAgent health
- preserve pid-only behavior for legacy current-run files and update cross-platform CLI fixtures/docs

## Validation

- `swift test --package-path Core` — 567 tests passed
- `swift test` — 76 tests passed
- `xcodebuild -scheme "Restic Station" build CODE_SIGNING_ALLOWED=NO`
- `scripts/headless-cli-test.sh` (includes live-pid/stale-heartbeat regression)
- `scripts/secret-cli-test.sh`
- `scripts/integration-test.sh` — all assertions passed with real restic
- aarch64 musl Linux cross-compile
- `git diff --check` and shell syntax checks

Fixes #54
Fixes #55