### PR TITLE
Uniform JSON output for every inspection and probe command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,12 @@ jobs:
           echo "$OUT"
           echo "$OUT" | grep -q "discovered $FAKEBIN/restic"
           # Got past restic resolution and on to the real (absent) set.
-          echo "$OUT" | grep -q "no backup set with id"
+          # Case-insensitive on purpose: this asserts *where* execution got
+          # to, not the sentence. The wording is presentation text that moves
+          # as commands convert to `CLIFailure` (#81) — probe-repo's went from
+          # a lowercase `HelperExit.fail` fragment to a capitalised sentence
+          # and turned this step red for nothing but the leading letter.
+          echo "$OUT" | grep -qi "backup set with id"
 
           # 3. tick still exits 0 on a host with nothing configured.
           #    (tick resolves restic through the same `resolveResticPath`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,9 +230,9 @@ jobs:
             echo "$OUT"; echo "status exited non-zero on a host with no systemd"; exit 1
           }
           echo "$OUT"
-          echo "$OUT" | jq -e '.scheduler.kind == "unknown"' > /dev/null
-          echo "$OUT" | jq -e '.scheduler.healthy == null' > /dev/null
-          echo "$OUT" | jq -e '.health == "idle"' > /dev/null
+          echo "$OUT" | jq -e '.data | .scheduler.kind == "unknown"' > /dev/null
+          echo "$OUT" | jq -e '.data | .scheduler.healthy == null' > /dev/null
+          echo "$OUT" | jq -e '.data | .health == "idle"' > /dev/null
 
       - name: status refuses to report healthy when it cannot read the run history
         run: |

--- a/Core/Sources/ResticStationCore/Support/CLIError.swift
+++ b/Core/Sources/ResticStationCore/Support/CLIError.swift
@@ -725,6 +725,45 @@ extension CLIFailure {
     }
 }
 
+// MARK: - CLISuccessEnvelope
+
+/// The exact document a `--json` command writes to stdout when it succeeds
+/// (`docs/cli-json.md`, issue #79).
+///
+/// ```json
+/// { "schemaVersion": 1, "ok": true, "data": { … } }
+/// ```
+///
+/// Deliberately the same three top-level keys as ``CLIErrorEnvelope``, with
+/// `data` where that has `error`. A caller reads `ok` once and knows which
+/// key to look in — it never has to probe for the presence of `error`, and
+/// never has to know which command it called to know the shape.
+///
+/// **This replaced a bare payload**, so it is a breaking change for anyone
+/// who was reading `.health` rather than `.data.health`. The migration note
+/// is in `docs/cli-json.md` §Migrating from the unwrapped shape.
+public struct CLISuccessEnvelope<Payload: Encodable>: Encodable {
+
+    /// Shared with ``CLIErrorEnvelope/schemaVersion`` on purpose: the two
+    /// are one contract with two branches, and a caller that has pinned
+    /// `schemaVersion: 1` has pinned both. Bumping one without the other
+    /// would mean a document whose version says nothing about half the
+    /// shapes it can take.
+    public static var schemaVersion: Int { CLIErrorEnvelope.schemaVersion }
+
+    public let schemaVersion: Int
+    /// Always `true`. Present so `ok` is the single discriminator rather
+    /// than "does an `error` key exist".
+    public let ok: Bool
+    public let data: Payload
+
+    public init(_ data: Payload) {
+        self.schemaVersion = Self.schemaVersion
+        self.ok = true
+        self.data = data
+    }
+}
+
 // MARK: - CLIErrorEnvelope
 
 /// The exact document a `--json` command writes to stdout when it fails.

--- a/Core/Sources/ResticStationCore/Support/CLIError.swift
+++ b/Core/Sources/ResticStationCore/Support/CLIError.swift
@@ -518,10 +518,15 @@ extension CLIFailure {
     /// The path stays in `message` and out of `details` — a data-directory
     /// path carries a home directory, and `details` is the half of the
     /// envelope that promises to be safe to log.
-    public static func machineIdentityUnreadable(path: String, underlying: any Error) -> CLIFailure {
-        CLIFailure(
+    /// `underlying` is optional because one caller reaches this having
+    /// already decided the identity is unusable without holding the error
+    /// that says why — and a message that names the file is still the right
+    /// answer there, just a shorter one.
+    public static func machineIdentityUnreadable(path: String, underlying: (any Error)? = nil) -> CLIFailure {
+        let reason = underlying.map { ": \($0)" } ?? ""
+        return CLIFailure(
             code: .configInvalid,
-            message: bounded("could not read this machine's identity (\(path)): \(underlying)")
+            message: bounded("could not read this machine's identity (\(path))\(reason)")
         )
     }
 

--- a/Core/Sources/ResticStationCore/Support/CLIInstaller.swift
+++ b/Core/Sources/ResticStationCore/Support/CLIInstaller.swift
@@ -210,6 +210,23 @@ public enum CLIInstaller {
         /// our symlinks — `install`/`uninstall` will refuse until it is
         /// removed by hand.
         public let foreignEntryPresent: Bool
+
+        // `resolvedTarget` encodes as explicit `null` rather than being
+        // omitted, matching every other `--json` shape
+        // (`docs/data-model.md` §Encoding conventions).
+        private enum CodingKeys: String, CodingKey {
+            case linkPath, installed, resolvedTarget, upToDate, onPath, foreignEntryPresent
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(linkPath, forKey: .linkPath)
+            try container.encode(installed, forKey: .installed)
+            try container.encode(resolvedTarget, forKey: .resolvedTarget)
+            try container.encode(upToDate, forKey: .upToDate)
+            try container.encode(onPath, forKey: .onPath)
+            try container.encode(foreignEntryPresent, forKey: .foreignEntryPresent)
+        }
     }
 
     /// `currentTarget` is what a fresh `install` would point at right now

--- a/Core/Sources/ResticStationCore/Support/CLIInstaller.swift
+++ b/Core/Sources/ResticStationCore/Support/CLIInstaller.swift
@@ -192,7 +192,8 @@ public enum CLIInstaller {
 
     // MARK: - Status
 
-    public struct Status: Sendable, Equatable {
+    /// Also `cli status --json`'s shape (`docs/cli-json.md`).
+    public struct Status: Sendable, Equatable, Encodable {
         public let linkPath: String
         /// `true` only for a symlink of ours (owned basename) — a foreign
         /// file at the same path is reported as not installed, since it is

--- a/Helper/Sources/CLIJSON.swift
+++ b/Helper/Sources/CLIJSON.swift
@@ -1,27 +1,35 @@
 import Foundation
 import ResticStationCore
 
-/// The shared `--json` output convention for T27's read-oriented subcommands
-/// (`status`, `sets list`, `runs list`, `runs show`, `config show`).
+/// The one path that owns stdout in `--json` mode, for every subcommand
+/// (`docs/cli-json.md`, issues #29/#79/#81).
 ///
-/// Two rules, both load-bearing:
+/// Three rules, all load-bearing:
 ///
 /// 1. **`--json` output is only JSON on stdout.** No leading/trailing prose,
 ///    no progress dots — a caller pipes this straight into `jq` (the test
 ///    suite does exactly that). Anything a subcommand wants to say *about*
 ///    the JSON (a warning it could not fetch some optional piece of state,
 ///    for instance) belongs on stderr.
-/// 2. **Same encoding convention as everything else this app persists** —
+/// 2. **Every payload is wrapped in ``CLISuccessEnvelope``.** Commands hand
+///    over their own shape and this adds `schemaVersion`/`ok`/`data`, which
+///    is what stops the envelope from being something each command has to
+///    remember — and what makes success and failure the same three top-level
+///    keys. A command therefore cannot opt out by accident; `config export`,
+///    which must emit a bare config document, deliberately does not come
+///    through here at all.
+/// 3. **Same encoding convention as everything else this app persists** —
 ///    `.sortedKeys` + `.prettyPrinted`, ISO 8601 dates with fractional
 ///    seconds (`ConfigStore.makeEncoder()`). A machine-readable shape that
 ///    used a different date format than `runs/index.jsonl` would be its own
 ///    small bug waiting to happen for anyone scripting against both.
 enum CLIJSON {
-    /// Encodes `value` and writes it to stdout followed by exactly one
-    /// newline — nothing else touches stdout in `--json` mode.
+    /// Wraps `value` in the success envelope, encodes it, and writes it to
+    /// stdout followed by exactly one newline — nothing else touches stdout
+    /// in `--json` mode.
     static func print<T: Encodable>(_ value: T) {
         do {
-            let data = try ConfigStore.makeEncoder().encode(value)
+            let data = try ConfigStore.makeEncoder().encode(CLISuccessEnvelope(value))
             FileHandle.standardOutput.write(data)
             FileHandle.standardOutput.write(Data("\n".utf8))
         } catch {

--- a/Helper/Sources/Commands/Cli.swift
+++ b/Helper/Sources/Commands/Cli.swift
@@ -126,14 +126,17 @@ struct CliUninstall: AsyncParsableCommand {
 
 // MARK: - cli status
 
-struct CliStatus: AsyncParsableCommand {
+struct CliStatus: AsyncParsableCommand, JSONRenderable {
     static let configuration = CommandConfiguration(
         commandName: "status",
         abstract: "Report whether the restic-station symlink is installed, where it resolves to, and "
-            + "whether the install directory is on PATH. Exit 0 ok."
+            + "whether the install directory is on PATH. --json for scripting. Exit 0 ok."
     )
 
     @OptionGroup var options: CliPrefixOptions
+
+    @Flag(name: .long, help: "Emit JSON. Only JSON reaches stdout in this mode.")
+    var json = false
 
     func run() async throws {
         let directory = options.directory
@@ -143,6 +146,14 @@ struct CliStatus: AsyncParsableCommand {
             currentTarget: target,
             pathEnvironment: ProcessInfo.processInfo.environment["PATH"]
         )
+
+        if json {
+            // `CLIInstaller.Status` is already the model the human renderer
+            // reads; emitting it directly is what keeps the two from
+            // drifting, rather than re-deriving the same booleans here.
+            CLIJSON.print(status)
+            HelperExit.code(0)
+        }
 
         if status.installed {
             let staleness = status.upToDate

--- a/Helper/Sources/Commands/Config.swift
+++ b/Helper/Sources/Commands/Config.swift
@@ -376,7 +376,7 @@ struct ConfigImport: AsyncParsableCommand {
 
 // MARK: - config validate
 
-struct ConfigValidate: AsyncParsableCommand {
+struct ConfigValidate: AsyncParsableCommand, JSONRenderable {
     static let configuration = CommandConfiguration(
         commandName: "validate",
         abstract: "Check config.json and report, for one machine: hard errors (exit 1); warnings "
@@ -390,6 +390,28 @@ struct ConfigValidate: AsyncParsableCommand {
     @Option(name: .long, help: "Validate as resolved for this machine id, instead of this host's own.")
     var machine: String?
 
+    @Flag(name: .long, help: "Emit JSON. Only JSON reaches stdout in this mode.")
+    var json = false
+
+    /// `config validate --json`'s shape — see `docs/cli-json.md`.
+    ///
+    /// `errors` is always empty here: a config that will not load is
+    /// reported as a `config_invalid` **error envelope**, not as a success
+    /// document with an error list, because that is the same condition every
+    /// other `--json` command reports that way. The field exists so the
+    /// shape does not change when a future check can find a hard error in a
+    /// config that *does* load.
+    struct Report: Encodable {
+        let machineId: String
+        let errors: [String]
+        let warnings: [String]
+        let effective: EffectiveConfigReport
+        /// The machine-readable form of the human "nothing will run on this
+        /// machine." line — the anti-silent-failure guarantee (T27), which a
+        /// caller would otherwise have to notice by counting enabled sets.
+        let nothingRunsHere: Bool
+    }
+
     func run() async throws {
         let context = ConfigCLIContext.make()
 
@@ -399,13 +421,20 @@ struct ConfigValidate: AsyncParsableCommand {
         do {
             config = try context.configStore.load()
         } catch {
+            // Human mode keeps printing its own `Errors:` block and exiting
+            // 1; JSON mode reports the same condition as the shared
+            // `config_invalid` envelope so a caller does not need a
+            // per-command exception.
+            guard !json else { throw CLIFailure.configInvalid(underlying: error) }
             print("Errors:")
             print("  - \(error)")
             HelperExit.code(1)
         }
-        print("Errors:")
-        print("  (none)")
-        print("")
+        if !json {
+            print("Errors:")
+            print("  (none)")
+            print("")
+        }
 
         let localMachineId = try? MachineStore(paths: context.paths).load().machineId
         let targetMachineId: String
@@ -452,6 +481,21 @@ struct ConfigValidate: AsyncParsableCommand {
             }
         }
 
+        let nothingRunsHere = report.sets.allSatisfy { !$0.enabledHere }
+
+        if json {
+            CLIJSON.print(
+                Report(
+                    machineId: targetMachineId,
+                    errors: [],
+                    warnings: warnings,
+                    effective: report,
+                    nothingRunsHere: nothingRunsHere
+                )
+            )
+            HelperExit.code(0)
+        }
+
         print("Warnings:")
         if warnings.isEmpty {
             print("  (none)")
@@ -466,7 +510,7 @@ struct ConfigValidate: AsyncParsableCommand {
         for line in report.humanLines() {
             print(line.isEmpty ? "" : "  \(line)")
         }
-        if report.sets.allSatisfy({ !$0.enabledHere }) {
+        if nothingRunsHere {
             print("")
             print("  nothing will run on this machine.")
         }

--- a/Helper/Sources/Commands/Config.swift
+++ b/Helper/Sources/Commands/Config.swift
@@ -436,7 +436,18 @@ struct ConfigValidate: AsyncParsableCommand, JSONRenderable {
             print("")
         }
 
-        let localMachineId = try? MachineStore(paths: context.paths).load().machineId
+        // The error is kept, not discarded: `localMachineId` is optional on
+        // purpose — with `--machine` given, this host's own identity is only
+        // used to widen the `confirmable` set below, and an unreadable one
+        // is not fatal there. But when it *is* the answer, the reason it
+        // could not be read is the whole failure, and `try?` threw it away.
+        var localMachineId: String?
+        var localMachineIdError: (any Error)?
+        do {
+            localMachineId = try MachineStore(paths: context.paths).load().machineId
+        } catch {
+            localMachineIdError = error
+        }
         let targetMachineId: String
         if let machine {
             try ConfigCLIContext.requireValidMachineId(machine)
@@ -444,7 +455,14 @@ struct ConfigValidate: AsyncParsableCommand, JSONRenderable {
         } else if let localMachineId {
             targetMachineId = localMachineId
         } else {
-            HelperExit.fail("could not read this machine's identity (\(context.paths.machineFile.path))")
+            // Thrown, not exited: this command promises an envelope in
+            // `--json` mode, and exiting here answered a corrupt
+            // `machine.json` with an empty stdout and prose on stderr —
+            // the one shape the contract exists to remove.
+            throw CLIFailure.machineIdentityUnreadable(
+                path: context.paths.machineFile.path,
+                underlying: localMachineIdError
+            )
         }
 
         let scheduled = config.resolved(for: targetMachineId)

--- a/Helper/Sources/Commands/FdaCheck.swift
+++ b/Helper/Sources/Commands/FdaCheck.swift
@@ -46,6 +46,22 @@ struct FdaCheck: AsyncParsableCommand, JSONRenderable {
         let probedPath: String?
         let checkedAt: Date?
         let context: String
+
+        // Explicit `null` for the three that are absent off macOS — see the
+        // encoding convention in `docs/data-model.md`. A missing key and a
+        // null one must not be two ways of saying "not applicable".
+        private enum CodingKeys: String, CodingKey {
+            case applicable, granted, probedPath, checkedAt, context
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(applicable, forKey: .applicable)
+            try container.encode(granted, forKey: .granted)
+            try container.encode(probedPath, forKey: .probedPath)
+            try container.encode(checkedAt, forKey: .checkedAt)
+            try container.encode(context, forKey: .context)
+        }
     }
 
     func run() async throws {

--- a/Helper/Sources/Commands/FdaCheck.swift
+++ b/Helper/Sources/Commands/FdaCheck.swift
@@ -21,26 +21,58 @@ import ResticStationCore
 /// Does not go through `HelperContext.make()`: no restic path is needed to
 /// probe FDA, and this command must succeed even before restic is
 /// configured (it's part of onboarding, which runs before that).
-struct FdaCheck: AsyncParsableCommand {
+struct FdaCheck: AsyncParsableCommand, JSONRenderable {
     static let configuration = CommandConfiguration(
         commandName: "fda-check",
         abstract: "Probe Full Disk Access and record the result to state/fda-check.json "
-            + "(macOS only; a no-op elsewhere). Always exits 0."
+            + "(macOS only; a no-op elsewhere). --json for scripting. Always exits 0."
     )
 
     @Option(name: .long, help: "Which process context ran the probe: \"launchd\" or \"app\".")
     var context: String = "launchd"
 
+    @Flag(name: .long, help: "Emit JSON. Only JSON reaches stdout in this mode.")
+    var json = false
+
+    /// `fda-check --json`'s shape — see `docs/cli-json.md`.
+    ///
+    /// `applicable: false` off macOS is the machine-readable form of the
+    /// human "not applicable" line, and mirrors the file-level rule: an
+    /// absent `state/fda-check.json` means *unknown*, never *denied*. A
+    /// caller must branch on `applicable` before reading `granted`.
+    struct Report: Encodable {
+        let applicable: Bool
+        let granted: Bool?
+        let probedPath: String?
+        let checkedAt: Date?
+        let context: String
+    }
+
     func run() async throws {
-        guard let result = Self.probeAndRecord(
+        let result = Self.probeAndRecord(
             context: context,
             stateStore: StateStore(paths: AppPaths.default())
-        ) else {
-            print("full disk access: not applicable on this platform (no TCC outside macOS); "
-                + "state/fda-check.json not written.")
+        )
+
+        guard json else {
+            guard let result else {
+                print("full disk access: not applicable on this platform (no TCC outside macOS); "
+                    + "state/fda-check.json not written.")
+                return
+            }
+            print("full disk access: \(result.hasFullDiskAccess ? "granted" : "not granted") (probed \(result.probedPath), context: \(context))")
             return
         }
-        print("full disk access: \(result.hasFullDiskAccess ? "granted" : "not granted") (probed \(result.probedPath), context: \(context))")
+
+        CLIJSON.print(
+            Report(
+                applicable: result != nil,
+                granted: result?.hasFullDiskAccess,
+                probedPath: result?.probedPath,
+                checkedAt: result?.checkedAt,
+                context: context
+            )
+        )
     }
 
     /// Probes and records in one step. Also called by `tick` on every firing,

--- a/Helper/Sources/Commands/ProbeRepo.swift
+++ b/Helper/Sources/Commands/ProbeRepo.swift
@@ -42,6 +42,24 @@ struct ProbeRepo: AsyncParsableCommand, JSONRenderable {
         /// Why, when `outcome` is not `reachable`. Never a repository URL
         /// or a credential — it is `Reachability`'s own bounded reason.
         let reason: String?
+
+        // Explicit `null`, never an omitted key: that is the convention
+        // every other `--json` shape follows (`docs/data-model.md`
+        // §Encoding conventions), and the synthesized encoder would use
+        // `encodeIfPresent` and drop it.
+        private enum CodingKeys: String, CodingKey {
+            case setId, destinationId, label, outcome, reachable, reason
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(setId, forKey: .setId)
+            try container.encode(destinationId, forKey: .destinationId)
+            try container.encode(label, forKey: .label)
+            try container.encode(outcome, forKey: .outcome)
+            try container.encode(reachable, forKey: .reachable)
+            try container.encode(reason, forKey: .reason)
+        }
     }
 
     func run() async throws {

--- a/Helper/Sources/Commands/ProbeRepo.swift
+++ b/Helper/Sources/Commands/ProbeRepo.swift
@@ -5,11 +5,11 @@ import ResticStationCore
 /// `probe-repo --set <uuid> --dest <uuid>` — an on-demand reachability
 /// probe (the app's manual "check now" action; also what `tick` does for
 /// every destination every 30 minutes, inline).
-struct ProbeRepo: AsyncParsableCommand {
+struct ProbeRepo: AsyncParsableCommand, JSONRenderable {
     static let configuration = CommandConfiguration(
         commandName: "probe-repo",
         abstract: "Probe one destination's reachability and record the result. "
-            + "Exit 0 reachable, 3 offline, 1 error."
+            + "--json for scripting. Exit 0 reachable, 3 offline, 1 error."
     )
 
     @Option(name: .long, help: "The backup set's UUID.")
@@ -18,16 +18,42 @@ struct ProbeRepo: AsyncParsableCommand {
     @Option(name: .long, help: "The destination UUID to probe.")
     var dest: UUID
 
+    @Flag(name: .long, help: "Emit JSON. Only JSON reaches stdout in this mode.")
+    var json = false
+
+    /// `probe-repo --json`'s shape — see `docs/cli-json.md`.
+    ///
+    /// **Offline is reported as a success, not as an error envelope.** An
+    /// unplugged drive is the expected state of a destination, not a fault,
+    /// and the exit code (3) already says so. Wrapping it as a failure would
+    /// make a caller treat "your NAS is asleep" the same as "your config is
+    /// broken". `outcome` is the field to branch on.
+    struct Report: Encodable {
+        enum Outcome: String, Encodable {
+            case reachable
+            case offline
+            case error
+        }
+        let setId: UUID
+        let destinationId: UUID
+        let label: String
+        let outcome: Outcome
+        let reachable: Bool
+        /// Why, when `outcome` is not `reachable`. Never a repository URL
+        /// or a credential — it is `Reachability`'s own bounded reason.
+        let reason: String?
+    }
+
     func run() async throws {
         let context = try await HelperContext.make()
         // Repository utilities address every repository in the shared config,
         // including sets this machine does not back up (T24): `addressable`,
         // not `scheduled`.
         guard let backupSet = context.addressable.set(id: set) else {
-            HelperExit.fail("no backup set with id \(set)")
+            throw CLIFailure.setNotFound(setId: set)
         }
         guard let destination = backupSet.destinations.first(where: { $0.id == dest }) else {
-            HelperExit.fail("destination \(dest) does not belong to backup set \(set)")
+            throw CLIFailure.destinationNotFound(setId: set, destinationId: dest)
         }
 
         let probe = await context.reachability.probe(destination)
@@ -51,16 +77,39 @@ struct ProbeRepo: AsyncParsableCommand {
             FileHandle.standardError.write(Data("probe-repo: could not write repo-status: \(error)\n".utf8))
         }
 
+        let outcome: Report.Outcome
+        let reason: String?
+        let exitCode: Int32
         switch probe {
         case .reachable:
-            print("\"\(destination.label)\": reachable")
-            HelperExit.code(0)
-        case .offline(let reason):
-            print("\"\(destination.label)\": offline — \(reason)")
-            HelperExit.code(3)
+            (outcome, reason, exitCode) = (.reachable, nil, HelperExitCode.ok.rawValue)
+        case .offline(let text):
+            (outcome, reason, exitCode) = (.offline, text, HelperExitCode.offline.rawValue)
         case .error(let exitClass):
-            print("\"\(destination.label)\": error — \(exitClass.userFacingMessage)")
-            HelperExit.code(1)
+            (outcome, reason, exitCode) = (.error, exitClass.userFacingMessage, HelperExitCode.error.rawValue)
         }
+
+        if json {
+            CLIJSON.print(
+                Report(
+                    setId: set,
+                    destinationId: destination.id,
+                    label: destination.label,
+                    outcome: outcome,
+                    reachable: outcome == .reachable,
+                    reason: reason
+                )
+            )
+        } else {
+            switch outcome {
+            case .reachable:
+                print("\"\(destination.label)\": reachable")
+            case .offline:
+                print("\"\(destination.label)\": offline — \(reason ?? "")")
+            case .error:
+                print("\"\(destination.label)\": error — \(reason ?? "")")
+            }
+        }
+        HelperExit.code(exitCode)
     }
 }

--- a/Helper/Sources/Commands/Secret.swift
+++ b/Helper/Sources/Commands/Secret.swift
@@ -150,12 +150,16 @@ struct SecretRemove: AsyncParsableCommand {
 
 // MARK: - secret list
 
-struct SecretList: AsyncParsableCommand {
+struct SecretList: AsyncParsableCommand, JSONRenderable {
     static let configuration = CommandConfiguration(
         commandName: "list",
         abstract: "List the configured destinations that have a stored password and/or secret "
-            + "environment. Never prints a secret value. Exit 0 ok, 1 error."
+            + "environment. Never prints a secret value. --json for scripting. "
+            + "Exit 0 ok, 1 error."
     )
+
+    @Flag(name: .long, help: "Emit JSON. Only JSON reaches stdout in this mode.")
+    var json = false
 
     func run() async throws {
         let context = SecretContext.make()
@@ -172,14 +176,14 @@ struct SecretList: AsyncParsableCommand {
             } catch SecretStoreError.itemNotFound {
                 hasPassword = false
             } catch {
-                HelperExit.fail("could not read stored secrets: \(error)")
+                throw CLIFailure.classify(error)
             }
 
             let secretEnvCount: Int
             do {
                 secretEnvCount = try await context.store.secretEnv(destId: destId).count
             } catch {
-                HelperExit.fail("could not read stored secrets: \(error)")
+                throw CLIFailure.classify(error)
             }
 
             rows.append(
@@ -193,8 +197,16 @@ struct SecretList: AsyncParsableCommand {
             )
         }
 
-        for line in SecretListing.format(rows) {
-            print(line)
+        if json {
+            // Presence metadata only. `Row` has no field that can hold a
+            // password or an env *value* — it counts them. That is the same
+            // redaction-by-shape rule `CLIErrorDetails` follows, and it is
+            // why this command can have a JSON mode at all.
+            CLIJSON.print(rows)
+        } else {
+            for line in SecretListing.format(rows) {
+                print(line)
+            }
         }
         HelperExit.code(0)
     }
@@ -370,7 +382,9 @@ enum SecretEnvInput {
 /// Renders `secret list`. Pure, so a test can assert on the exact lines and
 /// prove no secret value can reach stdout.
 enum SecretListing {
-    struct Row {
+    /// Also `secret list --json`'s element shape (`docs/cli-json.md`).
+    /// Encodable deliberately carries *counts*, never values.
+    struct Row: Encodable {
         let destId: UUID
         let label: String
         let setName: String

--- a/Helper/Sources/Commands/Secret.swift
+++ b/Helper/Sources/Commands/Secret.swift
@@ -53,7 +53,7 @@ struct SecretSet: AsyncParsableCommand {
     var dest: UUID
 
     func run() async throws {
-        let context = SecretContext.make()
+        let context = try SecretContext.make()
         let destination = context.destination(dest)
 
         let password = SecretInput.read(prompt: "Password for \"\(destination.label)\": ")
@@ -85,7 +85,7 @@ struct SecretSetEnv: AsyncParsableCommand {
     var dest: UUID
 
     func run() async throws {
-        let context = SecretContext.make()
+        let context = try SecretContext.make()
         let destination = context.destination(dest)
 
         let raw = SecretInput.readAllStdin()
@@ -128,7 +128,7 @@ struct SecretRemove: AsyncParsableCommand {
     var env = false
 
     func run() async throws {
-        let context = SecretContext.make()
+        let context = try SecretContext.make()
         let destination = context.destination(dest)
 
         do {
@@ -162,7 +162,7 @@ struct SecretList: AsyncParsableCommand, JSONRenderable {
     var json = false
 
     func run() async throws {
-        let context = SecretContext.make()
+        let context = try SecretContext.make()
 
         var rows: [SecretListing.Row] = []
         for entry in context.destinations {
@@ -202,7 +202,15 @@ struct SecretList: AsyncParsableCommand, JSONRenderable {
             // password or an env *value* — it counts them. That is the same
             // redaction-by-shape rule `CLIErrorDetails` follows, and it is
             // why this command can have a JSON mode at all.
-            CLIJSON.print(rows)
+            //
+            // Filtered by `hasAnything`, exactly as `SecretListing.format`
+            // filters for human mode: this command lists "destinations that
+            // have a stored password and/or secret environment", so an empty
+            // store must answer `[]` rather than one row per configured
+            // destination saying it has nothing. The two modes disagreeing
+            // about the result set is the trap a shared payload exists to
+            // remove.
+            CLIJSON.print(rows.filter(\.hasAnything))
         } else {
             for line in SecretListing.format(rows) {
                 print(line)
@@ -241,7 +249,7 @@ struct PrintPassword: AsyncParsableCommand {
 
     func run() async throws {
         let paths = AppPaths.default()
-        let store = HelperContext.makeSecretStore(paths: paths, runner: DefaultProcessRunner())
+        let store = try HelperContext.makeSecretStore(paths: paths, runner: DefaultProcessRunner())
 
         let password: String
         do {

--- a/Helper/Sources/Commands/Tick.swift
+++ b/Helper/Sources/Commands/Tick.swift
@@ -65,7 +65,7 @@ struct Tick: AsyncParsableCommand {
             return
         }
         let context: HelperContext
-        switch await HelperContext.makeTolerant(
+        switch try await HelperContext.makeTolerant(
             paths: paths,
             views: views,
             configStore: configStore

--- a/Helper/Sources/Commands/Version.swift
+++ b/Helper/Sources/Commands/Version.swift
@@ -1,12 +1,54 @@
 import ArgumentParser
+import Foundation
 
-struct Version: ParsableCommand {
+/// `version [--json]` — the helper's own version.
+///
+/// The one command with no configuration, no state and no restic: an agent
+/// calls it first to find out what it is talking to, so it must work on a
+/// host where nothing else does.
+struct Version: AsyncParsableCommand, JSONRenderable {
     static let configuration = CommandConfiguration(
         commandName: "version",
-        abstract: "Print the helper's version and exit."
+        abstract: "Print the helper's version and exit. --json for scripting."
     )
 
-    func run() throws {
-        print("restic-station-helper 0.1.0")
+    @Flag(name: .long, help: "Emit JSON. Only JSON reaches stdout in this mode.")
+    var json = false
+
+    /// The single source of truth for the printed version. The human line
+    /// is built from this rather than the other way round, so the two can
+    /// never disagree.
+    static let name = "restic-station-helper"
+    static let version = "0.1.0"
+
+    /// `version --json`'s shape — see `docs/cli-json.md`.
+    struct Report: Encodable {
+        let name: String
+        let version: String
+        /// The OS this binary was built for. An agent choosing between
+        /// `launchctl` and `systemctl` advice, or deciding whether
+        /// `fda-check` means anything here, needs it — and it is otherwise
+        /// only inferable from prose.
+        let platform: String
+    }
+
+    func run() async throws {
+        guard json else {
+            print("\(Self.name) \(Self.version)")
+            return
+        }
+        CLIJSON.print(
+            Report(name: Self.name, version: Self.version, platform: Self.platform)
+        )
+    }
+
+    static var platform: String {
+        #if os(macOS)
+        return "macOS"
+        #elseif os(Linux)
+        return "Linux"
+        #else
+        return "unknown"
+        #endif
     }
 }

--- a/Helper/Sources/HelperContext.swift
+++ b/Helper/Sources/HelperContext.swift
@@ -102,7 +102,7 @@ struct HelperContext {
         } catch {
             throw CLIFailure.configInvalid(underlying: error)
         }
-        switch await makeTolerant(paths: paths, views: views, configStore: configStore) {
+        switch try await makeTolerant(paths: paths, views: views, configStore: configStore) {
         case .ready(let context):
             return context
         case .noRestic(let result):
@@ -127,11 +127,15 @@ struct HelperContext {
         case noRestic(ResticDiscoveryResult)
     }
 
+    /// - Throws: only ``CLIFailure`` from ``makeSecretStore(paths:runner:)``,
+    ///   which is a misconfigured backend selection — a hard error in every
+    ///   caller including `tick`, and one that exited 1 here before it was
+    ///   made throwable.
     static func makeTolerant(
         paths: AppPaths,
         views: Views,
         configStore: ConfigStore
-    ) async -> TolerantOutcome {
+    ) async throws -> TolerantOutcome {
         let resticPath: String
         switch await resolveResticPath(resolved: views.scheduled) {
         case .resolved(let path):
@@ -140,7 +144,7 @@ struct HelperContext {
             return .noRestic(result)
         }
         let processRunner = DefaultProcessRunner()
-        let secrets = makeSecretStore(paths: paths, runner: processRunner)
+        let secrets = try makeSecretStore(paths: paths, runner: processRunner)
         let restic = ResticRunner(resticPath: resticPath, paths: paths, secrets: secrets, runner: processRunner)
         let runStore = RunStore(paths: paths)
         let stateStore = StateStore(paths: paths)
@@ -188,7 +192,12 @@ struct HelperContext {
     /// file backend's `RESTIC_PASSWORD_COMMAND` — the app must pass its
     /// embedded helper's path instead, which is why the factory has no
     /// default.
-    static func makeSecretStore(paths: AppPaths, runner: ProcessRunning) -> any SecretStore {
+    /// - Throws: ``CLIFailure`` rather than exiting, so a `--json` caller of
+    ///   `secret list` gets the envelope instead of prose on stderr. The
+    ///   only way this fails is a bad `RESTIC_STATION_SECRET_BACKEND`, which
+    ///   is a misconfiguration of this host that a human has to fix — hence
+    ///   `config_invalid` and not the retryable `secret_unavailable`.
+    static func makeSecretStore(paths: AppPaths, runner: ProcessRunning) throws -> any SecretStore {
         do {
             return try SecretStoreFactory.make(
                 paths: paths,
@@ -196,7 +205,8 @@ struct HelperContext {
                 helperExecutablePath: FileSecretStore.currentExecutablePath()
             )
         } catch {
-            HelperExit.fail("secret storage is misconfigured: \(error)")
+            // Wording preserved from the `HelperExit.fail` this replaced.
+            throw CLIFailure(code: .configInvalid, message: "secret storage is misconfigured: \(error)")
         }
     }
 }
@@ -212,17 +222,21 @@ struct SecretContext {
     let store: any SecretStore
     let config: AppConfig
 
-    static func make() -> SecretContext {
+    /// - Throws: ``CLIFailure``. Every failure here is one the `--json`
+    ///   commands promise to report as an envelope, and exiting from inside
+    ///   the setup path is how `secret list --json` used to answer an
+    ///   unloadable `config.json` with an empty stdout.
+    static func make() throws -> SecretContext {
         let paths = AppPaths.default()
         let config: AppConfig
         do {
             config = try ConfigStore(paths: paths).load()
         } catch {
-            HelperExit.fail("could not load configuration: \(error)")
+            throw CLIFailure.configInvalid(underlying: error)
         }
         return SecretContext(
             paths: paths,
-            store: HelperContext.makeSecretStore(paths: paths, runner: DefaultProcessRunner()),
+            store: try HelperContext.makeSecretStore(paths: paths, runner: DefaultProcessRunner()),
             config: config
         )
     }

--- a/Helper/Tests/HelperTests/CLIErrorEnvelopeTests.swift
+++ b/Helper/Tests/HelperTests/CLIErrorEnvelopeTests.swift
@@ -226,7 +226,12 @@ struct CommandFailureClassificationTests {
         setenv("RESTIC_STATION_DATA_DIR", directory.path, 1)
         defer { unsetenv("RESTIC_STATION_DATA_DIR") }
 
-        for argv in [["sets", "list"], ["status"], ["config", "show"]] {
+        // `secret list` is in this list because it reaches its config
+        // through `SecretContext.make()`, not `HelperContext.make()` —
+        // entering a password has to work before restic is configured — so
+        // it had a second setup path with its own `HelperExit.fail` and kept
+        // answering a broken config with an empty stdout.
+        for argv in [["sets", "list"], ["status"], ["config", "show"], ["secret", "list"]] {
             var command = try #require(HelperMain.parseAsRoot(argv) as? any AsyncParsableCommand)
             do {
                 try await command.run()

--- a/Helper/Tests/HelperTests/CLIErrorEnvelopeTests.swift
+++ b/Helper/Tests/HelperTests/CLIErrorEnvelopeTests.swift
@@ -19,21 +19,36 @@ import Testing
 @Suite("--json mode detection")
 struct JSONModeDetectionTests {
 
+    /// The complete set of `--json`-capable commands, and the same list
+    /// `docs/cli-json.md`'s matrix publishes. A new `--json` command that
+    /// forgets the `JSONRenderable` conformance shows up here as a missing
+    /// entry rather than as silent prose on stdout when it fails.
+    ///
+    /// `timer status` is deliberately absent — it is Linux-only and
+    /// documented as human-only, its machine-readable equivalent being
+    /// `status --json`'s `.scheduler` object.
+    static let jsonCapable: [[String]] = [
+        ["version", "--json"],
+        ["status", "--json"],
+        ["sets", "list", "--json"],
+        ["runs", "list", "--json"],
+        ["runs", "show", "some-run-id", "--json"],
+        ["config", "show", "--json"],
+        ["config", "validate", "--json"],
+        [
+            "probe-repo", "--set", "00000000-0000-0000-0000-000000000001",
+            "--dest", "00000000-0000-0000-0000-000000000002", "--json",
+        ],
+        ["secret", "list", "--json"],
+        ["cli", "status", "--json"],
+        ["fda-check", "--json"],
+    ]
+
     @Test("every command with a --json flag reports it through JSONRenderable")
-    func theFiveAreRenderable() throws {
+    func everyJSONCommandIsRenderable() throws {
         // Parsed rather than constructed: this asserts the flag is actually
         // wired to the protocol, which a hand-built instance would not.
-        // The list is the whole set of `--json` commands today; #79 extends
-        // it, and a new `--json` command that forgets the conformance shows
-        // up here as a missing entry rather than as silent prose on stdout.
-        let invocations: [[String]] = [
-            ["status", "--json"],
-            ["sets", "list", "--json"],
-            ["runs", "list", "--json"],
-            ["runs", "show", "some-run-id", "--json"],
-            ["config", "show", "--json"],
-        ]
-        for argv in invocations {
+        for argv in Self.jsonCapable {
             let command = try HelperMain.parseAsRoot(argv)
             #expect(
                 command is JSONRenderable,
@@ -45,16 +60,13 @@ struct JSONModeDetectionTests {
 
     @Test("the same commands report human mode without the flag")
     func withoutTheFlagTheyAreHuman() throws {
-        let invocations: [[String]] = [
-            ["status"],
-            ["sets", "list"],
-            ["runs", "list"],
-            ["runs", "show", "some-run-id"],
-            ["config", "show"],
-        ]
-        for argv in invocations {
-            let command = try HelperMain.parseAsRoot(argv)
-            #expect(!HelperOutput.wantsJSON(command))
+        for argv in Self.jsonCapable {
+            let human = argv.filter { $0 != "--json" }
+            let command = try HelperMain.parseAsRoot(human)
+            #expect(
+                !HelperOutput.wantsJSON(command),
+                "\(human.joined(separator: " ")) reported JSON mode without the flag"
+            )
         }
     }
 

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -52,7 +52,7 @@ itself, unwrapped, because its output is meant to be fed straight back into
 | `config show` | ✅ | effective-config report |
 | `config validate` | ✅ | `{ machineId, errors, warnings, effective, nothingRunsHere }` |
 | `probe-repo` | ✅ | `{ setId, destinationId, label, outcome, reachable, reason }` |
-| `secret list` | ✅ | array of `{ destId, label, setName, hasPassword, secretEnvCount }` |
+| `secret list` | ✅ | array of `{ destId, label, setName, hasPassword, secretEnvCount }` — only destinations that have something stored, the same set human mode prints |
 | `cli status` | ✅ | `CLIInstaller.Status` |
 | `fda-check` | ✅ | `{ applicable, granted, probedPath, checkedAt, context }` |
 | `config export` | — | **Unwrapped by design.** The exported config document itself, so it round-trips into `config import`. |
@@ -97,7 +97,7 @@ never match on it. `details` is omitted entirely when empty.
 | `code` | `retryable` | exit | Meaning |
 |---|---|---|---|
 | `invalid_arguments` | no | 64 / 1 | Arguments missing, malformed, or out of range. See §Argument-parser failures for the two exit codes. |
-| `config_invalid` | no | 1 | A configuration file on this host will not load — `config.json` undecodable, failing `validate()`, or written by a newer build; or `machine.json` unreadable. `message` names which. |
+| `config_invalid` | no | 1 | A configuration file on this host will not load — `config.json` undecodable, failing `validate()`, or written by a newer build; `machine.json` unreadable; or `RESTIC_STATION_SECRET_BACKEND` naming a backend that does not exist. `message` names which. |
 | `set_not_found` | no | 1 | No backup set with that id. |
 | `set_disabled_here` | no | 1 | The set exists in the shared config but is switched off for this machine. |
 | `destination_not_found` | no | 1 | No such destination in that set. |

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -1,4 +1,4 @@
-# The `--json` error envelope
+# The `--json` contract
 
 **Normative.** The contract in this document is what automated callers of
 `restic-station-helper` are entitled to rely on. Implemented by
@@ -19,7 +19,59 @@ Rather than allocate a new exit code per failure — which would break every
 existing caller — the precise classification moves into the JSON payload and
 **the exit code stays exactly what it always was**.
 
-## The envelope
+## The two envelopes
+
+Every `--json` command emits exactly one document with the same three
+top-level keys. `ok` is the only discriminator a caller needs — it never has
+to probe for the presence of a key, and never has to know which command it
+called to know the shape.
+
+```json
+{ "schemaVersion": 1, "ok": true,  "data":  { … } }
+{ "schemaVersion": 1, "ok": false, "error": { … } }
+```
+
+`schemaVersion` covers both branches: they are one contract, and a caller
+that has pinned `1` has pinned both.
+
+The wrapping happens in one place (`CLIJSON.print`), which is what stops it
+from being something each command has to remember. `config export` is the
+single deliberate exception — it emits the exported `config.json` document
+itself, unwrapped, because its output is meant to be fed straight back into
+`config import`.
+
+## Command matrix
+
+| Command | `--json` | Payload (`data`) |
+|---|---|---|
+| `version` | ✅ | `{ name, version, platform }` |
+| `status` | ✅ | `StatusReport` — see `data-model.md` §`status --json` |
+| `sets list` | ✅ | array of set entries — `data-model.md` §`sets list --json` |
+| `runs list` | ✅ | array of `RunIndexEntry` |
+| `runs show <id>` | ✅ | `RunMetadata` |
+| `config show` | ✅ | effective-config report |
+| `config validate` | ✅ | `{ machineId, errors, warnings, effective, nothingRunsHere }` |
+| `probe-repo` | ✅ | `{ setId, destinationId, label, outcome, reachable, reason }` |
+| `secret list` | ✅ | array of `{ destId, label, setName, hasPassword, secretEnvCount }` |
+| `cli status` | ✅ | `CLIInstaller.Status` |
+| `fda-check` | ✅ | `{ applicable, granted, probedPath, checkedAt, context }` |
+| `config export` | — | **Unwrapped by design.** The exported config document itself, so it round-trips into `config import`. |
+| `timer status` (Linux) | — | **Human-only.** Its report is narrative assembled while probing; the machine-readable equivalent is `status --json`'s `.scheduler`, in the same problem vocabulary. |
+| `print-password` | — | Hidden; exists for `RESTIC_PASSWORD_COMMAND` and writes a secret to stdout. |
+| `tick`, `run-set`, `restore`, `init-secondary`, `unlock`, `config import`, `secret set`/`set-env`/`rm`, `cli install`/`uninstall`, `timer install`/`uninstall` | — | Mutating, not inspection. Progress is a human/log concern; the machine-readable record of what happened is the run record (`runs show --json`). |
+
+Two payload notes that are easy to get wrong:
+
+- **`probe-repo` reports offline as a success.** `outcome: "offline"` with
+  `ok: true` and exit 3. An unplugged drive is a destination's expected
+  state, not a fault — an error envelope would make a sleeping NAS
+  indistinguishable from a broken config. Branch on `outcome`.
+- **`fda-check` has three states, not two.** Off macOS, `applicable` is
+  `false` and `granted` is `null`. A caller must check `applicable` before
+  reading `granted`, exactly as an absent `state/fda-check.json` means
+  *unknown* rather than *denied*.
+
+## The error branch
 
 On a handled failure in `--json` mode, stdout contains exactly one document:
 
@@ -168,15 +220,37 @@ code alone.
 
 ## Coverage today
 
-`status`, `sets list`, `runs list`, `runs show`, and `config show`. The
-remaining commands are human-only and still write prose to stderr; #79 converts
-them as it gives them their own `--json`. That boundary is stated here rather
-than papered over.
+Eleven commands, listed in the matrix above. The mutating commands remain
+human-only and still write prose to stderr — the boundary is stated in the
+matrix rather than papered over.
 
 Two codes have no producer yet — `repository_offline` (#79 wires the
 reachability probe) and `operation_not_allowed` (the engine invariants refuse
 before throwing). They are defined because the mapping is settled, and their
 absence is asserted, not assumed.
+
+## Migrating from the unwrapped shape
+
+Before this contract, the five commands that had `--json` emitted their
+payload bare: `status --json` was the `StatusReport` object itself, and
+`sets list --json` was a bare array. Every one of them is now wrapped.
+
+The migration is mechanical — prefix the path:
+
+```console
+# before
+$ restic-station-helper status --json | jq -r '.health'
+$ restic-station-helper sets list --json | jq 'length'
+
+# after
+$ restic-station-helper status --json | jq -r '.data.health'
+$ restic-station-helper sets list --json | jq '.data | length'
+```
+
+This was a deliberate break rather than an additive `schemaVersion` key.
+Two shapes coexisting — some commands wrapped, some bare, arrays unable to
+carry a version at all — would have been permanent, and the alternative cost
+is one `.data` in each caller while the tool is pre-1.0.
 
 ## Versioning
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -424,7 +424,17 @@ The net effect on an existing single-machine install is that `"version": 1` beco
 
 ## Headless CLI `--json` shapes (T27)
 
-`config show`, `status`, `sets list`, `runs list` and `runs show` all accept `--json`. This is documented **as an interface**, not as debug output: a script that pipes one of these into `jq` today must keep working across releases the same way `runs/index.jsonl` does. The conventions from the preamble apply identically — `.sortedKeys` + `.prettyPrinted`, ISO 8601 dates with fractional seconds, every optional field encoded as explicit `null` rather than omitted (`ConfigStore.makeEncoder()`, reused verbatim by the CLI's `CLIJSON.print(_:)`).
+Eleven commands accept `--json`; **`cli-json.md` holds the command matrix, the envelope, the error taxonomy and the versioning policy**, and is the normative document for all of it. This section documents the *payload shapes* those commands put in `data`, because they are made of the same types the state files are.
+
+This is documented **as an interface**, not as debug output: a script that pipes one of these into `jq` today must keep working across releases the same way `runs/index.jsonl` does. The conventions from the preamble apply identically — `.sortedKeys` + `.prettyPrinted`, ISO 8601 dates with fractional seconds, every optional field encoded as explicit `null` rather than omitted (`ConfigStore.makeEncoder()`, reused verbatim by the CLI's `CLIJSON.print(_:)`).
+
+**Every payload below is the `data` value, not the whole document.** `CLIJSON.print` wraps it:
+
+```json
+{ "schemaVersion": 1, "ok": true, "data": { … the shapes in this section … } }
+```
+
+So `status --json | jq '.data.health'`, not `.health`. See `cli-json.md` §Migrating from the unwrapped shape — this changed, and the old bare form is gone.
 
 Every `--json` mode writes *only* JSON to stdout; diagnostics go to stderr. `runs list --json` and `runs show --json` reuse `RunIndexEntry` and `RunMetadata` verbatim (§runs/index.jsonl, §runs/\<runId\>/metadata.json above) — no separate shape to document.
 

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -501,7 +501,7 @@ or the direct `init` fails authentication against a backend the rest of this too
 # Non-secret env this destination already carries in config.json (e.g. AWS_DEFAULT_REGION) —
 # read it back with:
 restic-station-helper config show --json \
-    | jq '.sets[].destinations[] | select(.id=="<destination-id>") | .nonSecretEnv'
+    | jq '.data.sets[].destinations[] | select(.id=="<destination-id>") | .nonSecretEnv'
 
 # Export both that non-secret env and the secret credentials — the same values you are
 # about to hand to `secret set-env` — for this one command only:
@@ -728,17 +728,21 @@ backing it up early (the set itself is due every 5 minutes):
   t=+230s  service starts=2  backup runs=1
 
 $ restic-station-helper runs list --json
-[
-  {
-    "kind" : "backup",
-    "runId" : "20260815T185107Z-backup-e1000000",
-    "setId" : "E1000000-0000-4000-8000-000000000001",
-    "snapshotId" : "c8f3f32b8ece4b56b7813aa2c14ddead13a6dbd999377653babbed9c0323eb58",
-    "status" : "success",
-    "trigger" : "scheduled",
-    ...
-  }
-]
+{
+  "data" : [
+    {
+      "kind" : "backup",
+      "runId" : "20260815T185107Z-backup-e1000000",
+      "setId" : "E1000000-0000-4000-8000-000000000001",
+      "snapshotId" : "c8f3f32b8ece4b56b7813aa2c14ddead13a6dbd999377653babbed9c0323eb58",
+      "status" : "success",
+      "trigger" : "scheduled",
+      ...
+    }
+  ],
+  "ok" : true,
+  "schemaVersion" : 1
+}
 
 $ journalctl --user -u restic-station.service --no-pager --since -5 minutes
 Aug 15 18:51:07 runnervm69nxj systemd[1238]: Starting restic-station.service - Restic Station scheduling tick...
@@ -820,75 +824,79 @@ excluded here, and why:
 
 $ restic-station-helper status --json
 {
-  "excludedHere" : [
-    {
-      "description" : "backup set \"Mac Photos Library\" is disabled on this machine",
-      "id" : "F1000000-0000-4000-8000-000000000004",
-      "name" : "Mac Photos Library",
-      "reason" : "disabledForMachine",
-      "setId" : "F1000000-0000-4000-8000-000000000004",
-      "subject" : "backupSet"
-    }
-  ],
-  "fullDiskAccessDenied" : false,
-  "generatedAt" : "2026-08-06T23:03:36.040Z",
-  "health" : "warning",
-  "machineId" : "linux-nas",
-  "scheduler" : {
-    "healthy" : false,
-    "kind" : "systemd-timer",
-    "problems" : [
-      "dataDirectoryMismatch"
+  "data" : {
+    "excludedHere" : [
+      {
+        "description" : "backup set \"Mac Photos Library\" is disabled on this machine",
+        "id" : "F1000000-0000-4000-8000-000000000004",
+        "name" : "Mac Photos Library",
+        "reason" : "disabledForMachine",
+        "setId" : "F1000000-0000-4000-8000-000000000004",
+        "subject" : "backupSet"
+      }
     ],
-    "summaries" : [
-      "the installed timer ticks a different data directory than this command reads"
+    "fullDiskAccessDenied" : false,
+    "generatedAt" : "2026-08-06T23:03:36.040Z",
+    "health" : "warning",
+    "machineId" : "linux-nas",
+    "scheduler" : {
+      "healthy" : false,
+      "kind" : "systemd-timer",
+      "problems" : [
+        "dataDirectoryMismatch"
+      ],
+      "summaries" : [
+        "the installed timer ticks a different data directory than this command reads"
+      ]
+    },
+    "sets" : [
+      {
+        "abandonedRun" : null,
+        "abandonedRunFile" : null,
+        "currentRun" : null,
+        "destinations" : [
+          {
+            "id" : "F1000000-0000-4000-8000-000000000002",
+            "isPrimary" : true,
+            "label" : "NAS Primary",
+            "lastError" : null,
+            "lastSyncedAt" : "2026-08-06T23:03:34.641Z",
+            "reachable" : true,
+            "stale" : false
+          },
+          {
+            "id" : "F1000000-0000-4000-8000-000000000003",
+            "isPrimary" : false,
+            "label" : "Offsite Mirror",
+            "lastError" : null,
+            "lastSyncedAt" : "2026-08-06T23:03:36.003Z",
+            "reachable" : true,
+            "stale" : false
+          }
+        ],
+        "firstBackupOverdue" : false,
+        "id" : "F1000000-0000-4000-8000-000000000001",
+        "isRunning" : false,
+        "lastBackup" : {
+          "ageSeconds" : 1.400916576385498,
+          "end" : "2026-08-06T23:03:34.639Z",
+          "runId" : "20260806T230333Z-backup-f1000000",
+          "start" : "2026-08-06T23:03:33.943Z",
+          "status" : "success"
+        },
+        "lastCheck" : null,
+        "lastPrune" : null,
+        "name" : "Projects",
+        "needsAttention" : false,
+        "nextDue" : "2026-08-06T23:08:33.941Z"
+      }
+    ],
+    "unattributedRuns" : [
+
     ]
   },
-  "sets" : [
-    {
-      "abandonedRun" : null,
-      "abandonedRunFile" : null,
-      "currentRun" : null,
-      "destinations" : [
-        {
-          "id" : "F1000000-0000-4000-8000-000000000002",
-          "isPrimary" : true,
-          "label" : "NAS Primary",
-          "lastError" : null,
-          "lastSyncedAt" : "2026-08-06T23:03:34.641Z",
-          "reachable" : true,
-          "stale" : false
-        },
-        {
-          "id" : "F1000000-0000-4000-8000-000000000003",
-          "isPrimary" : false,
-          "label" : "Offsite Mirror",
-          "lastError" : null,
-          "lastSyncedAt" : "2026-08-06T23:03:36.003Z",
-          "reachable" : true,
-          "stale" : false
-        }
-      ],
-      "firstBackupOverdue" : false,
-      "id" : "F1000000-0000-4000-8000-000000000001",
-      "isRunning" : false,
-      "lastBackup" : {
-        "ageSeconds" : 1.400916576385498,
-        "end" : "2026-08-06T23:03:34.639Z",
-        "runId" : "20260806T230333Z-backup-f1000000",
-        "start" : "2026-08-06T23:03:33.943Z",
-        "status" : "success"
-      },
-      "lastCheck" : null,
-      "lastPrune" : null,
-      "name" : "Projects",
-      "needsAttention" : false,
-      "nextDue" : "2026-08-06T23:08:33.941Z"
-    }
-  ],
-  "unattributedRuns" : [
-
-  ]
+  "ok" : true,
+  "schemaVersion" : 1
 }
 (exit 1)
 
@@ -982,63 +990,67 @@ so this stays regression-checked):
 --- status --json for the same data dir, right after the timer above was uninstalled ---
 $ restic-station-helper status --json; echo "exit $?"
 {
-  "excludedHere" : [
+  "data" : {
+    "excludedHere" : [
 
-  ],
-  "fullDiskAccessDenied" : false,
-  "generatedAt" : "2026-08-06T23:05:10.591Z",
-  "health" : "warning",
-  "machineId" : "linux-nas",
-  "scheduler" : {
-    "healthy" : false,
-    "kind" : "systemd-timer",
-    "problems" : [
-      "unitsMissing",
-      "notEnabled",
-      "notActive"
     ],
-    "summaries" : [
-      "the units are not installed — run `restic-station-helper timer install`",
-      "the timer is not enabled, so it will not come back after a reboot",
-      "the timer is not active, so it is not firing now"
+    "fullDiskAccessDenied" : false,
+    "generatedAt" : "2026-08-06T23:05:10.591Z",
+    "health" : "warning",
+    "machineId" : "linux-nas",
+    "scheduler" : {
+      "healthy" : false,
+      "kind" : "systemd-timer",
+      "problems" : [
+        "unitsMissing",
+        "notEnabled",
+        "notActive"
+      ],
+      "summaries" : [
+        "the units are not installed — run `restic-station-helper timer install`",
+        "the timer is not enabled, so it will not come back after a reboot",
+        "the timer is not active, so it is not firing now"
+      ]
+    },
+    "sets" : [
+      {
+        "abandonedRun" : null,
+        "abandonedRunFile" : null,
+        "currentRun" : null,
+        "destinations" : [
+          {
+            "id" : "E1000000-0000-4000-8000-000000000002",
+            "isPrimary" : true,
+            "label" : "Fire Primary",
+            "lastError" : null,
+            "lastSyncedAt" : "2026-08-06T23:05:02.676Z",
+            "reachable" : true,
+            "stale" : false
+          }
+        ],
+        "firstBackupOverdue" : false,
+        "id" : "E1000000-0000-4000-8000-000000000001",
+        "isRunning" : false,
+        "lastBackup" : {
+          "ageSeconds" : 7.917420506477356,
+          "end" : "2026-08-06T23:05:02.674Z",
+          "runId" : "20260806T230501Z-backup-e1000000",
+          "start" : "2026-08-06T23:05:01.986Z",
+          "status" : "success"
+        },
+        "lastCheck" : null,
+        "lastPrune" : null,
+        "name" : "Fire Check",
+        "needsAttention" : false,
+        "nextDue" : "2026-08-06T23:10:01.983Z"
+      }
+    ],
+    "unattributedRuns" : [
+
     ]
   },
-  "sets" : [
-    {
-      "abandonedRun" : null,
-      "abandonedRunFile" : null,
-      "currentRun" : null,
-      "destinations" : [
-        {
-          "id" : "E1000000-0000-4000-8000-000000000002",
-          "isPrimary" : true,
-          "label" : "Fire Primary",
-          "lastError" : null,
-          "lastSyncedAt" : "2026-08-06T23:05:02.676Z",
-          "reachable" : true,
-          "stale" : false
-        }
-      ],
-      "firstBackupOverdue" : false,
-      "id" : "E1000000-0000-4000-8000-000000000001",
-      "isRunning" : false,
-      "lastBackup" : {
-        "ageSeconds" : 7.917420506477356,
-        "end" : "2026-08-06T23:05:02.674Z",
-        "runId" : "20260806T230501Z-backup-e1000000",
-        "start" : "2026-08-06T23:05:01.986Z",
-        "status" : "success"
-      },
-      "lastCheck" : null,
-      "lastPrune" : null,
-      "name" : "Fire Check",
-      "needsAttention" : false,
-      "nextDue" : "2026-08-06T23:10:01.983Z"
-    }
-  ],
-  "unattributedRuns" : [
-
-  ]
+  "ok" : true,
+  "schemaVersion" : 1
 }
 exit 1
 

--- a/scripts/headless-cli-test.sh
+++ b/scripts/headless-cli-test.sh
@@ -24,6 +24,8 @@
 #      grepped for the fixture secret value at the very end.
 #   7. Exit-code contract (0 ok / 1 error) spot-checked for the new
 #      subcommands on both the happy and unhappy path.
+#   9. Every `--json` command emits one success envelope
+#      ({schemaVersion, ok, data}) on stdout and nothing else (issue #79).
 #   8. A failing `--json` command emits exactly one error envelope on
 #      stdout with the documented `error.code` (issue #81,
 #      `docs/cli-json.md`), human mode is unchanged, and a nonzero exit
@@ -771,6 +773,94 @@ jq -e '.data | .sets' "$OUT_FILE" >/dev/null \
 jq -e 'has("error") | not' "$OUT_FILE" >/dev/null \
     || fail "status --json turned a warning-level report into an error envelope"
 ok "status --json exit 1 on a warning is still a report, not an error envelope"
+
+# ─────────────────────────────────────────────────────────────────────────
+# 9. The success envelope, across every --json command (issue #79).
+#
+#    The Swift suite checks that each of these conforms to JSONRenderable;
+#    what only a real process can show is that stdout carries exactly one
+#    envelope and nothing else — no progress prose, no warning line, no
+#    ANSI. Stdout and stderr are captured separately for that reason.
+# ─────────────────────────────────────────────────────────────────────────
+log "9. every --json command emits one success envelope on stdout"
+
+# `probe-repo` is given the healthy fixture's real set/destination so it
+# reaches its report rather than a not-found failure. It probes a local path
+# that does not exist, so it reports offline — which is a *success* with
+# outcome "offline", and is exactly the case worth pinning here.
+ENVELOPE_CMDS=(
+    "version"
+    "status"
+    "sets list"
+    "runs list"
+    "runs show r-healthy"
+    "config show"
+    "config validate"
+    "probe-repo --set $SET_ID --dest $PRIMARY_ID"
+    "secret list"
+    "cli status"
+    "fda-check"
+)
+
+for CMD in "${ENVELOPE_CMDS[@]}"; do
+    # shellcheck disable=SC2086
+    RESTIC_STATION_DATA_DIR="$HEALTHY" run_helper_split $CMD --json
+    jq -e . "$OUT_FILE" >/dev/null 2>&1 \
+        || fail "\`$CMD --json\` did not put exactly one JSON document on stdout: $(cat "$OUT_FILE")"
+    [[ "$(jq -r '.ok' "$OUT_FILE")" == "true" ]] \
+        || fail "\`$CMD --json\` did not report ok=true (got $(jq -c '.' "$OUT_FILE"))"
+    [[ "$(jq -r '.schemaVersion' "$OUT_FILE")" == "1" ]] \
+        || fail "\`$CMD --json\` did not pin schemaVersion 1"
+    jq -e 'has("data")' "$OUT_FILE" >/dev/null \
+        || fail "\`$CMD --json\` emitted no data key"
+    # The three envelope keys and nothing else: a command that leaks an
+    # extra top-level field has escaped CLIJSON.
+    [[ "$(jq -r 'keys | join(",")' "$OUT_FILE")" == "data,ok,schemaVersion" ]] \
+        || fail "\`$CMD --json\` has unexpected top-level keys: $(jq -r 'keys | join(",")' "$OUT_FILE")"
+done
+ok "all ${#ENVELOPE_CMDS[@]} --json commands emit {schemaVersion, ok, data} and nothing else"
+
+# The payload each one actually carries, spot-checked so the envelope test
+# above cannot pass on an empty or wrong `data`.
+RESTIC_STATION_DATA_DIR="$HEALTHY" run_helper_split version --json
+[[ "$(jq -r '.data.name' "$OUT_FILE")" == "restic-station-helper" ]] || fail "version --json lost its name"
+[[ -n "$(jq -r '.data.platform' "$OUT_FILE")" ]] || fail "version --json did not name a platform"
+
+# probe-repo's outcome depends on whether the fixture's repository path
+# happens to exist, so the *mapping* is what gets pinned, not one outcome:
+# every outcome is a success envelope, and the exit code is the coarse
+# shell signal for the same fact. An offline destination reported as an
+# error envelope would make a sleeping NAS look like a broken config.
+RESTIC_STATION_DATA_DIR="$HEALTHY" run_helper_split probe-repo --set "$SET_ID" --dest "$PRIMARY_ID" --json
+PROBE_RC="$RC"
+PROBE_OUTCOME="$(jq -r '.data.outcome' "$OUT_FILE")"
+[[ "$(jq -r '.ok' "$OUT_FILE")" == "true" ]] \
+    || fail "probe-repo --json reported an error envelope for outcome=$PROBE_OUTCOME"
+case "$PROBE_OUTCOME" in
+    reachable) [[ "$PROBE_RC" -eq 0 ]] || fail "probe-repo reachable must exit 0, got $PROBE_RC" ;;
+    offline)   [[ "$PROBE_RC" -eq 3 ]] || fail "probe-repo offline must exit 3, got $PROBE_RC" ;;
+    error)     [[ "$PROBE_RC" -eq 1 ]] || fail "probe-repo error must exit 1, got $PROBE_RC" ;;
+    *)         fail "probe-repo --json reported an unknown outcome: $PROBE_OUTCOME" ;;
+esac
+[[ "$(jq -r '.data.reachable' "$OUT_FILE")" == "$([[ "$PROBE_OUTCOME" == "reachable" ]] && echo true || echo false)" ]] \
+    || fail "probe-repo's reachable flag disagrees with its outcome"
+# The optional field is present as an explicit null, never omitted.
+jq -e 'has("reason")' <<<"$(jq -c '.data' "$OUT_FILE")" >/dev/null \
+    || fail "probe-repo --json omitted the reason key instead of encoding null"
+
+RESTIC_STATION_DATA_DIR="$HEALTHY" run_helper_split config validate --json
+[[ "$(jq -r '.data.nothingRunsHere' "$OUT_FILE")" == "false" ]] \
+    || fail "config validate --json did not report that something runs here"
+jq -e '.data.effective.sets | length >= 1' "$OUT_FILE" >/dev/null \
+    || fail "config validate --json carried no effective plan"
+
+# secret list reports presence, never values — the reason it can have a JSON
+# mode at all. Asserted structurally, not just by the end-of-run grep.
+RESTIC_STATION_DATA_DIR="$HEALTHY" run_helper_split secret list --json
+jq -e '[.data[] | keys] | flatten | unique | inside(["destId","label","setName","hasPassword","secretEnvCount"])' \
+    "$OUT_FILE" >/dev/null \
+    || fail "secret list --json grew a field beyond presence metadata: $(jq -c '.data' "$OUT_FILE")"
+ok "payloads carry what they claim, and secret list --json stays presence-only"
 
 # ─────────────────────────────────────────────────────────────────────────
 # 6. THE secret-leak check: every byte this script's helper invocations

--- a/scripts/headless-cli-test.sh
+++ b/scripts/headless-cli-test.sh
@@ -105,7 +105,7 @@ expect_rc() {
 # status exit 1, while healthy or unknown scheduler state contributes 0.
 CLEAN_STATUS_RC=0
 capture_clean_status_rc() {
-    if jq -e '.scheduler.healthy == false' "$OUT_FILE" >/dev/null; then
+    if jq -e '.data | .scheduler.healthy == false' "$OUT_FILE" >/dev/null; then
         CLEAN_STATUS_RC=1
     else
         CLEAN_STATUS_RC=0
@@ -176,9 +176,9 @@ ok "real import installs config.json"
 
 RESTIC_STATION_DATA_DIR="$LINUX_DATA" run_helper config show --json
 expect_rc 0
-echo "$(cat "$OUT_FILE")" | jq -e '.sets[0].name == "Projects"' >/dev/null \
+echo "$(cat "$OUT_FILE")" | jq -e '.data | .sets[0].name == "Projects"' >/dev/null \
     || fail "imported config does not resolve the same set on the new host"
-echo "$(cat "$OUT_FILE")" | jq -e '.sets[0].destinations | length == 2' >/dev/null \
+echo "$(cat "$OUT_FILE")" | jq -e '.data | .sets[0].destinations | length == 2' >/dev/null \
     || fail "imported config lost a destination"
 ok "config show --json on the importing host matches the exported set semantically"
 
@@ -328,6 +328,7 @@ RESTIC_STATION_DATA_DIR="$HEALTHY" run_helper status --json
 capture_clean_status_rc
 expect_rc "$CLEAN_STATUS_RC"
 jq -e '
+    .data |
     .sets[0].needsAttention == false
     and .sets[0].lastBackup.status == "success"
     and .health == (if .scheduler.healthy == false then "warning" else "idle" end)
@@ -340,7 +341,7 @@ make_status_fixture "$FIRST_BACKUP_FRESH"
 RESTIC_STATION_DATA_DIR="$FIRST_BACKUP_FRESH" run_helper status --json
 capture_clean_status_rc
 expect_rc "$CLEAN_STATUS_RC"
-echo "$(cat "$OUT_FILE")" | jq -e '.sets[0].firstBackupOverdue == false' >/dev/null \
+echo "$(cat "$OUT_FILE")" | jq -e '.data | .sets[0].firstBackupOverdue == false' >/dev/null \
     || fail "a fresh never-run set warned before its first-backup grace elapsed"
 
 FIRST_BACKUP_OVERDUE="$WORK/status-first-backup-overdue"
@@ -353,6 +354,7 @@ touch -t 202001010000 "$FIRST_BACKUP_OVERDUE/config.json" "$FIRST_BACKUP_OVERDUE
 RESTIC_STATION_DATA_DIR="$FIRST_BACKUP_OVERDUE" run_helper status --json
 expect_rc 1
 echo "$(cat "$OUT_FILE")" | jq -e '
+    .data |
     .health == "warning"
     and .sets[0].lastBackup == null
     and .sets[0].firstBackupOverdue == true
@@ -378,10 +380,10 @@ EOF
 RESTIC_STATION_DATA_DIR="$INFLIGHT" run_helper status --json
 capture_clean_status_rc
 expect_rc "$CLEAN_STATUS_RC"
-echo "$(cat "$OUT_FILE")" | jq -e '.health == "running"' >/dev/null || fail "in-flight fixture did not report running"
-echo "$(cat "$OUT_FILE")" | jq -e '.sets[0].currentRun.phase == "backing-up-primary"' >/dev/null \
+echo "$(cat "$OUT_FILE")" | jq -e '.data | .health == "running"' >/dev/null || fail "in-flight fixture did not report running"
+echo "$(cat "$OUT_FILE")" | jq -e '.data | .sets[0].currentRun.phase == "backing-up-primary"' >/dev/null \
     || fail "in-flight fixture did not surface live progress"
-echo "$(cat "$OUT_FILE")" | jq -e '.sets[0].abandonedRun == null' >/dev/null \
+echo "$(cat "$OUT_FILE")" | jq -e '.data | .sets[0].abandonedRun == null' >/dev/null \
     || fail "a live run was misreported as abandoned"
 ok "in-flight fixture: health=running, live progress surfaced; exit reflects the host scheduler"
 
@@ -400,6 +402,7 @@ EOF
 RESTIC_STATION_DATA_DIR="$STALLED" run_helper status --json
 expect_rc 1
 jq -e '
+    .data |
     .health == "warning"
     and .sets[0].isRunning == false
     and .sets[0].currentRun == null
@@ -426,11 +429,11 @@ cat > "$ABANDONED/state/current-run-$SET_ID.json" <<EOF
 EOF
 RESTIC_STATION_DATA_DIR="$ABANDONED" run_helper status --json
 expect_rc 1
-echo "$(cat "$OUT_FILE")" | jq -e '.health == "warning"' >/dev/null \
+echo "$(cat "$OUT_FILE")" | jq -e '.data | .health == "warning"' >/dev/null \
     || fail "abandoned fixture did not report warning"
-echo "$(cat "$OUT_FILE")" | jq -e '.sets[0].isRunning == false' >/dev/null \
+echo "$(cat "$OUT_FILE")" | jq -e '.data | .sets[0].isRunning == false' >/dev/null \
     || fail "abandoned fixture still reported the set as running"
-echo "$(cat "$OUT_FILE")" | jq -e '.sets[0].abandonedRun.runId == "r-dead"' >/dev/null \
+echo "$(cat "$OUT_FILE")" | jq -e '.data | .sets[0].abandonedRun.runId == "r-dead"' >/dev/null \
     || fail "abandoned fixture did not name the abandoned run"
 ok "abandoned fixture: status --json exits 1, health=warning, the dead run is named"
 
@@ -457,6 +460,7 @@ EOF
 RESTIC_STATION_DATA_DIR="$UNATTRIBUTED" run_helper status --json
 expect_rc 1
 echo "$(cat "$OUT_FILE")" | jq -e '
+    .data |
     (.sets | length) == 0
     and (.unattributedRuns | length) == 2
     and any(.unattributedRuns[]; .currentRun.runId == "r-unattributed-live" and .liveness == "live")
@@ -480,8 +484,8 @@ cat > "$FAILED/runs/index.jsonl" <<EOF
 EOF
 RESTIC_STATION_DATA_DIR="$FAILED" run_helper status --json
 expect_rc 1
-echo "$(cat "$OUT_FILE")" | jq -e '.health == "warning"' >/dev/null || fail "failed fixture did not report warning"
-echo "$(cat "$OUT_FILE")" | jq -e '.sets[0].needsAttention == true' >/dev/null \
+echo "$(cat "$OUT_FILE")" | jq -e '.data | .health == "warning"' >/dev/null || fail "failed fixture did not report warning"
+echo "$(cat "$OUT_FILE")" | jq -e '.data | .sets[0].needsAttention == true' >/dev/null \
     || fail "failed fixture's set was not flagged needsAttention"
 ok "failed fixture: status --json exits 1, health=warning"
 
@@ -500,8 +504,8 @@ cat > "$STALE/state/repo-status-$PRIMARY_ID.json" <<EOF
 EOF
 RESTIC_STATION_DATA_DIR="$STALE" run_helper status --json
 expect_rc 1
-echo "$(cat "$OUT_FILE")" | jq -e '.health == "warning"' >/dev/null || fail "stale fixture did not report warning"
-echo "$(cat "$OUT_FILE")" | jq -e '.sets[0].destinations[0].stale == true' >/dev/null \
+echo "$(cat "$OUT_FILE")" | jq -e '.data | .health == "warning"' >/dev/null || fail "stale fixture did not report warning"
+echo "$(cat "$OUT_FILE")" | jq -e '.data | .sets[0].destinations[0].stale == true' >/dev/null \
     || fail "stale fixture's destination was not flagged stale"
 ok "stale-mirror fixture: status --json exits 1, health=warning, destination flagged stale"
 
@@ -527,9 +531,9 @@ NOW_TS=$(date -u +%s)
 } > "$CROWDED/runs/index.jsonl"
 RESTIC_STATION_DATA_DIR="$CROWDED" run_helper status --json
 expect_rc 1
-echo "$(cat "$OUT_FILE")" | jq -e '.health == "warning"' >/dev/null \
+echo "$(cat "$OUT_FILE")" | jq -e '.data | .health == "warning"' >/dev/null \
     || fail "a quiet set's failed last run must not be hidden behind 200+ newer runs from another set"
-echo "$(cat "$OUT_FILE")" | jq -e '.sets[0].needsAttention == true' >/dev/null \
+echo "$(cat "$OUT_FILE")" | jq -e '.data | .sets[0].needsAttention == true' >/dev/null \
     || fail "the quiet, configured set was not flagged needsAttention despite its last run having failed"
 ok "a quiet set's failed last run survives 200+ newer runs from another set — status --json exit code stays 1"
 
@@ -541,15 +545,15 @@ log "5. --json output is parseable JSON with nothing else on stdout"
 RESTIC_STATION_DATA_DIR="$HEALTHY" run_helper status --json
 capture_clean_status_rc
 expect_rc "$CLEAN_STATUS_RC"
-jq -e '.machineId | length > 0' "$OUT_FILE" >/dev/null \
+jq -e '.data | .machineId | length > 0' "$OUT_FILE" >/dev/null \
     || fail "status --json did not produce clean JSON"
-RESTIC_STATION_DATA_DIR="$HEALTHY" "$HELPER" sets list --json | jq -e 'type == "array"' >/dev/null \
+RESTIC_STATION_DATA_DIR="$HEALTHY" "$HELPER" sets list --json | jq -e '.data | type == "array"' >/dev/null \
     || fail "sets list --json did not pipe cleanly through jq"
-RESTIC_STATION_DATA_DIR="$HEALTHY" "$HELPER" runs list --json | jq -e 'type == "array"' >/dev/null \
+RESTIC_STATION_DATA_DIR="$HEALTHY" "$HELPER" runs list --json | jq -e '.data | type == "array"' >/dev/null \
     || fail "runs list --json did not pipe cleanly through jq"
-RESTIC_STATION_DATA_DIR="$HEALTHY" "$HELPER" config show --json | jq -e '.machineId | length > 0' >/dev/null \
+RESTIC_STATION_DATA_DIR="$HEALTHY" "$HELPER" config show --json | jq -e '.data | .machineId | length > 0' >/dev/null \
     || fail "config show --json did not pipe cleanly through jq"
-RESTIC_STATION_DATA_DIR="$HEALTHY" "$HELPER" runs show r-healthy --json | jq -e '.runId == "r-healthy"' >/dev/null \
+RESTIC_STATION_DATA_DIR="$HEALTHY" "$HELPER" runs show r-healthy --json | jq -e '.data | .runId == "r-healthy"' >/dev/null \
     || fail "runs show --json did not pipe cleanly through jq"
 ok "status, sets list, runs list, runs show, config show --json all parse cleanly through jq"
 
@@ -666,7 +670,7 @@ EOF
     RESTIC_STATION_DATA_DIR="$REAL_DATA" run_helper status --json
     capture_clean_status_rc
     expect_rc "$CLEAN_STATUS_RC"
-    echo "$(cat "$OUT_FILE")" | jq -e '.sets[0].lastBackup.status == "success"' >/dev/null \
+    echo "$(cat "$OUT_FILE")" | jq -e '.data | .sets[0].lastBackup.status == "success"' >/dev/null \
         || fail "status did not reflect the real backup that just ran"
     ok "a real run-set backup is reflected by status --json"
 
@@ -762,7 +766,7 @@ ok "--json --help still prints help and exits 0"
 # stay a StatusReport, never an error envelope.
 RESTIC_STATION_DATA_DIR="$FAILED" run_helper_split status --json
 expect_rc 1
-jq -e '.sets' "$OUT_FILE" >/dev/null \
+jq -e '.data | .sets' "$OUT_FILE" >/dev/null \
     || fail "status --json stopped emitting a report when health is warning"
 jq -e 'has("error") | not' "$OUT_FILE" >/dev/null \
     || fail "status --json turned a warning-level report into an error envelope"

--- a/scripts/headless-cli-test.sh
+++ b/scripts/headless-cli-test.sh
@@ -702,7 +702,12 @@ echo 'not valid json{{{' > "$ENVELOPE_DATA/config.json"
 # never loads config.json, so an unloadable config is not a failure for it —
 # it correctly reports an empty history and exits 0. Its own failure path is
 # asserted separately below.
-for CMD in "status" "sets list" "config show"; do
+# `secret list` is in this loop because its setup path is a *different* one:
+# it does not go through `HelperContext.make()` at all (entering a password
+# must work before restic is configured), so it had its own `HelperExit.fail`
+# and answered a broken config with an empty stdout long after the other
+# commands stopped doing that.
+for CMD in "status" "sets list" "config show" "secret list"; do
     # shellcheck disable=SC2086
     RESTIC_STATION_DATA_DIR="$ENVELOPE_DATA" run_helper_split $CMD --json
     expect_rc 1
@@ -716,6 +721,25 @@ for CMD in "status" "sets list" "config show"; do
         || fail "\`$CMD --json\` marked an invalid config retryable"
 done
 ok "every --json command reports an unloadable config.json as config_invalid, exit 1"
+
+# `config validate --json` has a second setup failure of its own: with no
+# `--machine`, the answer comes from this host's `machine.json`, and an
+# unreadable one used to exit with prose rather than an envelope. The config
+# here is *valid* — this is specifically the identity path, not the config
+# path the loop above covers.
+MACHINE_DATA="$WORK/bad-machine"
+mkdir -p "$MACHINE_DATA"
+cp "$HEALTHY/config.json" "$MACHINE_DATA/config.json"
+echo 'not valid json{{{' > "$MACHINE_DATA/machine.json"
+RESTIC_STATION_DATA_DIR="$MACHINE_DATA" run_helper_split config validate --json
+expect_rc 1
+jq -e . "$OUT_FILE" >/dev/null 2>&1 \
+    || fail "config validate --json on an unreadable machine.json put no JSON document on stdout"
+[[ "$(jq -r '.error.code' "$OUT_FILE")" == "config_invalid" ]] \
+    || fail "config validate --json reported $(jq -r '.error.code' "$OUT_FILE") for an unreadable machine.json"
+jq -e '.error.message | test("machine")' "$OUT_FILE" >/dev/null \
+    || fail "the envelope did not say which file it was: $(jq -r '.error.message' "$OUT_FILE")"
+ok "config validate --json reports an unreadable machine.json as config_invalid, exit 1"
 
 # `runs list`'s own classified failure: its --limit check is hand-written
 # rather than an ArgumentParser `validate()` throw, specifically so it exits
@@ -883,7 +907,38 @@ RESTIC_STATION_DATA_DIR="$HEALTHY" run_helper_split secret list --json
 jq -e '[.data[] | keys] | flatten | unique | inside(["destId","label","setName","hasPassword","secretEnvCount"])' \
     "$OUT_FILE" >/dev/null \
     || fail "secret list --json grew a field beyond presence metadata: $(jq -c '.data' "$OUT_FILE")"
-ok "payloads carry what they claim, and secret list --json stays presence-only"
+# Both modes list the same destinations. JSON mode used to serialize every
+# configured destination, including the ones with nothing stored, while
+# human mode filtered them — so an empty store answered `[]` to a person
+# and a full array of "has nothing" rows to a script.
+jq -e 'all(.data[]; .hasPassword or .secretEnvCount > 0)' "$OUT_FILE" >/dev/null \
+    || fail "secret list --json listed a destination with nothing stored: $(jq -c '.data' "$OUT_FILE")"
+# Nothing is stored in this fixture, so both modes must say so — `[]` and
+# the sentence, not a row per configured destination.
+[[ "$(jq -r '.data | length' "$OUT_FILE")" -eq 0 ]] \
+    || fail "secret list --json listed destinations from a store with nothing in it: $(jq -c '.data' "$OUT_FILE")"
+RESTIC_STATION_DATA_DIR="$HEALTHY" run_helper_split secret list
+grep -q "no destination has a stored password" "$OUT_FILE" \
+    || fail "secret list (human) did not report an empty store: $(cat "$OUT_FILE")"
+
+# ...and with one stored, both modes list exactly it. The two counts are
+# what caught the divergence: JSON mode served every configured destination
+# while human mode filtered, so the modes disagreed about the result set.
+printf '%s' "$SECRET_PASSWORD" \
+    | RESTIC_STATION_DATA_DIR="$HEALTHY" "$HELPER" secret set --dest "$PRIMARY_ID" >>"$COMBINED_LOG" 2>&1 \
+    || fail "could not store a password in the healthy fixture"
+RESTIC_STATION_DATA_DIR="$HEALTHY" run_helper_split secret list --json
+JSON_ROWS="$(jq -r '.data | length' "$OUT_FILE")"
+[[ "$JSON_ROWS" -eq 1 ]] || fail "secret list --json listed $JSON_ROWS destinations, expected 1"
+jq -e --arg id "$PRIMARY_ID" '.data[0] | .destId == $id and .hasPassword' "$OUT_FILE" >/dev/null \
+    || fail "secret list --json did not report the stored password: $(jq -c '.data' "$OUT_FILE")"
+RESTIC_STATION_DATA_DIR="$HEALTHY" run_helper_split secret list
+HUMAN_ROWS="$(grep -c "$PRIMARY_ID" "$OUT_FILE" || true)"
+[[ "$JSON_ROWS" -eq "$HUMAN_ROWS" ]] \
+    || fail "secret list listed $HUMAN_ROWS destinations to a human and $JSON_ROWS to a script"
+RESTIC_STATION_DATA_DIR="$HEALTHY" "$HELPER" secret rm --dest "$PRIMARY_ID" >>"$COMBINED_LOG" 2>&1 \
+    || fail "could not remove the fixture password again"
+ok "payloads carry what they claim, secret list --json stays presence-only and agrees with human mode"
 
 # ─────────────────────────────────────────────────────────────────────────
 # 6. THE secret-leak check: every byte this script's helper invocations

--- a/scripts/headless-cli-test.sh
+++ b/scripts/headless-cli-test.sh
@@ -784,10 +784,11 @@ ok "status --json exit 1 on a warning is still a report, not an error envelope"
 # ─────────────────────────────────────────────────────────────────────────
 log "9. every --json command emits one success envelope on stdout"
 
-# `probe-repo` is given the healthy fixture's real set/destination so it
-# reaches its report rather than a not-found failure. It probes a local path
-# that does not exist, so it reports offline — which is a *success* with
-# outcome "offline", and is exactly the case worth pinning here.
+# `probe-repo` is deliberately absent from this loop and handled below:
+# it is the only command here that must resolve a usable restic before it
+# can produce any report at all, so on a host without one its correct
+# output is an error envelope, not a success. The `linux` CI job is exactly
+# such a host.
 ENVELOPE_CMDS=(
     "version"
     "status"
@@ -796,7 +797,6 @@ ENVELOPE_CMDS=(
     "runs show r-healthy"
     "config show"
     "config validate"
-    "probe-repo --set $SET_ID --dest $PRIMARY_ID"
     "secret list"
     "cli status"
     "fda-check"
@@ -818,7 +818,7 @@ for CMD in "${ENVELOPE_CMDS[@]}"; do
     [[ "$(jq -r 'keys | join(",")' "$OUT_FILE")" == "data,ok,schemaVersion" ]] \
         || fail "\`$CMD --json\` has unexpected top-level keys: $(jq -r 'keys | join(",")' "$OUT_FILE")"
 done
-ok "all ${#ENVELOPE_CMDS[@]} --json commands emit {schemaVersion, ok, data} and nothing else"
+ok "all ${#ENVELOPE_CMDS[@]} restic-independent --json commands emit {schemaVersion, ok, data} and nothing else"
 
 # The payload each one actually carries, spot-checked so the envelope test
 # above cannot pass on an empty or wrong `data`.
@@ -826,27 +826,50 @@ RESTIC_STATION_DATA_DIR="$HEALTHY" run_helper_split version --json
 [[ "$(jq -r '.data.name' "$OUT_FILE")" == "restic-station-helper" ]] || fail "version --json lost its name"
 [[ -n "$(jq -r '.data.platform' "$OUT_FILE")" ]] || fail "version --json did not name a platform"
 
-# probe-repo's outcome depends on whether the fixture's repository path
-# happens to exist, so the *mapping* is what gets pinned, not one outcome:
-# every outcome is a success envelope, and the exit code is the coarse
-# shell signal for the same fact. An offline destination reported as an
-# error envelope would make a sleeping NAS look like a broken config.
+# probe-repo, on both kinds of host.
+#
+# With a usable restic its *outcome mapping* is what gets pinned, not one
+# outcome — whether the fixture's repository path happens to exist is not
+# this test's subject. Every outcome is a success envelope, and the exit
+# code is the coarse shell signal for the same fact; an offline destination
+# reported as an error envelope would make a sleeping NAS look like a
+# broken config.
+#
+# Without one, `HelperContext.make()` fails before any probe happens and
+# restic_not_found is the correct answer. Asserting that rather than
+# skipping keeps the no-restic host covered instead of silently untested.
 RESTIC_STATION_DATA_DIR="$HEALTHY" run_helper_split probe-repo --set "$SET_ID" --dest "$PRIMARY_ID" --json
 PROBE_RC="$RC"
-PROBE_OUTCOME="$(jq -r '.data.outcome' "$OUT_FILE")"
-[[ "$(jq -r '.ok' "$OUT_FILE")" == "true" ]] \
-    || fail "probe-repo --json reported an error envelope for outcome=$PROBE_OUTCOME"
-case "$PROBE_OUTCOME" in
-    reachable) [[ "$PROBE_RC" -eq 0 ]] || fail "probe-repo reachable must exit 0, got $PROBE_RC" ;;
-    offline)   [[ "$PROBE_RC" -eq 3 ]] || fail "probe-repo offline must exit 3, got $PROBE_RC" ;;
-    error)     [[ "$PROBE_RC" -eq 1 ]] || fail "probe-repo error must exit 1, got $PROBE_RC" ;;
-    *)         fail "probe-repo --json reported an unknown outcome: $PROBE_OUTCOME" ;;
-esac
-[[ "$(jq -r '.data.reachable' "$OUT_FILE")" == "$([[ "$PROBE_OUTCOME" == "reachable" ]] && echo true || echo false)" ]] \
-    || fail "probe-repo's reachable flag disagrees with its outcome"
-# The optional field is present as an explicit null, never omitted.
-jq -e 'has("reason")' <<<"$(jq -c '.data' "$OUT_FILE")" >/dev/null \
-    || fail "probe-repo --json omitted the reason key instead of encoding null"
+# Branch on what the helper actually reported, not on `command -v restic`:
+# discovery also searches well-known absolute paths, so a host can have a
+# usable restic that is not on PATH and the two would disagree.
+if [[ "$(jq -r '.ok' "$OUT_FILE")" == "false" ]]; then
+    # The only legitimate failures here are the two that mean "no usable
+    # restic". Any other code is a regression, not an environment.
+    PROBE_CODE="$(jq -r '.error.code' "$OUT_FILE")"
+    case "$PROBE_CODE" in
+        restic_not_found|restic_unsupported) ;;
+        *) fail "probe-repo --json failed with $PROBE_CODE, which is not a restic-availability problem" ;;
+    esac
+    [[ "$PROBE_RC" -eq 1 ]] || fail "$PROBE_CODE must exit 1, got $PROBE_RC"
+    ok "probe-repo --json on a host with no usable restic reports $PROBE_CODE, exit 1"
+else
+    PROBE_OUTCOME="$(jq -r '.data.outcome' "$OUT_FILE")"
+    [[ "$(jq -r '.ok' "$OUT_FILE")" == "true" ]] \
+        || fail "probe-repo --json reported an error envelope for outcome=$PROBE_OUTCOME"
+    case "$PROBE_OUTCOME" in
+        reachable) [[ "$PROBE_RC" -eq 0 ]] || fail "probe-repo reachable must exit 0, got $PROBE_RC" ;;
+        offline)   [[ "$PROBE_RC" -eq 3 ]] || fail "probe-repo offline must exit 3, got $PROBE_RC" ;;
+        error)     [[ "$PROBE_RC" -eq 1 ]] || fail "probe-repo error must exit 1, got $PROBE_RC" ;;
+        *)         fail "probe-repo --json reported an unknown outcome: $PROBE_OUTCOME" ;;
+    esac
+    [[ "$(jq -r '.data.reachable' "$OUT_FILE")" == "$([[ "$PROBE_OUTCOME" == "reachable" ]] && echo true || echo false)" ]] \
+        || fail "probe-repo's reachable flag disagrees with its outcome"
+    # The optional field is present as an explicit null, never omitted.
+    jq -e 'has("reason")' <<<"$(jq -c '.data' "$OUT_FILE")" >/dev/null \
+        || fail "probe-repo --json omitted the reason key instead of encoding null"
+    ok "probe-repo --json maps every outcome to a success envelope and its exit code"
+fi
 
 RESTIC_STATION_DATA_DIR="$HEALTHY" run_helper_split config validate --json
 [[ "$(jq -r '.data.nothingRunsHere' "$OUT_FILE")" == "false" ]] \

--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -789,9 +789,9 @@ JSON
 
     [[ $rc -eq 1 ]] || fail "$step" "expected status --json to exit 1 with an abandoned run, got $rc: $out"
     local health is_running abandoned
-    health="$(printf '%s' "$out" | jq -r '.health')"
-    is_running="$(printf '%s' "$out" | jq -r --arg id "$SET_ID" '.sets[] | select(.id == $id) | .isRunning')"
-    abandoned="$(printf '%s' "$out" | jq -r --arg id "$SET_ID" '.sets[] | select(.id == $id) | .abandonedRun.runId')"
+    health="$(printf '%s' "$out" | jq -r '.data | .health')"
+    is_running="$(printf '%s' "$out" | jq -r --arg id "$SET_ID" '.data | .sets[] | select(.id == $id) | .isRunning')"
+    abandoned="$(printf '%s' "$out" | jq -r --arg id "$SET_ID" '.data | .sets[] | select(.id == $id) | .abandonedRun.runId')"
     [[ "$health" == "warning" ]] || fail "$step" "expected health=warning, got '$health'"
     [[ "$is_running" == "false" ]] || fail "$step" "expected isRunning=false, got '$is_running'"
     [[ "$abandoned" == "20260101T000000Z-backup-deadbeef" ]] \
@@ -864,7 +864,7 @@ JSON
     set +e
     out="$("$HELPER" status --json 2>&1)"
     set -e
-    abandoned="$(printf '%s' "$out" | jq -r --arg id "$SET_ID" '.sets[] | select(.id == $id) | .abandonedRun.runId')"
+    abandoned="$(printf '%s' "$out" | jq -r --arg id "$SET_ID" '.data | .sets[] | select(.id == $id) | .abandonedRun.runId')"
     [[ "$abandoned" == "$run_id" ]] \
         || fail "$step" "precondition: expected the abandoned run to be named before the tick, got '$abandoned'"
 
@@ -879,7 +879,7 @@ JSON
     set +e
     out="$("$HELPER" status --json 2>&1)"
     set -e
-    abandoned="$(printf '%s' "$out" | jq -r --arg id "$SET_ID" '.sets[] | select(.id == $id) | .abandonedRun')"
+    abandoned="$(printf '%s' "$out" | jq -r --arg id "$SET_ID" '.data | .sets[] | select(.id == $id) | .abandonedRun')"
     [[ "$abandoned" == "null" ]] \
         || fail "$step" "expected no abandoned run after the tick, got '$abandoned': $out"
 
@@ -1170,43 +1170,43 @@ assert_fixture_flow() {
     # will not. Assert the answer is internally consistent in either state.
     if [[ "$OS_NAME" == "Linux" ]]; then
         [[ $status_rc -eq 1 ]] || fail "$step" "expected exit 1 with no timer installed, got $status_rc"
-        echo "$status_json" | jq -e '.scheduler.healthy == false' >/dev/null \
+        echo "$status_json" | jq -e '.data | .scheduler.healthy == false' >/dev/null \
             || fail "$step" "expected scheduler.healthy=false with no timer installed: $status_json"
-        echo "$status_json" | jq -e '.scheduler.problems | index("unitsMissing")' >/dev/null \
+        echo "$status_json" | jq -e '.data | .scheduler.problems | index("unitsMissing")' >/dev/null \
             || fail "$step" "expected scheduler.problems to name unitsMissing: $status_json"
     else
-        echo "$status_json" | jq -e '.scheduler.kind == "launchd-agent"' >/dev/null \
+        echo "$status_json" | jq -e '.data | .scheduler.kind == "launchd-agent"' >/dev/null \
             || fail "$step" "expected a launchd-agent scheduler probe on macOS: $status_json"
         local scheduler_health
-        scheduler_health="$(echo "$status_json" | jq -r '.scheduler.healthy')"
+        scheduler_health="$(echo "$status_json" | jq -r '.data | .scheduler.healthy')"
         case "$scheduler_health" in
             true)
                 [[ $status_rc -eq 0 ]] || fail "$step" "healthy LaunchAgent should exit 0, got $status_rc: $status_json"
                 ;;
             false)
                 [[ $status_rc -eq 1 ]] || fail "$step" "missing LaunchAgent should exit 1, got $status_rc: $status_json"
-                echo "$status_json" | jq -e '.scheduler.problems | index("agentNotLoaded")' >/dev/null \
+                echo "$status_json" | jq -e '.data | .scheduler.problems | index("agentNotLoaded")' >/dev/null \
                     || fail "$step" "missing LaunchAgent did not name agentNotLoaded: $status_json"
                 ;;
             null)
                 [[ $status_rc -eq 0 ]] || fail "$step" "unknown LaunchAgent state should not fail status: $status_json"
-                echo "$status_json" | jq -e '.scheduler.problems | index("launchctlProbeFailed")' >/dev/null \
+                echo "$status_json" | jq -e '.data | .scheduler.problems | index("launchctlProbeFailed")' >/dev/null \
                     || fail "$step" "unknown LaunchAgent state did not name launchctlProbeFailed: $status_json"
                 ;;
             *) fail "$step" "unexpected LaunchAgent health '$scheduler_health': $status_json" ;;
         esac
     fi
-    echo "$status_json" | jq -e '.sets | length == 1' >/dev/null \
+    echo "$status_json" | jq -e '.data | .sets | length == 1' >/dev/null \
         || fail "$step" "expected exactly one set in status --json (the disabled-here set must not appear): $status_json"
-    echo "$status_json" | jq -e '.sets[0].name == "Projects"' >/dev/null \
+    echo "$status_json" | jq -e '.data | .sets[0].name == "Projects"' >/dev/null \
         || fail "$step" "status --json did not report the \"Projects\" set: $status_json"
-    echo "$status_json" | jq -e '.sets[0].lastBackup.status == "success"' >/dev/null \
+    echo "$status_json" | jq -e '.data | .sets[0].lastBackup.status == "success"' >/dev/null \
         || fail "$step" "status --json did not reflect the successful backup: $status_json"
-    echo "$status_json" | jq -e '.excludedHere | length == 1' >/dev/null \
+    echo "$status_json" | jq -e '.data | .excludedHere | length == 1' >/dev/null \
         || fail "$step" "expected exactly one exclusion in status --json: $status_json"
-    echo "$status_json" | jq -e '.excludedHere[0].reason == "disabledForMachine"' >/dev/null \
+    echo "$status_json" | jq -e '.data | .excludedHere[0].reason == "disabledForMachine"' >/dev/null \
         || fail "$step" "status --json's exclusion reason was not disabledForMachine: $status_json"
-    echo "$status_json" | jq -e --arg id "$FIXTURE_DISABLED_SET_ID" '.excludedHere[0].id == $id' >/dev/null \
+    echo "$status_json" | jq -e --arg id "$FIXTURE_DISABLED_SET_ID" '.data | .excludedHere[0].id == $id' >/dev/null \
         || fail "$step" "status --json's exclusion named the wrong set (expected $FIXTURE_DISABLED_SET_ID): $status_json"
     log "$step OK"
 

--- a/scripts/linux-docs-transcript.sh
+++ b/scripts/linux-docs-transcript.sh
@@ -153,11 +153,11 @@ STATUS_JSON="$(restic-station-helper status --json)"
 echo "$STATUS_JSON" | jq . >/dev/null 2>&1
 
 run restic-station-helper runs list
-RUN_ID="$(restic-station-helper runs list --json | jq -r '[.[] | select(.kind=="backup")][0].runId')"
+RUN_ID="$(restic-station-helper runs list --json | jq -r '.data | [.[] | select(.kind=="backup")][0].runId')"
 printf '\n(runId captured for the next command: %s)\n' "$RUN_ID"
 run restic-station-helper runs show "$RUN_ID" --log
 
-SNAPSHOT_ID="$(restic-station-helper runs show "$RUN_ID" --json | jq -r '.snapshotId')"
+SNAPSHOT_ID="$(restic-station-helper runs show "$RUN_ID" --json | jq -r '.data.snapshotId')"
 
 # ===========================================================================
 section "Restore"
@@ -355,7 +355,7 @@ printf '%s' 'fire-check-password' \
 RESTIC_PASSWORD_COMMAND="$BIN_DIR/restic-station-helper print-password --dest $FIRE_PRIMARY_ID" \
     RESTIC_STATION_DATA_DIR="$FIRE_DATA" restic -r "$FIRE_REPO" init >/dev/null
 
-BEFORE=$(RESTIC_STATION_DATA_DIR="$FIRE_DATA" restic-station-helper runs list --json | jq 'length')
+BEFORE=$(RESTIC_STATION_DATA_DIR="$FIRE_DATA" restic-station-helper runs list --json | jq '.data | length')
 echo
 echo "runs recorded for \"Fire Check\" before installing its timer: $BEFORE (expect 0)"
 JOURNAL_START="$(date --iso-8601=seconds)"
@@ -378,7 +378,7 @@ ELAPSED=0
 while [[ $ELAPSED -lt $WAIT_SECONDS ]]; do
     sleep 10
     ELAPSED=$((ELAPSED + 10))
-    AFTER=$(RESTIC_STATION_DATA_DIR="$FIRE_DATA" restic-station-helper runs list --json | jq 'length' 2>/dev/null || echo "$BEFORE")
+    AFTER=$(RESTIC_STATION_DATA_DIR="$FIRE_DATA" restic-station-helper runs list --json | jq '.data | length' 2>/dev/null || echo "$BEFORE")
     SERVICE_STARTS=$(service_start_count)
     printf '  t=+%3ds  service starts=%s  backup runs=%s\n' "$ELAPSED" "$SERVICE_STARTS" "$AFTER"
     if [[ "$AFTER" -gt "$BEFORE" ]]; then
@@ -443,11 +443,11 @@ if [[ "$STATUS_RC" -ne 1 ]]; then
     echo "expected 1. This is the exact 'green while broken' failure issue #46 tracked."
     exit 1
 fi
-echo "$SCHED_JSON" | jq -e '.scheduler.healthy == false' >/dev/null || {
+echo "$SCHED_JSON" | jq -e '.data | .scheduler.healthy == false' >/dev/null || {
     echo "REGRESSION: status --json did not report the scheduler as unhealthy"
     exit 1
 }
-echo "$SCHED_JSON" | jq -e '.scheduler.problems | index("unitsMissing")' >/dev/null || {
+echo "$SCHED_JSON" | jq -e '.data | .scheduler.problems | index("unitsMissing")' >/dev/null || {
     echo "REGRESSION: status --json did not name unitsMissing as the reason"
     exit 1
 }
@@ -477,7 +477,7 @@ section "Monitoring: a killed run does not leave the host reporting healthy fore
 # run id points at a run directory that does not exist, which is the same
 # thing a killed run looks like once its metadata has been recovered.
 FIRE_SET_ID="$(RESTIC_STATION_DATA_DIR="$FIRE_DATA" restic-station-helper status --json \
-    | jq -r '.sets[0].id')"
+    | jq -r '.data.sets[0].id')"
 WRECKAGE="$FIRE_DATA/state/current-run-$FIRE_SET_ID.json"
 cat >"$WRECKAGE" <<JSON
 {
@@ -498,18 +498,18 @@ echo "--- a current-run file whose process is gone (updatedAt is *now*, so no ti
 echo "    heuristic would catch it) ---"
 WRECK_RC=0
 WRECK_JSON="$(RESTIC_STATION_DATA_DIR="$FIRE_DATA" restic-station-helper status --json)" || WRECK_RC=$?
-echo "$WRECK_JSON" | jq '{health, sets: [.sets[] | {name, isRunning, needsAttention, abandonedRun}]}'
+echo "$WRECK_JSON" | jq '.data | {health, sets: [.sets[] | {name, isRunning, needsAttention, abandonedRun}]}'
 echo "exit $WRECK_RC"
 echo
-echo "$WRECK_JSON" | jq -e '.health == "warning"' >/dev/null || {
-    echo "REGRESSION: an abandoned run left health as $(echo "$WRECK_JSON" | jq -r .health), not warning"
+echo "$WRECK_JSON" | jq -e '.data | .health == "warning"' >/dev/null || {
+    echo "REGRESSION: an abandoned run left health as $(echo "$WRECK_JSON" | jq -r '.data.health'), not warning"
     exit 1
 }
-echo "$WRECK_JSON" | jq -e '.sets[0].isRunning == false' >/dev/null || {
+echo "$WRECK_JSON" | jq -e '.data | .sets[0].isRunning == false' >/dev/null || {
     echo "REGRESSION: an abandoned run still reports isRunning"
     exit 1
 }
-echo "$WRECK_JSON" | jq -e '.sets[0].abandonedRun != null' >/dev/null || {
+echo "$WRECK_JSON" | jq -e '.data | .sets[0].abandonedRun != null' >/dev/null || {
     echo "REGRESSION: the abandoned run was discarded rather than reported"
     exit 1
 }


### PR DESCRIPTION
Closes #79.

> **Stacked on #93 (issue #81).** Base is `agent/cli-error-envelope`, not `main` — this builds directly on the error envelope. Merge #93 first, then this retargets to `main` as a plain rebase.

## What changes

Every `--json` command now emits one document with the same three top-level keys, so a caller reads `ok` once and knows which key holds the payload — without knowing which command it called.

```json
{ "schemaVersion": 1, "ok": true,  "data":  { … } }
{ "schemaVersion": 1, "ok": false, "error": { … } }
```

The wrapping lives in `CLIJSON.print`, the one path that owns stdout, so the five commands that already had `--json` wrapped without per-command edits and **no command can opt out by accident**. `config export` is the single deliberate exception — it emits the config document itself, unwrapped, so it round-trips into `config import`.

`--json` added to six more commands, for **eleven** total:

| | payload |
|---|---|
| `version` | `{ name, version, platform }` |
| `config validate` | `{ machineId, errors, warnings, effective, nothingRunsHere }` |
| `probe-repo` | `{ setId, destinationId, label, outcome, reachable, reason }` |
| `secret list` | `[{ destId, label, setName, hasPassword, secretEnvCount }]` |
| `cli status` | `CLIInstaller.Status` |
| `fda-check` | `{ applicable, granted, probedPath, checkedAt, context }` |

`docs/cli-json.md` carries the full matrix, including **every command that does not have `--json` and why**.

## ⚠️ Breaking change

`status --json` was the `StatusReport` object itself; `sets list --json` was a bare array. Both are now under `data`.

```console
# before                                   # after
… status --json | jq -r '.health'          … | jq -r '.data.health'
… sets list --json | jq 'length'           … | jq '.data | length'
```

Chosen over an additive shape deliberately, and it was your call on the trade: two conventions coexisting — some commands wrapped, some bare, arrays unable to carry a version key at all — would have been permanent, against one `.data` per caller while the tool is pre-1.0. Migration note is in `docs/cli-json.md` §Migrating from the unwrapped shape.

Every in-repo consumer is migrated: both shell suites, the transcript script, `ci.yml`, and three `docs/linux.md` transcripts. Deliberately **not** migrated: `jq` against `config.json`, `machine.json`, `state/fda-check.json`, and restic's own `--json` — those are files and other programs' output, and a blanket rewrite would have broken them.

## Decisions worth reviewing

**`probe-repo` reports offline as a success** — `outcome: "offline"`, `ok: true`, exit 3. An unplugged drive is a destination's expected state, not a fault; an error envelope would make a sleeping NAS indistinguishable from a broken config. Branch on `outcome`.

**`secret list` can have a JSON mode at all** because its row type carries *counts*, never values — the same redaction-by-shape rule `CLIErrorDetails` follows. Asserted structurally in the shell suite, not just by the end-of-run secret grep.

**`config validate` reports an unloadable config as the shared `config_invalid` error envelope**, not as a success document with a populated `errors` list, so a caller needs no per-command exception. Human mode keeps its own `Errors:` block byte-for-byte.

**`timer status` stays human-only**, with a documented reason rather than a shrug: its report is narrative assembled while probing, and its machine-readable equivalent already exists as `status --json`'s `.scheduler` — in the same problem vocabulary (`unitsMissing`, `agentNotLoaded`) that CI already asserts on.

## Verification

`swift test` (89), `swift test --package-path Core` (608), and `./scripts/local-ci.sh` — all 8 stages PASS.

New `headless-cli-test.sh` §9 runs **all eleven** commands against a real binary and asserts stdout is exactly one envelope with `data,ok,schemaVersion` **and no other top-level key** — a command that escaped `CLIJSON` shows up there. The Swift suite pins the same eleven through `JSONRenderable`, so a new `--json` command that forgets the conformance fails as a missing entry rather than as silent prose on stdout.

Two things testing turned up that reasoning had not:

- **The new payloads omitted nil fields.** Swift's synthesized encoder uses `encodeIfPresent`, but every existing `--json` shape emits explicit `null` and `data-model.md` states that as a convention. `probe-repo`, `fda-check` and `cli status` now have hand-written encoders — a missing key and a null one must not become two ways of saying the same thing.
- **My first `probe-repo` assertion pinned `"offline"`**, which was really asserting that the fixture's repository path did not exist. It now pins the whole mapping instead: every outcome is a success envelope, and each implies its exit code.

The three `docs/linux.md` transcripts were rewritten by hand and then re-parsed to prove each is a valid envelope with exactly those three keys — CI produces those blocks but never diffs them against the doc, the same gap that took #92 red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VVUQTf9Xcm49R4PUMcL8nL
