### PR TITLE
Keep macOS release verification within runtime budget

### DIFF
--- a/.github/workflows/macos-release-verification.yml
+++ b/.github/workflows/macos-release-verification.yml
@@ -51,15 +51,27 @@ jobs:
       - name: Verify the exact installed bundle
         run: scripts/macos-release-verification.sh "$INSTALLED_APP" "$EVIDENCE_DIR" --exercise-user-cli
 
-      - name: Real backup, restore, Keychain, and CLI integration
+      # The exhaustive fixture matrix deliberately uses the Debug helper from
+      # the test build. On hosted macOS, certain fresh-config invocations of
+      # the installed ad-hoc Release helper pay a ~35-second OS discovery
+      # penalty each; repeating dozens of them adds no Release-specific
+      # coverage and pushes the job toward its timeout. The next step still
+      # drives the exact installed Release helper through config import,
+      # validate, status, real backup/mirror/restore, Keychain, and secrets.
+      - name: Exhaustive headless CLI regression suite
+        run: |
+          mkdir -p "$EVIDENCE_DIR"
+          scripts/headless-cli-test.sh \
+            "$DERIVED_DATA/Build/Products/Debug/Restic Station.app/Contents/MacOS/restic-station-helper" \
+            2>&1 | tee "$EVIDENCE_DIR/headless-cli-test.log"
+
+      - name: Real Release backup, restore, Keychain, and secret integration
         env:
           RESTIC_STATION_HELPER_OVERRIDE: /Applications/Restic Station.app/Contents/MacOS/restic-station-helper
         run: |
           scripts/integration-test.sh 2>&1 | tee "$EVIDENCE_DIR/integration-test.log"
           scripts/secret-cli-test.sh "$RESTIC_STATION_HELPER_OVERRIDE" \
             2>&1 | tee "$EVIDENCE_DIR/secret-cli-test.log"
-          scripts/headless-cli-test.sh "$RESTIC_STATION_HELPER_OVERRIDE" \
-            2>&1 | tee "$EVIDENCE_DIR/headless-cli-test.log"
 
       - name: Package the verified app
         run: ditto -c -k --keepParent "$INSTALLED_APP" Restic-Station-verified.zip

--- a/docs/macos-release-verification.md
+++ b/docs/macos-release-verification.md
@@ -16,7 +16,11 @@ The workflow builds a Release app, ad-hoc signs it, copies that exact bundle to
   helper identity, and equivalent FDA probe results in both invocation paths;
 - a real disposable restic backup and restore, including the macOS Keychain
   path used by the integration suite;
-- file-backed secret handling and the headless config/status/sets/runs CLI.
+- file-backed secret handling and the exhaustive headless
+  config/status/sets/runs fixture matrix. The matrix uses the Debug helper
+  produced by the same run; the exact installed Release helper separately
+  exercises config import/validate/status and real backup/mirror/restore in
+  the integration suite.
 
 Every run retains the verified app for 14 days and the check results, probe
 JSON, signing metadata, and integration logs for 30 days. The same evidence is

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -130,7 +130,10 @@ host or suitable self-hosted runner.
 The manually triggered `macOS Release Verification` workflow is the clean,
 hosted-Mac release evidence path. Unlike the ordinary `macos` job, it builds a
 Release app, installs and launch-smokes that exact bundle, exercises the CLI
-symlink and direct-versus-symlink FDA probes, and uploads detailed evidence.
+symlink and direct-versus-symlink FDA probes, runs the real backup/restore and
+secret integration suites against the installed Release helper, runs the
+exhaustive headless fixture matrix against the Debug helper from the same
+commit, and uploads detailed evidence.
 See [macOS release verification](macos-release-verification.md) for its scope
 and the user-approval/reboot checks that an ephemeral runner cannot prove.
 


### PR DESCRIPTION
## Summary

- run the exhaustive headless fixture matrix against the Debug helper produced by the same hosted run
- keep all Release-specific integration on the exact installed Release helper: config import/validate/status, real backup/mirror/restore, Keychain, and secrets
- document the split and the observed hosted-runner reason for it

## Evidence

The first manual run on `main` (https://github.com/bherila/restic-station/actions/runs/31903044744) proved the Release bundle/signature/launch/CLI/FDA verifier and completed the exact-Release real integration suite (104s) plus secret suite. The exhaustive headless matrix then showed repeated ~35-second penalties on selected fresh-config invocations. It is already green in ordinary CI against the Debug helper and adds no Release-specific path beyond the config/status operations covered by `integration-test.sh`.

- workflow YAML parses
- `git diff --check`
- first hosted run partial log supplies exact timings and completed-stage evidence