### PR TITLE
Correct diagnostic search and timeout details

### DIFF
--- a/Core/Sources/ResticStationCore/Restic/ResticDiscovery.swift
+++ b/Core/Sources/ResticStationCore/Restic/ResticDiscovery.swift
@@ -303,12 +303,20 @@ public struct ResticDiscovery: Sendable {
             let probe = await probe(path: path)
             switch probe.outcome {
             case .ok:
-                return ResticDiscoveryResult(chosen: probe, rejected: rejected)
+                return ResticDiscoveryResult(
+                    chosen: probe,
+                    rejected: rejected,
+                    searchedDescription: searchedDescription
+                )
             case .tooOld, .unusable:
                 rejected.append(probe)
             }
         }
-        return ResticDiscoveryResult(chosen: nil, rejected: rejected)
+        return ResticDiscoveryResult(
+            chosen: nil,
+            rejected: rejected,
+            searchedDescription: searchedDescription
+        )
     }
 }
 
@@ -354,10 +362,15 @@ public struct ResticDiscoveryResult: Equatable, Sendable {
     /// Candidates that were found and executed but rejected, in probe order
     /// — the raw material for "0.16.4 found, 0.17.0+ required".
     public let rejected: [ResticProbe]
+    /// The locations configured on the discovery instance that produced this
+    /// result. Keeping the description with the result prevents diagnostics
+    /// from substituting the platform defaults after a customized search.
+    public let searchedDescription: String
 
-    public init(chosen: ResticProbe?, rejected: [ResticProbe]) {
+    public init(chosen: ResticProbe?, rejected: [ResticProbe], searchedDescription: String) {
         self.chosen = chosen
         self.rejected = rejected
+        self.searchedDescription = searchedDescription
     }
 
     /// The first rejected candidate that at least *ran* but was too old —

--- a/Core/Tests/ResticStationCoreTests/Restic/ResticDiscoveryTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Restic/ResticDiscoveryTests.swift
@@ -527,14 +527,17 @@ import Testing
 
     // MARK: - searchedDescription
 
-    @Test("the failure message names what was searched")
-    func searchedDescriptionNamesTheList() {
+    @Test("the result carries the injected search description")
+    func searchedDescriptionNamesTheList() async {
         let discovery = ResticDiscovery(
-            wellKnownPaths: ResticDiscovery.linuxWellKnownPaths,
-            environment: [:],
+            wellKnownPaths: ["/custom/bin/restic"],
+            environment: ["PATH": "/another/custom/bin"],
             runner: ProbeRunner([:])
         )
         #expect(discovery.searchedDescription
-            == "/usr/bin/restic, /usr/local/bin/restic, /opt/restic/bin/restic, and every directory on PATH")
+            == "/custom/bin/restic, and every directory on PATH")
+
+        let result = await discovery.discover()
+        #expect(result.searchedDescription == discovery.searchedDescription)
     }
 }

--- a/Helper/Sources/ResticPathResolution.swift
+++ b/Helper/Sources/ResticPathResolution.swift
@@ -107,8 +107,7 @@ extension HelperContext {
         return "restic not configured — open Restic Station"
         #else
         return """
-            restic not found. Searched \(ResticDiscovery.wellKnownPaths.joined(separator: ", ")), \
-            and every directory on PATH.
+            restic not found. Searched \(result.searchedDescription).
             \(Self.officialBinaryAdvice)
             \(Self.resticPathAdvice(paths: paths))
             """

--- a/Helper/Sources/SystemdTimerManager.swift
+++ b/Helper/Sources/SystemdTimerManager.swift
@@ -42,7 +42,8 @@ struct SystemdTimerManager {
     /// as a cheap check safe to run as often as a monitoring system likes,
     /// and a monitoring system that runs it every minute must not be able to
     /// accumulate overlapping helper processes against a wedged user bus.
-    /// Three calls at 5s is a worst case a per-minute check survives.
+    /// Three calls at 5s plus up to 10s termination grace per timed-out
+    /// process is a roughly 45s worst case a per-minute check survives.
     static let verdictOnlyTimeout: TimeInterval = 5
 
     var serviceUnitURL: URL {
@@ -202,8 +203,9 @@ struct SystemdTimerManager {
     ///     the slowest call here, and pure narrative — is waste that a
     ///     wedged D-Bus turns into a stall. Also shortens the per-command
     ///     timeout, so the whole probe is bounded by
-    ///     `verdictOnlyTimeout × 3` rather than `commandTimeout × 4` plus
-    ///     termination grace (`@codex review` on #51).
+    ///     three `verdictOnlyTimeout` windows plus up to three termination
+    ///     grace periods, rather than four full `commandTimeout` windows and
+    ///     their termination grace (`@codex review` on #51).
     func status(
         helperPath: String? = nil,
         dataDirectory: String? = nil,

--- a/Helper/Tests/HelperTests/PlatformConditionalTests.swift
+++ b/Helper/Tests/HelperTests/PlatformConditionalTests.swift
@@ -220,7 +220,11 @@ import ResticStationCore
         let paths = testPaths
         let message = HelperContext.resticNotFoundMessage(
             paths: paths,
-            result: ResticDiscoveryResult(chosen: nil, rejected: [])
+            result: ResticDiscoveryResult(
+                chosen: nil,
+                rejected: [],
+                searchedDescription: "/custom/restic and the injected PATH"
+            )
         )
 
         #if os(macOS)
@@ -229,9 +233,8 @@ import ResticStationCore
         #expect(message == "restic not configured — open Restic Station")
         #else
         // Headless: name what was searched and how to fix it.
-        #expect(message.contains("/usr/bin/restic"))
-        #expect(message.contains("/opt/restic/bin/restic"))
-        #expect(message.contains("every directory on PATH"))
+        #expect(message.contains("/custom/restic and the injected PATH"))
+        #expect(!message.contains("/usr/bin/restic"))
         #expect(message.contains("Install an official release binary"))
         // machine.json, not config.json: the binary path is per-machine (T24).
         #expect(message.contains(paths.machineFile.path))
@@ -248,7 +251,8 @@ import ResticStationCore
         let paths = testPaths
         let result = ResticDiscoveryResult(
             chosen: nil,
-            rejected: [ResticProbe(path: "/usr/bin/restic", outcome: .tooOld(version: "0.16.4"))]
+            rejected: [ResticProbe(path: "/usr/bin/restic", outcome: .tooOld(version: "0.16.4"))],
+            searchedDescription: "test search"
         )
         let message = HelperContext.resticNotFoundMessage(paths: paths, result: result)
 
@@ -277,7 +281,8 @@ import ResticStationCore
             rejected: [ResticProbe(
                 path: "/opt/homebrew/bin/restic",
                 outcome: .unusable(reason: "/opt/homebrew/bin/restic exited 72 when asked for its version.")
-            )]
+            )],
+            searchedDescription: "test search"
         )
         let message = HelperContext.resticNotFoundMessage(paths: testPaths, result: result)
 
@@ -296,7 +301,8 @@ import ResticStationCore
             rejected: [
                 ResticProbe(path: "/broken/restic", outcome: .unusable(reason: "could not be run.")),
                 ResticProbe(path: "/usr/bin/restic", outcome: .tooOld(version: "0.16.4")),
-            ]
+            ],
+            searchedDescription: "test search"
         )
         let message = HelperContext.resticNotFoundMessage(paths: testPaths, result: result)
 


### PR DESCRIPTION
Closes #59.

## What changed
- carry each ResticDiscovery instance search description on ResticDiscoveryResult
- use that captured description in the Linux not-found diagnostic
- document the verdict-only timeout as approximately 45 seconds when all three processes consume timeout plus termination grace
- cover injected search descriptions in Core and helper regression tests

## Why
The helper previously substituted the static platform default list after discovery, so an injected search could be reported inaccurately. The timeout comments also omitted ProcessRunning termination grace.

## Validation
- swift test --filter PlatformConditionalTests
- swift test --package-path Core --filter ResticDiscoveryTests
- git diff --check