### PR TITLE
Upgrade GitHub Actions to current runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     container: swift:6.1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       # Root package = the headless side (helper executable + Core by path).
       # A Linux-only compile error in Helper/ or Core/ fails here.
       - name: Build helper (root SwiftPM package)
@@ -300,7 +300,7 @@ jobs:
   macos:
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Install tools
         run: brew install xcodegen restic jq
       - name: Generate Xcode project
@@ -350,7 +350,7 @@ jobs:
           codesign --force --deep --sign - "$APP"
           ditto -c -k --keepParent "$APP" "Restic-Station.zip"
       - name: Upload app artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Restic-Station-app
           path: Restic-Station.zip
@@ -367,11 +367,11 @@ jobs:
   release-linux:
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       # ~1.7 GB of downloads (toolchain .pkg + static SDK bundle); cached by
       # the exact pinned version so a green run only pays for this once.
       - name: Cache Static Linux SDK toolchain
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: .build/static-linux-sdk-cache
           key: static-linux-sdk-${{ hashFiles('scripts/setup-static-linux-sdk.sh') }}
@@ -397,7 +397,7 @@ jobs:
             done
           done
       - name: Upload Linux release artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: restic-station-linux
           path: |
@@ -419,8 +419,8 @@ jobs:
     needs: release-linux
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
         with:
           name: restic-station-linux
           path: dist
@@ -526,7 +526,7 @@ jobs:
             runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: restic-station-linux
           path: dist

--- a/.github/workflows/macos-release-verification.yml
+++ b/.github/workflows/macos-release-verification.yml
@@ -22,7 +22,7 @@ jobs:
       EVIDENCE_DIR: ${{ github.workspace }}/release-evidence
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install test tools
         run: brew install xcodegen restic jq
@@ -106,7 +106,7 @@ jobs:
 
       - name: Upload verification evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: macos-release-evidence
           path: release-evidence
@@ -115,7 +115,7 @@ jobs:
 
       - name: Upload verified app
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Restic-Station-verified-app
           path: Restic-Station-verified.zip


### PR DESCRIPTION
## Summary

- upgrade `actions/checkout` to v7
- upgrade artifact upload/download to v7/v8
- upgrade Actions cache to v6

These are the current official major releases and remove the Node 20 deprecation annotations observed in the new macOS Release Verification run. Existing inputs remain supported; download v8 also makes artifact digest mismatches fail closed.

## Validation

- queried each action's current official GitHub release and v-major notes
- parsed both workflow YAML files
- `git diff --check`
- live CI will exercise checkout, cache, artifact upload, and artifact download on both architectures