### PR TITLE
Complete macOS background agent lifecycle

### DIFF
--- a/App/Sources/Support/LaunchdManager.swift
+++ b/App/Sources/Support/LaunchdManager.swift
@@ -45,6 +45,12 @@ public final class LaunchdManager: ObservableObject {
     /// is surfaced as information rather than thrown.
     @Published public private(set) var lastKickstartError: String?
 
+    /// Whether this copy of the app actually contains the LaunchAgent plist.
+    /// macOS can report `.notFound` before a first registration even when the
+    /// resource is present, so the UI must not turn that status alone into a
+    /// false "broken installation" diagnosis.
+    public let embeddedAgentExists: Bool
+
     private let service: SMAppService
     private let bundlePath: String
 
@@ -54,6 +60,7 @@ public final class LaunchdManager: ObservableObject {
     ) {
         self.service = service
         self.bundlePath = bundlePath
+        self.embeddedAgentExists = Self.embeddedAgentExists(in: bundlePath)
         self.status = service.status
         self.diagnostic = Self.diagnostic(for: service.status, bundlePath: bundlePath)
     }
@@ -181,7 +188,7 @@ public final class LaunchdManager: ObservableObject {
     /// One user-facing sentence per `SMAppService.Status`. All four
     /// documented cases are handled explicitly (plus `@unknown default`,
     /// since `SMAppService.Status` is a non-frozen ObjC enum).
-    static func diagnostic(for status: SMAppService.Status, bundlePath: String) -> String? {
+    nonisolated static func diagnostic(for status: SMAppService.Status, bundlePath: String) -> String? {
         switch status {
         case .enabled:
             return nil
@@ -193,6 +200,10 @@ public final class LaunchdManager: ObservableObject {
             return "Background backups are not set up yet. Registering the background "
                 + "agent lets Restic Station back up on schedule even while it is closed."
         case .notFound:
+            if embeddedAgentExists(in: bundlePath) {
+                return "Background backups are not set up yet. Registering the background "
+                    + "agent lets Restic Station back up on schedule even while it is closed."
+            }
             var message = "macOS could not find the background agent "
                 + "(\(plistName)) inside this copy of Restic Station."
             if isDerivedDataPath(bundlePath) {
@@ -215,8 +226,15 @@ public final class LaunchdManager: ObservableObject {
     /// lives under `~/Library/Developer/Xcode/DerivedData/…` by default but
     /// is freely relocatable via build settings, and `swift build` output
     /// paths differ again — the marker component is what's reliable.
-    static func isDerivedDataPath(_ path: String) -> Bool {
+    nonisolated static func isDerivedDataPath(_ path: String) -> Bool {
         path.contains("DerivedData")
+    }
+
+    nonisolated static func embeddedAgentExists(in bundlePath: String) -> Bool {
+        FileManager.default.fileExists(atPath: URL(fileURLWithPath: bundlePath, isDirectory: true)
+            .appendingPathComponent("Contents/Library/LaunchAgents", isDirectory: true)
+            .appendingPathComponent(plistName, isDirectory: false)
+            .path)
     }
 }
 

--- a/App/Sources/Views/Settings/OnboardingView.swift
+++ b/App/Sources/Views/Settings/OnboardingView.swift
@@ -220,9 +220,13 @@ struct OnboardingView: View {
                     case .requiresApproval:
                         Button("Open Login Items settings") { launchd.openLoginItemsSettings() }
                     case .notFound:
-                        VStack(alignment: .leading, spacing: 8) {
-                            CopyablePath(text: Bundle.main.bundlePath, helpText: "Copy this app's path")
-                            Button("Try to register anyway") { permissions.enableAgent(launchd: launchd) }
+                        if launchd.embeddedAgentExists {
+                            Button("Enable background agent") { permissions.enableAgent(launchd: launchd) }
+                        } else {
+                            VStack(alignment: .leading, spacing: 8) {
+                                CopyablePath(text: Bundle.main.bundlePath, helpText: "Copy this app's path")
+                                Button("Try to register anyway") { permissions.enableAgent(launchd: launchd) }
+                            }
                         }
                     default:
                         Button("Enable background agent") { permissions.enableAgent(launchd: launchd) }
@@ -427,7 +431,7 @@ struct OnboardingView: View {
         case .enabled: return "Enabled"
         case .requiresApproval: return "Requires approval"
         case .notRegistered: return "Not registered"
-        case .notFound: return "Not found"
+        case .notFound: return launchd.embeddedAgentExists ? "Not registered" : "Not found"
         @unknown default: return "Unknown"
         }
     }

--- a/App/Sources/Views/Settings/PermissionsView.swift
+++ b/App/Sources/Views/Settings/PermissionsView.swift
@@ -123,7 +123,18 @@ struct PermissionsView: View {
 
             switch launchd.status {
             case .enabled:
-                EmptyView()
+                HStack {
+                    Button("Remove") {
+                        pane.removeAgent(launchd: launchd, model: model)
+                    }
+                    .disabled(pane.agentOperationInProgress)
+                    if let error = pane.agentError {
+                        Text(error)
+                            .font(.callout)
+                            .foregroundStyle(.red)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
             case .requiresApproval:
                 Button("Open Login Items settings") {
                     launchd.openLoginItemsSettings()
@@ -141,16 +152,30 @@ struct PermissionsView: View {
                     }
                 }
             case .notFound:
-                VStack(alignment: .leading, spacing: 8) {
-                    CopyablePath(text: Bundle.main.bundlePath, helpText: "Copy this app's path")
-                    Button("Try to register anyway") {
-                        pane.enableAgent(launchd: launchd)
+                if launchd.embeddedAgentExists {
+                    HStack {
+                        Button("Enable") {
+                            pane.enableAgent(launchd: launchd)
+                        }
+                        if let error = pane.agentError {
+                            Text(error)
+                                .font(.callout)
+                                .foregroundStyle(.red)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
                     }
-                    if let error = pane.agentError {
-                        Text(error)
-                            .font(.callout)
-                            .foregroundStyle(.red)
-                            .fixedSize(horizontal: false, vertical: true)
+                } else {
+                    VStack(alignment: .leading, spacing: 8) {
+                        CopyablePath(text: Bundle.main.bundlePath, helpText: "Copy this app's path")
+                        Button("Try to register anyway") {
+                            pane.enableAgent(launchd: launchd)
+                        }
+                        if let error = pane.agentError {
+                            Text(error)
+                                .font(.callout)
+                                .foregroundStyle(.red)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
                     }
                 }
             @unknown default:
@@ -181,7 +206,7 @@ struct PermissionsView: View {
         case .enabled: return "Enabled"
         case .requiresApproval: return "Requires approval"
         case .notRegistered: return "Not registered"
-        case .notFound: return "Not found"
+        case .notFound: return launchd.embeddedAgentExists ? "Not registered" : "Not found"
         @unknown default: return "Unknown"
         }
     }
@@ -204,6 +229,7 @@ final class PermissionsPaneModel: ObservableObject {
     @Published private(set) var appVerdict: FdaVerdict = .unknown(reason: "Not checked yet.")
     @Published private(set) var recheck: RecheckPhase = .idle
     @Published private(set) var agentError: String?
+    @Published private(set) var agentOperationInProgress = false
 
     /// How long to wait for the agent to write a fresh
     /// `state/fda-check.json` after the kickstart (T18: "timeout 30 s →
@@ -312,6 +338,28 @@ final class PermissionsPaneModel: ObservableObject {
             agentError = nil
         } catch {
             agentError = error.localizedDescription
+        }
+    }
+
+    func removeAgent(launchd: LaunchdManager, model: AppModel) {
+        guard !agentOperationInProgress else { return }
+        model.refresh()
+        let busy = model.setsWithWorkInFlight
+        guard busy.isEmpty else {
+            agentError = "Wait for the current backup to finish before removing the background agent: "
+                + busy.joined(separator: ", ")
+            return
+        }
+
+        agentOperationInProgress = true
+        agentError = nil
+        Task { @MainActor [weak self] in
+            defer { self?.agentOperationInProgress = false }
+            do {
+                try await launchd.unregister()
+            } catch {
+                self?.agentError = error.localizedDescription
+            }
         }
     }
 

--- a/App/Tests/LaunchdManagerTests.swift
+++ b/App/Tests/LaunchdManagerTests.swift
@@ -1,0 +1,33 @@
+import Foundation
+import ServiceManagement
+import Testing
+@testable import Restic_Station
+
+@Suite("Launchd registration presentation")
+struct LaunchdManagerTests {
+    @Test("a present embedded agent is not diagnosed as a broken installation")
+    func presentAgentBeforeRegistration() throws {
+        let bundle = FileManager.default.temporaryDirectory
+            .appendingPathComponent("launchd-present-\(UUID().uuidString).app", isDirectory: true)
+        let agents = bundle.appendingPathComponent("Contents/Library/LaunchAgents", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: bundle) }
+        try FileManager.default.createDirectory(at: agents, withIntermediateDirectories: true)
+        try Data().write(to: agents.appendingPathComponent(LaunchdManager.plistName))
+
+        #expect(LaunchdManager.embeddedAgentExists(in: bundle.path))
+        let message = LaunchdManager.diagnostic(for: .notFound, bundlePath: bundle.path)
+        #expect(message?.contains("not set up yet") == true)
+        #expect(message?.contains("could not find") == false)
+    }
+
+    @Test("a genuinely absent embedded agent retains reinstall guidance")
+    func missingAgent() {
+        let bundle = FileManager.default.temporaryDirectory
+            .appendingPathComponent("launchd-missing-\(UUID().uuidString).app", isDirectory: true)
+
+        #expect(!LaunchdManager.embeddedAgentExists(in: bundle.path))
+        let message = LaunchdManager.diagnostic(for: .notFound, bundlePath: bundle.path)
+        #expect(message?.contains("could not find") == true)
+        #expect(message?.contains("reinstalling") == true)
+    }
+}

--- a/docs/ui-spec.md
+++ b/docs/ui-spec.md
@@ -82,7 +82,7 @@ Per set (picker or sections):
 - **restic binary**: discovered path + version chip; "Locate manually…" file picker; states: OK (green, "restic 0.18.1"), too old (yellow, "0.16 found — 0.17+ required"), missing (red, "Install with `brew install restic`").
 - **Permissions & background**:
   - FDA card: two badges — App: granted/denied; Background agent: granted/denied/unknown (from `fda-check.json`; "Re-check" button kickstarts the helper). "Open Full Disk Access settings" button (deep link). Help disclosure with the fallback instructions (add helper binary manually — path shown, copyable).
-  - Background agent card: SMAppService status (Enabled / Requires approval → "Open Login Items settings" button / Not registered → "Enable" button). Caption: "Runs backups on schedule even when Restic Station is closed."
+  - Background agent card: SMAppService status (Enabled → "Remove" button / Requires approval → "Open Login Items settings" button / Not registered → "Enable" button). Removal is refused while a backup is in flight. A pre-registration `.notFound` is presented as Not registered when the embedded plist is present; a genuinely missing plist remains Not found with reinstall guidance. Caption: "Runs backups on schedule even when Restic Station is closed."
 
 ## Onboarding (first launch, no config)
 


### PR DESCRIPTION
Closes the actionable SMAppService lifecycle gap from #21.

- adds a safe Remove action in Settings → Permissions
- refuses removal while backup work is in flight
- distinguishes an actually missing embedded plist from macOS pre-registration `.notFound`
- presents a valid unregistered bundle as Not registered / Enable in Settings and onboarding
- adds focused app tests and updates the UI spec

Live verification on macOS:
- registered the installed Release app and observed launchd runs advance from 1 to 3 after the app was quit
- observed the launchd-context FDA probe refresh with exit 0 while the foreground app was closed
- removed the agent through the new UI
- confirmed `launchctl print gui/$UID/net.herila.ResticStation.helper` no longer finds it
- confirmed CLI scheduler health reports `agentNotLoaded`

Validation: `xcodebuild -scheme "Restic Station" test CODE_SIGNING_ALLOWED=NO -derivedDataPath build` (4 app tests); Release build; deep strict codesign verification.