### PR TITLE
Add per-machine configuration UI

### DIFF
--- a/App/Sources/ViewModels/AppModel.swift
+++ b/App/Sources/ViewModels/AppModel.swift
@@ -32,8 +32,8 @@ final class AppModel: ObservableObject {
     /// The loaded configuration, **as written** — every per-machine
     /// `machines` override still on it. This is the value the editors read
     /// and `saveConfig(_:)` writes back, which is what keeps round-tripping
-    /// safe: the app does not yet edit `machines` keys (per-machine editing
-    /// UI is a follow-up), and it must never drop the ones it finds.
+    /// safe: machine-aware editors mutate only the selected sparse override,
+    /// and ordinary edits must never drop overrides they do not touch.
     /// Read-only to views; edits go through `saveConfig(_:)` /
     /// `updateConfig(_:)`.
     @Published private(set) var config: AppConfig

--- a/App/Sources/Views/Sets/DestinationEditorView.swift
+++ b/App/Sources/Views/Sets/DestinationEditorView.swift
@@ -52,6 +52,7 @@ struct DestinationEditorView: View {
     @State private var probe: DestinationProbeOutcome?
     @State private var busy: BusyKind?
     @State private var message: EditorMessage?
+    @State private var showingMachineOverrides = false
 
     init(set: Binding<BackupSet>, initialDestination destination: Destination, isNew: Bool) {
         _set = set
@@ -86,6 +87,8 @@ struct DestinationEditorView: View {
             Form {
                 identitySection
 
+                machineOverridesSection
+
                 switch kind {
                 case .local:
                     localSection
@@ -107,6 +110,13 @@ struct DestinationEditorView: View {
         .frame(minWidth: 620, idealWidth: 680, minHeight: 560, idealHeight: 640)
         .task {
             await loadSecrets()
+        }
+        .sheet(isPresented: $showingMachineOverrides) {
+            DestinationMachineOverridesEditor(
+                destination: $draft,
+                sharedConfig: model.config,
+                currentMachineID: model.machine.machineId
+            )
         }
     }
 
@@ -138,6 +148,20 @@ struct DestinationEditorView: View {
                     Text(formKind.title).tag(formKind)
                 }
             }
+        }
+    }
+
+    private var machineOverridesSection: some View {
+        Section {
+            LabeledContent("Configured profiles", value: "\(draft.machines?.count ?? 0)")
+            Button("Edit Machine Overrides…") { openMachineOverrides() }
+        } header: {
+            Text("Machine overrides")
+        } footer: {
+            Text("Override this destination's enabled state, complete repository URL, or non-secret "
+                + "environment per machine. Secrets stay in the local secret store.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
         }
     }
 
@@ -451,6 +475,15 @@ struct DestinationEditorView: View {
     }
 
     // MARK: - Actions
+
+    private func openMachineOverrides() {
+        // The destination form decomposes the shared URL into friendlier
+        // fields. Bring those pending values into the draft before the
+        // machine editor offers them as the starting point for an override.
+        draft.repoURL = assembledRepoURL
+        draft.nonSecretEnv = assembledNonSecretEnv
+        showingMachineOverrides = true
+    }
 
     private func chooseFolder() {
         let panel = NSOpenPanel()

--- a/App/Sources/Views/Sets/MachineOverrideViews.swift
+++ b/App/Sources/Views/Sets/MachineOverrideViews.swift
@@ -1,0 +1,591 @@
+import ResticStationCore
+import SwiftUI
+
+// MARK: - Testable effective-plan model
+
+enum MachineOverrideUI {
+    static func knownMachineIDs(
+        config: AppConfig,
+        currentMachineID: String,
+        additional: some Sequence<String> = EmptyCollection<String>()
+    ) -> [String] {
+        var ids = Set(config.referencedMachineIds)
+        ids.insert(currentMachineID)
+        ids.formUnion(additional)
+        return ids.sorted()
+    }
+
+    static func effectivePlan(config: AppConfig, machineID: String) -> MachineEffectivePlan {
+        let addressable = config.addressable(for: machineID)
+        let scheduled = config.resolved(for: machineID)
+        let scheduledSets = Dictionary(uniqueKeysWithValues: scheduled.config.sets.map { ($0.id, $0) })
+
+        let sets = addressable.config.sets.map { set in
+            let scheduledSet = scheduledSets[set.id]
+            let enabledDestinationIDs = Set((scheduledSet?.destinations ?? []).map(\.id))
+            return MachineEffectiveSet(
+                id: set.id,
+                name: set.name,
+                enabled: scheduledSet != nil,
+                sources: set.sources,
+                schedule: set.schedule,
+                destinations: set.destinations.map { destination in
+                    MachineEffectiveDestination(
+                        id: destination.id,
+                        label: destination.label,
+                        repoURL: destination.repoURL,
+                        isPrimary: destination.isPrimary,
+                        enabled: enabledDestinationIDs.contains(destination.id)
+                    )
+                }
+            )
+        }
+
+        return MachineEffectivePlan(
+            machineID: machineID,
+            sets: sets,
+            exclusions: scheduled.omissions.map(String.init(describing:))
+        )
+    }
+}
+
+struct MachineEffectivePlan: Equatable, Sendable {
+    let machineID: String
+    let sets: [MachineEffectiveSet]
+    let exclusions: [String]
+}
+
+struct MachineEffectiveSet: Equatable, Identifiable, Sendable {
+    let id: UUID
+    let name: String
+    let enabled: Bool
+    let sources: [String]
+    let schedule: Schedule
+    let destinations: [MachineEffectiveDestination]
+}
+
+struct MachineEffectiveDestination: Equatable, Identifiable, Sendable {
+    let id: UUID
+    let label: String
+    let repoURL: String
+    let isPrimary: Bool
+    let enabled: Bool
+}
+
+// MARK: - Effective-plan sheet
+
+struct MachineEffectivePlanView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    let config: AppConfig
+    let currentMachineID: String
+    @State private var selectedMachineID: String
+
+    init(config: AppConfig, currentMachineID: String) {
+        self.config = config
+        self.currentMachineID = currentMachineID
+        _selectedMachineID = State(initialValue: currentMachineID)
+    }
+
+    private var machineIDs: [String] {
+        MachineOverrideUI.knownMachineIDs(config: config, currentMachineID: currentMachineID)
+    }
+
+    private var plan: MachineEffectivePlan {
+        MachineOverrideUI.effectivePlan(config: config, machineID: selectedMachineID)
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Effective Backup Plan")
+                        .font(.title3.weight(.semibold))
+                    Text("Preview exactly what a machine will back up, after shared-config overrides.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Button("Done") { dismiss() }
+                    .keyboardShortcut(.defaultAction)
+            }
+            .padding(20)
+
+            Divider()
+
+            Form {
+                Section("Machine") {
+                    Picker("Profile", selection: $selectedMachineID) {
+                        ForEach(machineIDs, id: \.self) { machineID in
+                            Text(machineLabel(machineID)).tag(machineID)
+                        }
+                    }
+                    Text("These are the machine IDs referenced by config.json, plus this host. "
+                        + "Previewing another profile does not edit this host's machine.json.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+
+                if plan.sets.isEmpty {
+                    Section {
+                        ContentUnavailableView(
+                            "Nothing runs on this machine",
+                            systemImage: "externaldrive.badge.xmark",
+                            description: Text("Review the exclusions below to see why.")
+                        )
+                    }
+                } else {
+                    ForEach(plan.sets) { set in
+                        effectiveSetSection(set)
+                    }
+                }
+
+                if !plan.exclusions.isEmpty {
+                    Section("Excluded on this machine") {
+                        ForEach(plan.exclusions, id: \.self) { exclusion in
+                            Label(exclusion, systemImage: "minus.circle")
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
+            .formStyle(.grouped)
+        }
+        .frame(minWidth: 700, idealWidth: 780, minHeight: 580, idealHeight: 700)
+    }
+
+    private func machineLabel(_ machineID: String) -> String {
+        machineID == currentMachineID ? "\(machineID) — this host" : machineID
+    }
+
+    private func effectiveSetSection(_ set: MachineEffectiveSet) -> some View {
+        Section {
+            LabeledContent("Status") {
+                Label(
+                    set.enabled ? "Runs here" : "Does not run here",
+                    systemImage: set.enabled ? "checkmark.circle.fill" : "minus.circle.fill"
+                )
+                .foregroundStyle(set.enabled ? .green : .secondary)
+            }
+            LabeledContent("Schedule", value: SetsCopy.scheduleSummary(set.schedule))
+            LabeledContent("Sources") {
+                VStack(alignment: .trailing, spacing: 3) {
+                    if set.sources.isEmpty {
+                        Text("None")
+                    } else {
+                        ForEach(set.sources, id: \.self) { source in
+                            Text(source).monospaced().textSelection(.enabled)
+                        }
+                    }
+                }
+            }
+            ForEach(set.destinations) { destination in
+                LabeledContent(destination.isPrimary ? "Primary" : "Secondary") {
+                    VStack(alignment: .trailing, spacing: 2) {
+                        Label(
+                            destination.label,
+                            systemImage: destination.enabled ? "checkmark.circle" : "minus.circle"
+                        )
+                        Text(destination.repoURL)
+                            .font(.caption.monospaced())
+                            .foregroundStyle(.secondary)
+                            .textSelection(.enabled)
+                    }
+                }
+            }
+        } header: {
+            Text(set.name)
+        }
+    }
+}
+
+// MARK: - Backup-set override editor
+
+struct SetMachineOverridesEditor: View {
+    @Environment(\.dismiss) private var dismiss
+
+    @Binding var set: BackupSet
+    let sharedConfig: AppConfig
+    let currentMachineID: String
+
+    @State private var selectedMachineID: String
+    @State private var newMachineID = ""
+    @State private var machineIDError: String?
+
+    init(set: Binding<BackupSet>, sharedConfig: AppConfig, currentMachineID: String) {
+        _set = set
+        self.sharedConfig = sharedConfig
+        self.currentMachineID = currentMachineID
+        _selectedMachineID = State(initialValue: currentMachineID)
+    }
+
+    private var machineIDs: [String] {
+        MachineOverrideUI.knownMachineIDs(
+            config: sharedConfig,
+            currentMachineID: currentMachineID,
+            additional: self.set.machines.map { Array($0.keys) } ?? []
+        )
+    }
+
+    private var selectedOverride: BackupSetMachineOverride {
+        self.set.machines?[selectedMachineID] ?? BackupSetMachineOverride()
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            sheetHeader(title: "Backup Set Machine Overrides")
+            Divider()
+            Form {
+                profileSection
+                enabledSection
+
+                Section {
+                    Toggle("Replace the shared sources", isOn: sourcesOverrideEnabled)
+                    Text("A machine source list replaces the shared list completely; it is never merged.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                } header: {
+                    Text("Sources")
+                }
+                if selectedOverride.sources != nil {
+                    SourcesSection(sources: sourcesBinding, errorMessage: nil)
+                }
+
+                Section {
+                    Toggle("Replace the shared schedule", isOn: scheduleOverrideEnabled)
+                    Text("When off, this machine inherits \(SetsCopy.scheduleSummary(self.set.schedule)).")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                } header: {
+                    Text("Schedule")
+                }
+                if selectedOverride.schedule != nil {
+                    ScheduleSection(schedule: scheduleBinding, errorMessage: nil)
+                }
+
+                removeSection
+            }
+            .formStyle(.grouped)
+        }
+        .frame(minWidth: 680, idealWidth: 760, minHeight: 620, idealHeight: 720)
+    }
+
+    private func sheetHeader(title: String) -> some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title).font(.title3.weight(.semibold))
+                Text(self.set.name).font(.callout).foregroundStyle(.secondary)
+            }
+            Spacer()
+            Button("Done") { dismiss() }.keyboardShortcut(.defaultAction)
+        }
+        .padding(20)
+    }
+
+    private var profileSection: some View {
+        Section {
+            Picker("Machine", selection: $selectedMachineID) {
+                ForEach(machineIDs, id: \.self) { machineID in
+                    Text(machineID == currentMachineID ? "\(machineID) — this host" : machineID)
+                        .tag(machineID)
+                }
+            }
+            HStack {
+                TextField("new-machine-id", text: $newMachineID)
+                    .monospaced()
+                Button("Add Profile") { addProfile() }
+                    .disabled(newMachineID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+            if let machineIDError {
+                InlineMessage(machineIDError)
+            }
+            Text("Only config.json is edited. This host's machine.json identity remains local and unchanged.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        } header: {
+            Text("Machine profile")
+        }
+    }
+
+    private var enabledSection: some View {
+        Section {
+            Picker("Back up this set", selection: enabledBinding) {
+                Text("Inherit (enabled)").tag(Bool?.none)
+                Text("Enabled").tag(Bool?.some(true))
+                Text("Disabled").tag(Bool?.some(false))
+            }
+            Text("Disable the whole set when this machine should not schedule backups for it.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        } header: {
+            Text("Availability")
+        }
+    }
+
+    private var removeSection: some View {
+        Section {
+            Button("Remove Override for \(selectedMachineID)", role: .destructive) {
+                var machines = self.set.machines ?? [:]
+                machines.removeValue(forKey: selectedMachineID)
+                self.set.machines = machines.isEmpty ? nil : machines
+            }
+            .disabled(self.set.machines?[selectedMachineID] == nil)
+        } footer: {
+            Text("Removing an override makes this machine inherit all shared values.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var enabledBinding: Binding<Bool?> {
+        Binding(get: { selectedOverride.enabled }, set: { value in mutateOverride { $0.enabled = value } })
+    }
+
+    private var sourcesOverrideEnabled: Binding<Bool> {
+        Binding(
+            get: { selectedOverride.sources != nil },
+            set: { enabled in mutateOverride { $0.sources = enabled ? self.set.sources : nil } }
+        )
+    }
+
+    private var sourcesBinding: Binding<[String]> {
+        Binding(
+            get: { selectedOverride.sources ?? self.set.sources },
+            set: { value in mutateOverride { $0.sources = value } }
+        )
+    }
+
+    private var scheduleOverrideEnabled: Binding<Bool> {
+        Binding(
+            get: { selectedOverride.schedule != nil },
+            set: { enabled in mutateOverride { $0.schedule = enabled ? self.set.schedule : nil } }
+        )
+    }
+
+    private var scheduleBinding: Binding<Schedule> {
+        Binding(
+            get: { selectedOverride.schedule ?? self.set.schedule },
+            set: { value in mutateOverride { $0.schedule = value } }
+        )
+    }
+
+    private func mutateOverride(_ mutate: (inout BackupSetMachineOverride) -> Void) {
+        var machines = self.set.machines ?? [:]
+        var value = machines[selectedMachineID] ?? BackupSetMachineOverride()
+        mutate(&value)
+        machines[selectedMachineID] = value
+        self.set.machines = machines
+    }
+
+    private func addProfile() {
+        let value = newMachineID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard MachineIdentity.isValid(value) else {
+            machineIDError = "Use lowercase letters, numbers, and hyphens only."
+            return
+        }
+        var machines = self.set.machines ?? [:]
+        machines[value] = machines[value] ?? BackupSetMachineOverride()
+        self.set.machines = machines
+        selectedMachineID = value
+        newMachineID = ""
+        machineIDError = nil
+    }
+}
+
+// MARK: - Destination override editor
+
+struct DestinationMachineOverridesEditor: View {
+    @Environment(\.dismiss) private var dismiss
+
+    @Binding var destination: Destination
+    let sharedConfig: AppConfig
+    let currentMachineID: String
+
+    @State private var selectedMachineID: String
+    @State private var newMachineID = ""
+    @State private var machineIDError: String?
+    @State private var environmentRows: [EnvRow]
+
+    init(destination: Binding<Destination>, sharedConfig: AppConfig, currentMachineID: String) {
+        _destination = destination
+        self.sharedConfig = sharedConfig
+        self.currentMachineID = currentMachineID
+        _selectedMachineID = State(initialValue: currentMachineID)
+        _environmentRows = State(initialValue: EnvRow.rows(
+            from: destination.wrappedValue.machines?[currentMachineID]?.nonSecretEnv ?? [:],
+            excludingKeys: []
+        ))
+    }
+
+    private var machineIDs: [String] {
+        MachineOverrideUI.knownMachineIDs(
+            config: sharedConfig,
+            currentMachineID: currentMachineID,
+            additional: destination.machines.map { Array($0.keys) } ?? []
+        )
+    }
+
+    private var selectedOverride: DestinationMachineOverride {
+        destination.machines?[selectedMachineID] ?? DestinationMachineOverride()
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Destination Machine Overrides").font(.title3.weight(.semibold))
+                    Text(destination.label).font(.callout).foregroundStyle(.secondary)
+                }
+                Spacer()
+                Button("Done") { dismiss() }.keyboardShortcut(.defaultAction)
+            }
+            .padding(20)
+            Divider()
+            Form {
+                profileSection
+
+                Section("Availability") {
+                    Picker("Use this destination", selection: enabledBinding) {
+                        Text("Inherit (enabled)").tag(Bool?.none)
+                        Text("Enabled").tag(Bool?.some(true))
+                        Text("Disabled").tag(Bool?.some(false))
+                    }
+                    Text("Disable a destination that is unavailable on this machine. "
+                        + "A running set must still have exactly one enabled primary.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+
+                Section("Repository URL") {
+                    Toggle("Replace the shared repository URL", isOn: repoURLOverrideEnabled)
+                    if selectedOverride.repoURL != nil {
+                        TextField("Repository URL", text: repoURLBinding)
+                            .monospaced()
+                    }
+                    Text("The override is a complete restic repository URL, not a partial path.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+
+                Section("Non-secret environment") {
+                    Toggle("Replace the shared environment", isOn: environmentOverrideEnabled)
+                    if selectedOverride.nonSecretEnv != nil {
+                        EnvRowsEditor(rows: $environmentRows, isSecret: false)
+                    }
+                    Text("This dictionary replaces the shared values completely. Passwords and secret "
+                        + "variables remain in the destination's local secret store and are never written here.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+
+                Section {
+                    Button("Remove Override for \(selectedMachineID)", role: .destructive) {
+                        var machines = destination.machines ?? [:]
+                        machines.removeValue(forKey: selectedMachineID)
+                        destination.machines = machines.isEmpty ? nil : machines
+                        environmentRows = []
+                    }
+                    .disabled(destination.machines?[selectedMachineID] == nil)
+                } footer: {
+                    Text("Removing an override makes this machine inherit all shared values.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .formStyle(.grouped)
+        }
+        .frame(minWidth: 680, idealWidth: 760, minHeight: 600, idealHeight: 700)
+        .onChange(of: environmentRows) { _, rows in
+            guard selectedOverride.nonSecretEnv != nil else { return }
+            mutateOverride { $0.nonSecretEnv = EnvRow.dictionary(from: rows) }
+        }
+    }
+
+    private var profileSection: some View {
+        Section {
+            Picker("Machine", selection: Binding(
+                get: { selectedMachineID },
+                set: { selectMachine($0) }
+            )) {
+                ForEach(machineIDs, id: \.self) { machineID in
+                    Text(machineID == currentMachineID ? "\(machineID) — this host" : machineID)
+                        .tag(machineID)
+                }
+            }
+            HStack {
+                TextField("new-machine-id", text: $newMachineID).monospaced()
+                Button("Add Profile") { addProfile() }
+                    .disabled(newMachineID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+            if let machineIDError { InlineMessage(machineIDError) }
+            Text("Only config.json is edited. This host's machine.json identity remains local and unchanged.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        } header: {
+            Text("Machine profile")
+        }
+    }
+
+    private var enabledBinding: Binding<Bool?> {
+        Binding(get: { selectedOverride.enabled }, set: { value in mutateOverride { $0.enabled = value } })
+    }
+
+    private var repoURLOverrideEnabled: Binding<Bool> {
+        Binding(
+            get: { selectedOverride.repoURL != nil },
+            set: { enabled in mutateOverride { $0.repoURL = enabled ? destination.repoURL : nil } }
+        )
+    }
+
+    private var repoURLBinding: Binding<String> {
+        Binding(
+            get: { selectedOverride.repoURL ?? destination.repoURL },
+            set: { value in mutateOverride { $0.repoURL = value } }
+        )
+    }
+
+    private var environmentOverrideEnabled: Binding<Bool> {
+        Binding(
+            get: { selectedOverride.nonSecretEnv != nil },
+            set: { enabled in
+                if enabled {
+                    environmentRows = EnvRow.rows(from: destination.nonSecretEnv, excludingKeys: [])
+                    mutateOverride { $0.nonSecretEnv = destination.nonSecretEnv }
+                } else {
+                    mutateOverride { $0.nonSecretEnv = nil }
+                    environmentRows = []
+                }
+            }
+        )
+    }
+
+    private func mutateOverride(_ mutate: (inout DestinationMachineOverride) -> Void) {
+        var machines = destination.machines ?? [:]
+        var value = machines[selectedMachineID] ?? DestinationMachineOverride()
+        mutate(&value)
+        machines[selectedMachineID] = value
+        destination.machines = machines
+    }
+
+    private func selectMachine(_ machineID: String) {
+        selectedMachineID = machineID
+        environmentRows = EnvRow.rows(
+            from: destination.machines?[machineID]?.nonSecretEnv ?? [:],
+            excludingKeys: []
+        )
+        machineIDError = nil
+    }
+
+    private func addProfile() {
+        let value = newMachineID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard MachineIdentity.isValid(value) else {
+            machineIDError = "Use lowercase letters, numbers, and hyphens only."
+            return
+        }
+        var machines = destination.machines ?? [:]
+        machines[value] = machines[value] ?? DestinationMachineOverride()
+        destination.machines = machines
+        newMachineID = ""
+        selectMachine(value)
+    }
+}

--- a/App/Sources/Views/Sets/SetEditorView.swift
+++ b/App/Sources/Views/Sets/SetEditorView.swift
@@ -19,6 +19,7 @@ struct SetEditorView: View {
     @State private var isNew: Bool
     @State private var fieldErrors: [SetEditorField: String] = [:]
     @State private var didSave = false
+    @State private var showingMachineOverrides = false
 
     init(initialSet: BackupSet, isNew: Bool) {
         _draft = State(initialValue: initialSet)
@@ -40,6 +41,8 @@ struct SetEditorView: View {
                 schedule: $draft.schedule,
                 errorMessage: fieldErrors[.schedule]
             )
+
+            machineOverridesSection
 
             stalenessSection
 
@@ -67,6 +70,13 @@ struct SetEditorView: View {
         .toolbar { toolbarContent }
         .onChange(of: draft) { _, _ in
             didSave = false
+        }
+        .sheet(isPresented: $showingMachineOverrides) {
+            SetMachineOverridesEditor(
+                set: $draft,
+                sharedConfig: model.config,
+                currentMachineID: model.machine.machineId
+            )
         }
     }
 
@@ -100,6 +110,42 @@ struct SetEditorView: View {
         } header: {
             Text("Staleness warning")
         }
+    }
+
+    private var machineOverridesSection: some View {
+        Section {
+            LabeledContent("This host") {
+                let plan = MachineOverrideUI.effectivePlan(
+                    config: configReplacingDraft,
+                    machineID: model.machine.machineId
+                )
+                let runsHere = plan.sets.first(where: { $0.id == draft.id })?.enabled == true
+                Label(
+                    runsHere ? "Runs here" : "Does not run here",
+                    systemImage: runsHere ? "checkmark.circle.fill" : "minus.circle.fill"
+                )
+                .foregroundStyle(runsHere ? .green : .secondary)
+            }
+            LabeledContent("Configured profiles", value: "\(draft.machines?.count ?? 0)")
+            Button("Edit Machine Overrides…") { showingMachineOverrides = true }
+        } header: {
+            Text("Machine overrides")
+        } footer: {
+            Text("Override this set's enabled state, complete source list, or schedule per machine. "
+                + "Overrides live in shared config.json; this host's machine.json is never edited here.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var configReplacingDraft: AppConfig {
+        var config = model.config
+        if let index = config.sets.firstIndex(where: { $0.id == draft.id }) {
+            config.sets[index] = draft
+        } else {
+            config.sets.append(draft)
+        }
+        return config
     }
 
     // MARK: - Toolbar

--- a/App/Sources/Views/Sets/SetListView.swift
+++ b/App/Sources/Views/Sets/SetListView.swift
@@ -18,6 +18,7 @@ struct SetListView: View {
 
     /// The set the delete confirmation is about (`nil` = not shown).
     @State private var pendingDeletion: BackupSet?
+    @State private var showingEffectivePlan = false
 
     var body: some View {
         Group {
@@ -47,7 +48,20 @@ struct SetListView: View {
                 }
                 .disabled(selectedSet == nil)
                 .help("Delete the selected backup set")
+
+                Button {
+                    showingEffectivePlan = true
+                } label: {
+                    Label("Effective Plan", systemImage: "desktopcomputer.and.macbook")
+                }
+                .help("Preview what each configured machine will back up")
             }
+        }
+        .sheet(isPresented: $showingEffectivePlan) {
+            MachineEffectivePlanView(
+                config: model.config,
+                currentMachineID: model.machine.machineId
+            )
         }
         .alert(
             "Delete “\(pendingDeletion?.name ?? "")”?",

--- a/App/Tests/AppModelMachineOverrideTests.swift
+++ b/App/Tests/AppModelMachineOverrideTests.swift
@@ -6,6 +6,64 @@ import Testing
 @Suite("AppModel machine override wiring", .serialized)
 @MainActor
 struct AppModelMachineOverrideTests {
+    @Test("known machines and effective-plan preview include exclusions and replacements")
+    func effectivePlanPreview() throws {
+        let setId = UUID()
+        let primaryId = UUID()
+        let secondaryId = UUID()
+        let machineId = "linux-nas"
+        let config = AppConfig(sets: [
+            BackupSet(
+                id: setId,
+                name: "Projects",
+                sources: ["/Users/shared/Projects"],
+                schedule: .daily(hour: 2, minute: 30),
+                destinations: [
+                    Destination(
+                        id: primaryId,
+                        label: "Primary",
+                        repoURL: "/Volumes/shared/projects.restic",
+                        isPrimary: true,
+                        machines: [
+                            machineId: DestinationMachineOverride(
+                                repoURL: "/srv/restic/projects",
+                                nonSecretEnv: ["CACHE": "/var/cache/restic"]
+                            )
+                        ]
+                    ),
+                    Destination(
+                        id: secondaryId,
+                        label: "Portable",
+                        repoURL: "/Volumes/Portable/projects.restic",
+                        isPrimary: false,
+                        machines: [machineId: DestinationMachineOverride(enabled: false)]
+                    ),
+                ],
+                machines: [
+                    machineId: BackupSetMachineOverride(
+                        sources: ["/srv/projects"],
+                        schedule: .hourly(minute: 15)
+                    )
+                ]
+            ),
+        ])
+
+        #expect(MachineOverrideUI.knownMachineIDs(
+            config: config,
+            currentMachineID: "studio-mac"
+        ) == ["linux-nas", "studio-mac"])
+
+        let plan = MachineOverrideUI.effectivePlan(config: config, machineID: machineId)
+        let set = try #require(plan.sets.first)
+        #expect(set.enabled)
+        #expect(set.sources == ["/srv/projects"])
+        #expect(set.schedule == .hourly(minute: 15))
+        #expect(set.destinations.first(where: { $0.id == primaryId })?.repoURL == "/srv/restic/projects")
+        #expect(set.destinations.first(where: { $0.id == primaryId })?.enabled == true)
+        #expect(set.destinations.first(where: { $0.id == secondaryId })?.enabled == false)
+        #expect(plan.exclusions.contains { $0.contains("Portable") && $0.contains("disabled") })
+    }
+
     @Test("restore, maintenance, and repository actions use the addressable override")
     func destinationConsumersUseMachineOverride() throws {
         let root = FileManager.default.temporaryDirectory

--- a/docs/ui-spec.md
+++ b/docs/ui-spec.md
@@ -29,16 +29,20 @@ Quitting the app does NOT stop scheduled backups (they're launchd's job) — the
 
 **List** (sidebar selection → content): table/list of sets: name, source count, primary destination label + kind icon, schedule summary ("Daily 02:30"), last run status badge, next due time (via ScheduleMath, display only). Toolbar: add set, delete set (confirmation: "Deletes the backup set configuration. Repositories and snapshots are NOT touched."). Empty state: short explainer + "Create your first backup set".
 
+The toolbar's **Effective Plan** sheet lists the union of machine IDs referenced anywhere in `config.json`, plus this host's `machineId`. Picking a machine previews every effective source, schedule, repository URL, enabled destination, and exclusion reason. This is a preview of the shared configuration only; it never changes the host-local `machine.json`.
+
 **Set editor** (form):
 - Name.
 - **Sources**: list of absolute paths; add via `NSOpenPanel` (directories + files, multi-select), remove; warn inline (yellow) on nested/duplicate paths.
 - **Excludes**: editable string list; caption linking restic exclude-pattern syntax (`https://restic.readthedocs.io/en/stable/040_backup.html#excluding-files`).
 - **Schedule**: picker for kind (Every N minutes / Hourly / Daily / Weekly) with contextual fields (N stepper ≥5; minute; hour+minute; weekday+hour+minute).
+- **Machine overrides**: choose any known machine profile or add a valid machine ID, then inherit/enable/disable the set and optionally replace its complete sources list or schedule. Replacement arrays are labeled as replace-not-merge. Removing an override restores inheritance.
 - **Staleness warning**: stepper, days, default 14.
 - **Retention** (optional section, off = never forget): steppers/optional fields for keep-last/hourly/daily/weekly/monthly/yearly; default suggestion when enabling: 7 daily / 4 weekly / 12 monthly / 2 yearly. Footnote: "Applied to the primary after each backup, and mirrored to each secondary after it syncs."
 - **Integrity checks** (optional): toggle + slice count (default 20). Footnote: "Weekly `restic check`; over 20 weeks the entire repository's data is read and verified."
 - **Destinations**: table (label, repo, kind badge, PRIMARY tag, status dot reachable/offline/stale + "last synced N days ago"). Exactly-one-primary enforced by radio-style selection; changing primary shows an explanatory confirmation (new primary must already contain the data or the next backup re-uploads everything).
   - **Destination editor** (sheet): label; kind picker driving the form:
+    - **Machine overrides**: inherit/enable/disable this destination and optionally replace its complete repository URL or non-secret environment dictionary. Secret environment values and passwords stay in the local secret store and are never copied into shared config.
     - *Local folder*: path picker; inline warning if under `~/Library/Mobile Documents` ("iCloud may evict repository files with Optimize Mac Storage — this can corrupt reads; consider a non-synced location. Sync folders replicate deletions — treat this as a convenience copy, not your only backup."); note when under `/Volumes` ("Removable volume — will be skipped when not mounted" — for secondaries this is normal).
     - *S3-compatible*: endpoint URL (placeholder `https://<accountid>.r2.cloudflarestorage.com` / empty = AWS), bucket, path prefix, region (optional, "auto" hint for R2), Access Key ID (→ keychain env blob), Secret Access Key (SecureField → keychain env blob). The form assembles `repoURL = s3:<endpoint>/<bucket>/<prefix>`; show the assembled URL read-only.
     - *SFTP / REST / Other*: raw repo URL field + free-form non-secret env key/value table + secret env key/value table (values in SecureFields → keychain blob). Caption: "Anything restic accepts after `-r`."


### PR DESCRIPTION
## Summary
- add sparse per-machine editors for backup-set enabled/sources/schedule overrides
- add sparse per-machine editors for destination enabled/repository URL/non-secret environment overrides
- add an Effective Plan sheet showing every known machine, resolved values, and exclusion reasons
- keep machine.json explicitly read-only and document replace-not-merge behavior
- extend macOS app tests for known-machine discovery and effective-plan resolution

## Validation
- `xcodebuild -project ResticStation.xcodeproj -scheme "Restic Station" test CODE_SIGNING_ALLOWED=NO -derivedDataPath dd` (2 app tests)
- `swift test --package-path Core --filter ValidateMachineOverrideTests` (12 tests)
- real-app visual/accessibility walkthrough of the plan and set-override sheets
- real-app source override save, JSON readback, and `restic-station-helper config validate --machine demo-mac`
- `git diff --check`

Closes #39