### PR TITLE
Add hosted macOS release verification workflow

### DIFF
--- a/.github/workflows/macos-release-verification.yml
+++ b/.github/workflows/macos-release-verification.yml
@@ -1,0 +1,111 @@
+name: macOS Release Verification
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: macos-release-verification-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    name: macos-15 release evidence
+    runs-on: macos-15
+    timeout-minutes: 25
+    env:
+      DERIVED_DATA: ${{ github.workspace }}/dd-release-verification
+      BUILT_APP: ${{ github.workspace }}/dd-release-verification/Build/Products/Release/Restic Station.app
+      INSTALLED_APP: /Applications/Restic Station.app
+      EVIDENCE_DIR: ${{ github.workspace }}/release-evidence
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install test tools
+        run: brew install xcodegen restic jq
+
+      - name: Generate the Xcode project
+        run: xcodegen generate
+
+      - name: Run app and Core tests
+        run: |
+          xcodebuild -scheme "Restic Station" test \
+            CODE_SIGNING_ALLOWED=NO \
+            -derivedDataPath "$DERIVED_DATA"
+          swift test
+          swift test --package-path Core
+
+      - name: Build, sign, and install the Release app
+        run: |
+          xcodebuild -scheme "Restic Station" \
+            -configuration Release \
+            build \
+            CODE_SIGNING_ALLOWED=NO \
+            -derivedDataPath "$DERIVED_DATA"
+          codesign --force --deep --sign - "$BUILT_APP"
+          sudo ditto "$BUILT_APP" "$INSTALLED_APP"
+
+      - name: Verify the exact installed bundle
+        run: scripts/macos-release-verification.sh "$INSTALLED_APP" "$EVIDENCE_DIR" --exercise-user-cli
+
+      - name: Real backup, restore, Keychain, and CLI integration
+        env:
+          RESTIC_STATION_HELPER_OVERRIDE: /Applications/Restic Station.app/Contents/MacOS/restic-station-helper
+        run: |
+          scripts/integration-test.sh 2>&1 | tee "$EVIDENCE_DIR/integration-test.log"
+          scripts/secret-cli-test.sh "$RESTIC_STATION_HELPER_OVERRIDE" \
+            2>&1 | tee "$EVIDENCE_DIR/secret-cli-test.log"
+          scripts/headless-cli-test.sh "$RESTIC_STATION_HELPER_OVERRIDE" \
+            2>&1 | tee "$EVIDENCE_DIR/headless-cli-test.log"
+
+      - name: Package the verified app
+        run: ditto -c -k --keepParent "$INSTALLED_APP" Restic-Station-verified.zip
+
+      - name: Record evidence boundaries
+        if: always()
+        run: |
+          mkdir -p "$EVIDENCE_DIR"
+          tee "$EVIDENCE_DIR/hosted-runner-boundaries.md" <<'EOF'
+          # Hosted-runner evidence boundaries
+
+          A standard GitHub-hosted macOS runner can verify the Release bundle,
+          code signature, launch behavior, CLI symlink identity, process-context
+          FDA probe, Keychain access, and disposable real backup/restore flows.
+
+          It cannot honestly prove user-granted Full Disk Access, approval of the
+          SMAppService background item in System Settings, behavior across
+          sleep/wake or logout/reboot, or a missed-run catch-up after the runner
+          was powered off. Those remain named manual checks on a persistent Mac.
+          EOF
+          {
+            echo "## macOS release verification"
+            echo
+            if [[ -f "$EVIDENCE_DIR/checks.txt" ]]; then
+              echo '```text'
+              sed -n '1,200p' "$EVIDENCE_DIR/checks.txt"
+              echo '```'
+              echo
+            fi
+            sed -n '1,200p' "$EVIDENCE_DIR/hosted-runner-boundaries.md"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload verification evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-release-evidence
+          path: release-evidence
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Upload verified app
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Restic-Station-verified-app
+          path: Restic-Station-verified.zip
+          if-no-files-found: error
+          retention-days: 14

--- a/README.md
+++ b/README.md
@@ -84,6 +84,13 @@ swift test --package-path Core
 
 > **Note:** background-agent (SMAppService) and Full Disk Access behavior can only be tested with the app copied to `/Applications` — see [`docs/keychain-and-fda.md`](docs/keychain-and-fda.md).
 
+For a repeatable clean-machine release check, manually run **macOS Release
+Verification** on the [Actions page](../../actions). It builds and installs the
+Release app on a standard hosted `macos-15` runner, exercises real disposable
+backup/restore and CLI flows, and retains the verified bundle plus evidence.
+The exact coverage and persistent-Mac boundaries are documented in
+[`docs/macos-release-verification.md`](docs/macos-release-verification.md).
+
 ## Linux (headless)
 
 There is no GUI on Linux — `restic-station-helper` is the whole product: scheduling (`timer install`, a `systemd --user` timer), the `config`/`status`/`sets`/`runs`/`secret` CLI, and the same backup engine as the Mac app underneath. A statically-linked binary (no Swift runtime, no libc, no ICU — verified to run unmodified in a `scratch` container) is published for `x86_64` and `aarch64` on every green CI run: open any run on the [Actions page](../../actions), download the **restic-station-linux** artifact, then:

--- a/docs/macos-release-verification.md
+++ b/docs/macos-release-verification.md
@@ -1,0 +1,42 @@
+# macOS release verification
+
+The manually triggered **macOS Release Verification** workflow is the
+canonical clean-machine evidence run for a macOS build. In GitHub, open
+**Actions → macOS Release Verification → Run workflow** and choose the branch
+or tag to verify. It runs on the standard GitHub-hosted `macos-15` image.
+
+The workflow builds a Release app, ad-hoc signs it, copies that exact bundle to
+`/Applications`, and then verifies:
+
+- app and Core unit tests;
+- the shipped bundle, helper, LaunchAgent plist, version, and strict nested
+  code-signature validity;
+- an eight-second launch smoke test against isolated app data;
+- `cli install --user`, the exact symlink destination, direct-versus-symlink
+  helper identity, and equivalent FDA probe results in both invocation paths;
+- a real disposable restic backup and restore, including the macOS Keychain
+  path used by the integration suite;
+- file-backed secret handling and the headless config/status/sets/runs CLI.
+
+Every run retains the verified app for 14 days and the check results, probe
+JSON, signing metadata, and integration logs for 30 days. The same evidence is
+summarized on the workflow run page.
+
+## Deliberate boundary
+
+A hosted runner is an ephemeral VM with no durable, human-approved privacy or
+login state. It therefore cannot establish any of the following:
+
+- a user granting Full Disk Access in System Settings;
+- a user approving the `SMAppService` background item;
+- behavior across sleep/wake or logout/reboot;
+- catch-up of a run missed while the Mac was powered off.
+
+Those remain manual checks on a persistent Mac. The workflow records this
+boundary in every run rather than treating an unapproved runner as evidence of
+either approval or denial.
+
+The bundle-only verifier is also available as
+`scripts/macos-release-verification.sh`. Its CLI-install mode is intentionally
+restricted to GitHub Actions so invoking it locally cannot silently change a
+developer's `~/.local/bin/restic-station` entry.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -131,4 +131,11 @@ out (the job's own session never ends mid-run). Both remain genuinely open, trac
 | `linux-integration` | `ubuntu-24.04-arm` (bare VM, no container) | downloads `restic-station-linux`'s aarch64 tarball → installs real restic + jq → `ldd` + `install.sh` checks → `scripts/integration-test.sh` against the **static** binary (`RESTIC_STATION_HELPER_OVERRIDE`) → non-blocking T26 systemd diagnostic → `scripts/linux-docs-transcript.sh` (T30 / issue #32: real command transcripts for `docs/linux.md`, against this same static binary and real restic) |
 | `linux-runtime-verify` | `ubuntu-latest` (x86_64) and `ubuntu-24.04-arm` (aarch64), matrix | `ldd` → builds+runs a `scratch` container → runs on Alpine → runs on Debian 12 → (x86_64 only) runs on CentOS 7, the deliberately old-glibc distro |
 
+The manually triggered `macOS Release Verification` workflow is the clean,
+hosted-Mac release evidence path. Unlike the ordinary `macos` job, it builds a
+Release app, installs and launch-smokes that exact bundle, exercises the CLI
+symlink and direct-versus-symlink FDA probes, and uploads detailed evidence.
+See [macOS release verification](macos-release-verification.md) for its scope
+and the user-approval/reboot checks that an ephemeral runner cannot prove.
+
 All jobs on push + PR; the four Linux-release jobs depend only on `release-linux`, not on `linux`/`macos`, so a static-build regression is visible even if the debug-build jobs are still running. Keep total macOS time reasonable (public-repo runners are free but slow) — `release-linux` is the long pole (~1-2 min per architecture once its toolchain cache is warm, longer cold).

--- a/scripts/macos-release-verification.sh
+++ b/scripts/macos-release-verification.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+# Verify the exact macOS app bundle that would be handed to a user.
+#
+# Usage:
+#   scripts/macos-release-verification.sh <app-path> <evidence-directory> [--exercise-user-cli]
+#
+# `--exercise-user-cli` is intentionally restricted to GitHub Actions. It
+# installs and removes ~/.local/bin/restic-station, which is appropriate on
+# an ephemeral hosted runner but should not silently alter a developer's
+# workstation. All app data and FDA probe state live under a throwaway root.
+
+set -euo pipefail
+
+APP_PATH="${1:-}"
+EVIDENCE_DIR="${2:-}"
+EXERCISE_USER_CLI="${3:-}"
+
+if [[ -z "$APP_PATH" || -z "$EVIDENCE_DIR" ]]; then
+    echo "usage: $0 <app-path> <evidence-directory> [--exercise-user-cli]" >&2
+    exit 2
+fi
+if [[ "$EXERCISE_USER_CLI" != "" && "$EXERCISE_USER_CLI" != "--exercise-user-cli" ]]; then
+    echo "unknown option: $EXERCISE_USER_CLI" >&2
+    exit 2
+fi
+if [[ "$EXERCISE_USER_CLI" == "--exercise-user-cli" && "${GITHUB_ACTIONS:-}" != "true" ]]; then
+    echo "--exercise-user-cli is restricted to an ephemeral GitHub Actions runner" >&2
+    exit 2
+fi
+
+HELPER="$APP_PATH/Contents/MacOS/restic-station-helper"
+APP_EXECUTABLE="$APP_PATH/Contents/MacOS/Restic Station"
+AGENT_PLIST="$APP_PATH/Contents/Library/LaunchAgents/net.herila.ResticStation.helper.plist"
+INFO_PLIST="$APP_PATH/Contents/Info.plist"
+CLI_LINK="$HOME/.local/bin/restic-station"
+
+mkdir -p "$EVIDENCE_DIR"
+WORK="$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/restic-station-release-verify.XXXXXX")"
+CLI_WAS_CREATED=0
+APP_PID=""
+
+cleanup() {
+    local code=$?
+    if [[ -n "$APP_PID" ]] && kill -0 "$APP_PID" 2>/dev/null; then
+        kill -TERM "$APP_PID" 2>/dev/null || true
+        wait "$APP_PID" 2>/dev/null || true
+    fi
+    if [[ "$CLI_WAS_CREATED" == "1" && -x "$HELPER" ]]; then
+        "$HELPER" cli uninstall --user >/dev/null 2>&1 || true
+    fi
+    [[ -d "$WORK" ]] && rm -rf "$WORK"
+    exit "$code"
+}
+trap cleanup EXIT
+
+pass() { printf 'PASS  %s\n' "$*" | tee -a "$EVIDENCE_DIR/checks.txt"; }
+fail() { printf 'FAIL  %s\n' "$*" | tee -a "$EVIDENCE_DIR/checks.txt" >&2; exit 1; }
+assert_equal() {
+    local name="$1" expected="$2" actual="$3"
+    [[ "$actual" == "$expected" ]] || fail "$name (expected '$expected', got '$actual')"
+    pass "$name = $actual"
+}
+
+: > "$EVIDENCE_DIR/checks.txt"
+
+[[ -d "$APP_PATH" ]] || fail "app bundle exists at $APP_PATH"
+[[ -x "$APP_EXECUTABLE" ]] || fail "app executable is present"
+[[ -x "$HELPER" ]] || fail "embedded helper is executable"
+[[ -f "$AGENT_PLIST" ]] || fail "embedded LaunchAgent plist is present"
+pass "release bundle layout is complete"
+
+plutil -lint "$INFO_PLIST" "$AGENT_PLIST" | tee "$EVIDENCE_DIR/plist-lint.txt"
+assert_equal "bundle version" "0.1.0" "$(plutil -extract CFBundleShortVersionString raw -o - "$INFO_PLIST")"
+assert_equal "agent label" "net.herila.ResticStation.helper" "$(plutil -extract Label raw -o - "$AGENT_PLIST")"
+assert_equal "agent BundleProgram" "Contents/MacOS/restic-station-helper" "$(plutil -extract BundleProgram raw -o - "$AGENT_PLIST")"
+assert_equal "agent command" "tick" "$(plutil -extract ProgramArguments.1 raw -o - "$AGENT_PLIST")"
+assert_equal "agent interval" "120" "$(plutil -extract StartInterval raw -o - "$AGENT_PLIST")"
+
+codesign --verify --deep --strict --verbose=4 "$APP_PATH" 2>&1 | tee "$EVIDENCE_DIR/codesign-verify.txt"
+codesign -d --verbose=4 "$APP_PATH" > "$EVIDENCE_DIR/app-codesign.txt" 2>&1
+codesign -d --verbose=4 "$HELPER" > "$EVIDENCE_DIR/helper-codesign-direct.txt" 2>&1
+pass "app and nested helper pass strict code-signature verification"
+
+"$HELPER" version | tee "$EVIDENCE_DIR/helper-version.txt"
+grep -q '^restic-station-helper 0\.1\.0$' "$EVIDENCE_DIR/helper-version.txt" \
+    || fail "embedded helper reports version 0.1.0"
+pass "embedded helper reports version 0.1.0"
+
+# Launch the shipped executable against isolated data and require it to stay
+# alive long enough to prove the SwiftUI app did not crash during startup.
+mkdir -p "$WORK/app-data"
+RESTIC_STATION_DATA_DIR="$WORK/app-data" "$APP_EXECUTABLE" \
+    > "$EVIDENCE_DIR/app-launch.log" 2>&1 &
+APP_PID=$!
+sleep 8
+kill -0 "$APP_PID" 2>/dev/null || fail "app survives an 8-second launch smoke test"
+pass "app survives an 8-second launch smoke test"
+kill -TERM "$APP_PID"
+wait "$APP_PID" 2>/dev/null || true
+APP_PID=""
+
+# The FDA result itself is informational on a hosted runner: nobody has
+# granted that ephemeral VM Full Disk Access. What is verifiable is that the
+# exact helper probes and records its process context without touching user
+# data from the repository checkout.
+mkdir -p "$WORK/fda-direct"
+RESTIC_STATION_DATA_DIR="$WORK/fda-direct" \
+    "$HELPER" fda-check --context github-actions-direct \
+    | tee "$EVIDENCE_DIR/fda-direct.txt"
+jq -e '.context == "github-actions-direct" and (.hasFullDiskAccess | type == "boolean")' \
+    "$WORK/fda-direct/state/fda-check.json" > /dev/null
+cp "$WORK/fda-direct/state/fda-check.json" "$EVIDENCE_DIR/fda-direct.json"
+pass "direct helper FDA probe records honest, isolated process-context evidence"
+
+if [[ "$EXERCISE_USER_CLI" == "--exercise-user-cli" ]]; then
+    [[ ! -e "$CLI_LINK" && ! -L "$CLI_LINK" ]] \
+        || fail "ephemeral runner unexpectedly already has $CLI_LINK"
+
+    "$HELPER" cli install --user 2>&1 | tee "$EVIDENCE_DIR/cli-install.txt"
+    CLI_WAS_CREATED=1
+    [[ -L "$CLI_LINK" ]] || fail "cli install created a symlink"
+    assert_equal "CLI symlink target" "$HELPER" "$(readlink "$CLI_LINK")"
+
+    PATH="$HOME/.local/bin:$PATH" "$CLI_LINK" cli status --user \
+        2>&1 | tee "$EVIDENCE_DIR/cli-status.txt"
+    grep -q '^installed: ' "$EVIDENCE_DIR/cli-status.txt" \
+        || fail "CLI status reports the installed symlink"
+    if grep -q 'stale' "$EVIDENCE_DIR/cli-status.txt"; then
+        fail "CLI status reports a stale symlink"
+    fi
+    pass "CLI symlink is installed, current, and runnable from PATH"
+
+    "$CLI_LINK" version | tee "$EVIDENCE_DIR/helper-version-via-symlink.txt"
+    cmp "$EVIDENCE_DIR/helper-version.txt" "$EVIDENCE_DIR/helper-version-via-symlink.txt" \
+        || fail "direct and symlink helper versions differ"
+    codesign -d --verbose=4 "$CLI_LINK" > "$EVIDENCE_DIR/helper-codesign-via-symlink.txt" 2>&1
+    direct_id="$(sed -n 's/^Identifier=//p' "$EVIDENCE_DIR/helper-codesign-direct.txt")"
+    symlink_id="$(sed -n 's/^Identifier=//p' "$EVIDENCE_DIR/helper-codesign-via-symlink.txt")"
+    [[ -n "$direct_id" ]] || fail "direct helper has no signing identifier"
+    assert_equal "direct/symlink signing identifier" "$direct_id" "$symlink_id"
+
+    mkdir -p "$WORK/fda-symlink"
+    RESTIC_STATION_DATA_DIR="$WORK/fda-symlink" \
+        "$CLI_LINK" fda-check --context github-actions-symlink \
+        | tee "$EVIDENCE_DIR/fda-symlink.txt"
+    jq -e '.context == "github-actions-symlink" and (.hasFullDiskAccess | type == "boolean")' \
+        "$WORK/fda-symlink/state/fda-check.json" > /dev/null
+    cp "$WORK/fda-symlink/state/fda-check.json" "$EVIDENCE_DIR/fda-symlink.json"
+    direct_fda="$(jq -r '.hasFullDiskAccess' "$EVIDENCE_DIR/fda-direct.json")"
+    symlink_fda="$(jq -r '.hasFullDiskAccess' "$EVIDENCE_DIR/fda-symlink.json")"
+    assert_equal "direct/symlink FDA outcome on the same runner" "$direct_fda" "$symlink_fda"
+fi
+
+pass "bundle-level macOS release verification complete"


### PR DESCRIPTION
## Summary

- add a manually triggered `macos-15` Release verification workflow
- verify the exact installed, ad-hoc-signed app bundle, launch behavior, CLI symlink identity, and direct-vs-symlink FDA probe behavior
- run disposable real backup/restore, Keychain, secret, and headless CLI integration against the installed Release helper
- retain the verified app and detailed evidence, with persistent-Mac boundaries stated in every run
- document how to trigger the workflow and what it can and cannot prove

## Validation

- `bash -n scripts/macos-release-verification.sh`
- workflow YAML parsed locally
- `git diff --check`
- bundle verifier passed against the installed signed app (without the Actions-only CLI mutation)
- direct codesign inspection through the existing CLI symlink resolves to the embedded helper identity

The workflow itself is `workflow_dispatch`-only. GitHub only permits dispatching a new workflow after it exists on the default branch, so the first canonical hosted run will be triggered immediately after this PR merges.