### PR TITLE
Purging exclusions 2/5: read-only purge preview

### DIFF
--- a/Core/Sources/ResticStationCore/Engine/BackupEngine.swift
+++ b/Core/Sources/ResticStationCore/Engine/BackupEngine.swift
@@ -136,6 +136,11 @@ public final class BackupEngine: Sendable {
     private let reachability: Reachability
     private let now: @Sendable () -> Date
     private let uptime: @Sendable () -> TimeInterval
+    /// Raw shared-config source/hostname knowledge used by purge attribution.
+    /// Resolved configs deliberately strip machine overrides, so the helper
+    /// supplies these unions when it constructs the engine.
+    private let purgeSourcePaths: [UUID: Set<String>]
+    private let purgeHostnames: [UUID: Set<String>]
 
     public init(
         config: AppConfig,
@@ -146,7 +151,9 @@ public final class BackupEngine: Sendable {
         stateStore: StateStore,
         reachability: Reachability,
         now: @escaping @Sendable () -> Date = Date.init,
-        uptime: @escaping @Sendable () -> TimeInterval = { ProcessInfo.processInfo.systemUptime }
+        uptime: @escaping @Sendable () -> TimeInterval = { ProcessInfo.processInfo.systemUptime },
+        purgeSourcePaths: [UUID: Set<String>] = [:],
+        purgeHostnames: [UUID: Set<String>] = [:]
     ) {
         self.config = config
         self.paths = paths
@@ -157,6 +164,8 @@ public final class BackupEngine: Sendable {
         self.reachability = reachability
         self.now = now
         self.uptime = uptime
+        self.purgeSourcePaths = purgeSourcePaths
+        self.purgeHostnames = purgeHostnames
     }
 
     // MARK: - runSet
@@ -511,6 +520,126 @@ public final class BackupEngine: Sendable {
         }
 
         return Self.worstStatus(statuses)
+    }
+
+    // MARK: - purge preview
+
+    /// Builds a read-only purge plan for one destination.
+    ///
+    /// The set lock prevents a preview from racing a backup or another
+    /// repository operation.  The only restic commands are reachability's
+    /// `cat config` where needed, `snapshots --json`, and `rewrite --dry-run`.
+    /// In particular, this method cannot reach `rewrite --forget`, `prune`, or
+    /// the run-record machinery.
+    public func previewPurge(set: BackupSet, destination: Destination) async -> PurgePlanResult {
+        let emptyPlan = PurgePlan(
+            destinationId: destination.id,
+            snapshots: [],
+            sourcePaths: sourcePaths(for: set),
+            hostnames: hostnames(for: set),
+            patterns: set.purgeExcludes
+        )
+
+        guard !set.purgeExcludes.isEmpty else {
+            return PurgePlanResult(
+                plan: emptyPlan,
+                status: .empty,
+                message: "nothing to purge: purgeExcludes is empty"
+            )
+        }
+
+        let lock = makeSetLock(setId: set.id)
+        guard lock.tryAcquire() else {
+            return PurgePlanResult(plan: emptyPlan, status: .busy, message: "another operation is running")
+        }
+        defer { lock.release() }
+
+        guard await secretsAvailable(for: [destination]) else {
+            return PurgePlanResult(plan: emptyPlan, status: .failed, message: "secret store unavailable")
+        }
+
+        let probe = await reachability.probe(destination)
+        switch probe {
+        case .reachable:
+            break
+        case .offline(let reason):
+            return PurgePlanResult(
+                plan: emptyPlan,
+                status: .offline,
+                message: reason
+            )
+        case .error(let exitClass):
+            return PurgePlanResult(
+                plan: emptyPlan,
+                status: .failed,
+                message: exitClass.userFacingMessage
+            )
+        }
+
+        let snapshotsOutcome: ResticOutcome
+        do {
+            snapshotsOutcome = try await restic.run(
+                .snapshots(repo: destination.repoURL),
+                for: ResticInvocation(destination: destination)
+            )
+        } catch {
+            return PurgePlanResult(plan: emptyPlan, status: .failed, message: "could not list snapshots: \(error)")
+        }
+        guard snapshotsOutcome.status == .success else {
+            return PurgePlanResult(
+                plan: emptyPlan,
+                status: .failed,
+                message: snapshotsOutcome.status.userFacingMessage
+            )
+        }
+
+        let snapshots: [Snapshot]
+        do {
+            snapshots = try parseSnapshots(Data(snapshotsOutcome.rawOutput.utf8))
+        } catch {
+            return PurgePlanResult(plan: emptyPlan, status: .failed, message: "could not parse snapshots: \(error)")
+        }
+
+        let plan = PurgePlan(
+            destinationId: destination.id,
+            snapshots: snapshots,
+            sourcePaths: sourcePaths(for: set),
+            hostnames: hostnames(for: set),
+            patterns: set.purgeExcludes
+        )
+        guard !plan.matched.isEmpty else {
+            return PurgePlanResult(
+                plan: plan,
+                status: .ready,
+                message: "no snapshots are attributed to this backup set"
+            )
+        }
+
+        let rewriteOutcome: ResticOutcome
+        do {
+            rewriteOutcome = try await restic.run(
+                .rewrite(
+                    repo: destination.repoURL,
+                    snapshotIDs: plan.matched.map(\.id),
+                    excludes: plan.patterns,
+                    dryRun: true
+                ),
+                for: ResticInvocation(destination: destination)
+            )
+        } catch {
+            return PurgePlanResult(plan: plan, status: .failed, message: "could not preview rewrite: \(error)")
+        }
+        guard rewriteOutcome.status == .success else {
+            return PurgePlanResult(
+                plan: plan,
+                status: .failed,
+                message: rewriteOutcome.status.userFacingMessage
+            )
+        }
+
+        let rewrite = parseRewrite(rewriteOutcome.rawOutput)
+        let changed = plan.matched.filter { rewrite.changedShortIDs.contains($0.shortId) }
+        return PurgePlanResult(plan: plan, changed: changed, rewrite: rewrite, status: .ready)
     }
 
     // MARK: - runRestore
@@ -1009,6 +1138,31 @@ public final class BackupEngine: Sendable {
         case .error(let exitClass):
             return exitClass.userFacingMessage
         }
+    }
+
+    private func sourcePaths(for set: BackupSet) -> Set<String> {
+        if let known = purgeSourcePaths[set.id] {
+            return known
+        }
+        var paths = Set(set.sources)
+        if let machines = set.machines {
+            for override in machines.values {
+                paths.formUnion(override.sources ?? [])
+            }
+        }
+        return paths
+    }
+
+    private func hostnames(for set: BackupSet) -> Set<String> {
+        if let known = purgeHostnames[set.id], !known.isEmpty {
+            return known
+        }
+        var names = Set<String>()
+        if let machines = set.machines {
+            names.formUnion(machines.keys)
+        }
+        names.insert(MachineIdentity.generate())
+        return names
     }
 
     /// How the engine names the secret store in its user-visible log lines

--- a/Core/Sources/ResticStationCore/Engine/PurgePlan.swift
+++ b/Core/Sources/ResticStationCore/Engine/PurgePlan.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+/// The read-only decision about which snapshots a purge may address.
+///
+/// This type deliberately has no filesystem or restic dependency.  It is the
+/// boundary between an untrusted repository-wide snapshot list and the ids a
+/// future destructive operation may be allowed to use.
+public struct PurgePlan: Equatable, Sendable {
+    public let destinationId: UUID
+    public let matched: [Snapshot]
+    public let unattributed: [Snapshot]
+    public let patterns: [String]
+
+    public init(
+        destinationId: UUID,
+        snapshots: [Snapshot],
+        sourcePaths: Set<String>,
+        hostnames: Set<String>,
+        patterns: [String]
+    ) {
+        self.destinationId = destinationId
+        self.patterns = patterns
+
+        let attributed = snapshots.filter { snapshot in
+            let pathsMatch = Set(snapshot.paths).isSubset(of: sourcePaths)
+            let hostnameMatches = hostnames.contains(snapshot.hostname)
+                || hostnames.contains(where: {
+                    MachineIdentity.slugify($0) == MachineIdentity.slugify(snapshot.hostname)
+                })
+            return pathsMatch && hostnameMatches
+        }
+        let matchedIDs = Set(attributed.map(\.id))
+        self.matched = attributed
+        self.unattributed = snapshots.filter { !matchedIDs.contains($0.id) }
+    }
+
+    /// Convenience for pure callers that have a raw, shared `BackupSet`.
+    /// The source union includes every machine override, even though each
+    /// override replaces (rather than merges) the source list for that one
+    /// machine.
+    public init(
+        destinationId: UUID,
+        snapshots: [Snapshot],
+        set: BackupSet,
+        hostnames: Set<String> = []
+    ) {
+        var sourcePaths = Set(set.sources)
+        if let machines = set.machines {
+            for override in machines.values {
+                sourcePaths.formUnion(override.sources ?? [])
+            }
+        }
+        self.init(
+            destinationId: destinationId,
+            snapshots: snapshots,
+            sourcePaths: sourcePaths,
+            hostnames: hostnames,
+            patterns: set.purgeExcludes
+        )
+    }
+}
+
+/// The result of a non-destructive purge preview.  No run record is created:
+/// this is a query, not an operation, and its exact argv sequence is asserted
+/// by the engine tests.
+public struct PurgePlanResult: Equatable, Sendable {
+    public enum Status: String, Equatable, Sendable {
+        case empty
+        case ready
+        case busy
+        case offline
+        case failed
+    }
+
+    public let plan: PurgePlan
+    public let changed: [Snapshot]
+    public let rewrite: RewriteResult?
+    public let status: Status
+    public let message: String?
+
+    public init(
+        plan: PurgePlan,
+        changed: [Snapshot] = [],
+        rewrite: RewriteResult? = nil,
+        status: Status,
+        message: String? = nil
+    ) {
+        self.plan = plan
+        self.changed = changed
+        self.rewrite = rewrite
+        self.status = status
+        self.message = message
+    }
+}

--- a/Core/Sources/ResticStationCore/Restic/Parsers/RewriteResult.swift
+++ b/Core/Sources/ResticStationCore/Restic/Parsers/RewriteResult.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// One snapshot mentioned by `restic rewrite`.
+public struct RewriteSnapshot: Equatable, Sendable {
+    public let shortID: String
+    public let newSnapshotShortID: String?
+
+    public init(shortID: String, newSnapshotShortID: String? = nil) {
+        self.shortID = shortID
+        self.newSnapshotShortID = newSnapshotShortID
+    }
+}
+
+/// The useful, stable facts in the human output of `restic rewrite`.
+///
+/// `rewrite` has no JSON mode.  Keep the parser deliberately narrow: the
+/// snapshot header and save/modify phrases are the parts needed to connect a
+/// dry-run back to the already parsed snapshot list.  Unknown lines remain
+/// available through `rawOutput` and never make parsing fail.
+public struct RewriteResult: Equatable, Sendable {
+    public let snapshots: [RewriteSnapshot]
+    public let modifiedCount: Int?
+    public let rawOutput: String
+
+    public init(snapshots: [RewriteSnapshot], modifiedCount: Int?, rawOutput: String) {
+        self.snapshots = snapshots
+        self.modifiedCount = modifiedCount
+        self.rawOutput = rawOutput
+    }
+
+    public var changedShortIDs: Set<String> {
+        Set(snapshots.map(\.shortID))
+    }
+}
+
+/// Parses output captured from a real restic `rewrite` invocation.
+public func parseRewrite(_ output: String) -> RewriteResult {
+    let lines = output.components(separatedBy: .newlines)
+    var snapshots: [RewriteSnapshot] = []
+    var currentShortID: String?
+    var modifiedCount: Int?
+
+    let header = try? NSRegularExpression(pattern: #"^snapshot ([0-9a-f]+) of \["#)
+    let saved = try? NSRegularExpression(pattern: #"^saved new snapshot ([0-9a-f]+)$"#)
+    let modified = try? NSRegularExpression(pattern: #"^(?:would modify|modified) ([0-9]+) snapshots$"#)
+
+    for line in lines {
+        let range = NSRange(line.startIndex..<line.endIndex, in: line)
+        if let match = header?.firstMatch(in: line, range: range), match.numberOfRanges > 1,
+           let idRange = Range(match.range(at: 1), in: line) {
+            currentShortID = String(line[idRange])
+            continue
+        }
+
+        if line == "would save new snapshot", let currentShortID {
+            snapshots.append(RewriteSnapshot(shortID: currentShortID))
+            continue
+        }
+
+        if let match = saved?.firstMatch(in: line, range: range), match.numberOfRanges > 1,
+           let idRange = Range(match.range(at: 1), in: line), let currentShortID {
+            snapshots.append(RewriteSnapshot(
+                shortID: currentShortID,
+                newSnapshotShortID: String(line[idRange])
+            ))
+            continue
+        }
+
+        if let match = modified?.firstMatch(in: line, range: range), match.numberOfRanges > 1,
+           let countRange = Range(match.range(at: 1), in: line) {
+            modifiedCount = Int(line[countRange])
+        }
+    }
+
+    return RewriteResult(snapshots: snapshots, modifiedCount: modifiedCount, rawOutput: output)
+}

--- a/Core/Sources/ResticStationCore/Restic/ResticCommand.swift
+++ b/Core/Sources/ResticStationCore/Restic/ResticCommand.swift
@@ -115,6 +115,38 @@ public struct ResticCommand: Equatable, Sendable {
         ResticCommand(argv: ["-r", repo, "snapshots", "--json"], repoURL: repo)
     }
 
+    /// `restic -r <repo> rewrite [--forget] [--dry-run] [--exclude <pat>]... <snapshotID>...`
+    ///
+    /// Snapshot ids are deliberately required.  Without them restic rewrites
+    /// every snapshot in the repository, which is never safe for a repository
+    /// shared by more than one backup set.
+    public static func rewrite(
+        repo: String,
+        snapshotIDs: [String],
+        excludes: [String],
+        forget: Bool = false,
+        dryRun: Bool = false
+    ) -> ResticCommand {
+        precondition(!snapshotIDs.isEmpty, "ResticCommand.rewrite requires at least one snapshot ID")
+        precondition(!excludes.isEmpty, "ResticCommand.rewrite requires at least one exclude pattern")
+        var argv = ["-r", repo, "rewrite"]
+        if forget { argv.append("--forget") }
+        if dryRun { argv.append("--dry-run") }
+        for exclude in excludes {
+            argv.append("--exclude")
+            argv.append(exclude)
+        }
+        argv.append(contentsOf: snapshotIDs)
+        return ResticCommand(argv: argv, repoURL: repo)
+    }
+
+    /// `restic -r <repo> prune [--dry-run]`
+    public static func prune(repo: String, dryRun: Bool = false) -> ResticCommand {
+        var argv = ["-r", repo, "prune"]
+        if dryRun { argv.append("--dry-run") }
+        return ResticCommand(argv: argv, repoURL: repo)
+    }
+
     /// `restic -r <repo> ls --json <snapshotID> [<dir>]`
     ///
     /// `path` is an **in-snapshot** path (restic-cli.md §ls). Omitting it

--- a/Core/Tests/ResticStationCoreTests/Engine/BackupEngineTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Engine/BackupEngineTests.swift
@@ -135,7 +135,9 @@ struct BackupEngineTests {
         primaryReachable: Bool = true,
         reachableSecondaries: [Bool] = [true, true],
         startingAt: Date = t0,
-        onSpawn: (@Sendable ([String]) -> Void)? = nil
+        onSpawn: (@Sendable ([String]) -> Void)? = nil,
+        purgeSourcePaths: [UUID: Set<String>] = [:],
+        purgeHostnames: [UUID: Set<String>] = [:]
     ) -> Env {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("restic-station-engine-\(UUID().uuidString)", isDirectory: true)
@@ -206,7 +208,9 @@ struct BackupEngineTests {
             runStore: runStore,
             stateStore: stateStore,
             reachability: Reachability(restic: restic),
-            now: clock.now
+            now: clock.now,
+            purgeSourcePaths: purgeSourcePaths,
+            purgeHostnames: purgeHostnames
         )
 
         return Env(
@@ -1231,6 +1235,66 @@ struct BackupEngineTests {
         #expect(status == .skipped)
         #expect(env.fake.invocations.isEmpty, "nothing spawned — the guard is the first thing checked")
         #expect(env.indexEntries.isEmpty)
+    }
+
+    // MARK: - purge preview
+
+    @Test("previewPurge: snapshots then rewrite dry-run only, with explicit attributed ids")
+    func purgePreviewIsReadOnly() async throws {
+        let sourcePaths = [Self.setId: Set(["/Users/user/example/src"])]
+        let hostnames = [Self.setId: Set(["example-mac.local"])]
+        let env = Self.makeEnv(
+            script: [],
+            retention: nil,
+            purgeExcludes: ["build/**"],
+            reachableSecondaries: [],
+            purgeSourcePaths: sourcePaths,
+            purgeHostnames: hostnames
+        )
+        defer { env.cleanUp() }
+
+        let snapshotsJSON = try FixtureLoader.string("snapshots.json")
+        let snapshots = try parseSnapshots(Data(snapshotsJSON.utf8))
+        let snapshotIDs = snapshots.map(\.id)
+        let dryRunText = try FixtureLoader.string("rewrite-dry-run.txt")
+            .replacingOccurrences(of: "09b3295c", with: snapshots[0].shortId)
+            .replacingOccurrences(of: "b2435423", with: snapshots[1].shortId)
+        let dryRun = dryRunText
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map(String.init)
+        env.fake.script = Self.resticCall(
+            ["-r", env.primary.repoURL, "snapshots", "--json"],
+            dest: Self.primaryId,
+            stdoutLines: [snapshotsJSON]
+        ) + Self.resticCall(
+            ["-r", env.primary.repoURL, "rewrite", "--dry-run", "--exclude", "build/**"] + snapshotIDs,
+            dest: Self.primaryId,
+            stdoutLines: dryRun
+        )
+
+        let result = await env.engine.previewPurge(set: env.set, destination: env.primary)
+
+        #expect(result.status == .ready)
+        #expect(result.plan.matched.map(\.id) == snapshotIDs)
+        #expect(result.changed.map(\.id) == snapshotIDs)
+        #expect(env.resticArgvs == [
+            [Self.resticPath, "-r", env.primary.repoURL, "snapshots", "--json"],
+            [Self.resticPath, "-r", env.primary.repoURL, "rewrite", "--dry-run", "--exclude", "build/**"] + snapshotIDs,
+        ])
+        #expect(env.fake.invocations.allSatisfy { !$0.argv.contains("--forget") })
+        #expect(env.indexEntries.isEmpty, "a read-only preview creates no run record")
+    }
+
+    @Test("previewPurge with no patterns is empty and spawns nothing")
+    func purgePreviewEmpty() async throws {
+        let env = Self.makeEnv(script: [], retention: nil, purgeExcludes: [], reachableSecondaries: [])
+        defer { env.cleanUp() }
+
+        let result = await env.engine.previewPurge(set: env.set, destination: env.primary)
+
+        #expect(result.status == .empty)
+        #expect(result.plan.matched.isEmpty)
+        #expect(env.fake.invocations.isEmpty)
     }
 
     // MARK: - runRestore

--- a/Core/Tests/ResticStationCoreTests/Fixtures/rewrite-dry-run.txt
+++ b/Core/Tests/ResticStationCoreTests/Fixtures/rewrite-dry-run.txt
@@ -1,0 +1,8 @@
+
+snapshot 09b3295c of [/tmp/restic-station-purge-fixture.tyOGmf/source] at 2026-08-19 23:32:12.238741 -0700 PDT by bwh@Bens-Laptop
+would save new snapshot
+
+snapshot b2435423 of [/tmp/restic-station-purge-fixture.tyOGmf/source] at 2026-08-19 23:32:14.083168 -0700 PDT by bwh@Bens-Laptop
+would save new snapshot
+
+would modify 2 snapshots

--- a/Core/Tests/ResticStationCoreTests/Fixtures/rewrite-forget.txt
+++ b/Core/Tests/ResticStationCoreTests/Fixtures/rewrite-forget.txt
@@ -1,0 +1,11 @@
+create exclusive lock for repository
+
+snapshot 09b3295c of [/tmp/restic-station-purge-fixture.tyOGmf/source] at 2026-08-19 23:32:12.238741 -0700 PDT by bwh@Bens-Laptop
+saved new snapshot 14a53542
+removed old snapshot 09b3295c
+
+snapshot b2435423 of [/tmp/restic-station-purge-fixture.tyOGmf/source] at 2026-08-19 23:32:14.083168 -0700 PDT by bwh@Bens-Laptop
+saved new snapshot 3ca2e0a5
+removed old snapshot b2435423
+
+modified 2 snapshots

--- a/Core/Tests/ResticStationCoreTests/PurgePlanTests.swift
+++ b/Core/Tests/ResticStationCoreTests/PurgePlanTests.swift
@@ -1,0 +1,89 @@
+import Foundation
+import Testing
+@testable import ResticStationCore
+
+@Suite("PurgePlan snapshot attribution")
+struct PurgePlanTests {
+    private static let destinationId = UUID(uuidString: "0A1B2C3D-8B86-D011-B42D-00C04FC964FF")!
+    private static let setId = UUID(uuidString: "6F9619FF-8B86-D011-B42D-00C04FC964FF")!
+
+    private func snapshot(id: String, paths: [String], hostname: String) -> Snapshot {
+        let json = """
+        {
+          "id": "\(id)", "short_id": "\(id.prefix(8))",
+          "time": "2026-08-19T23:32:12Z", "paths": \(json(paths)),
+          "hostname": "\(hostname)", "username": "bwh"
+        }
+        """
+        return try! makeResticJSONDecoder().decode(Snapshot.self, from: Data(json.utf8))
+    }
+
+    private func json(_ values: [String]) -> String {
+        let data = try! JSONSerialization.data(withJSONObject: values)
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    @Test("requires both source-subset and known-hostname attribution")
+    func attribution() {
+        let good = snapshot(id: "aaaaaaaaaaaaaaaa", paths: ["/Users/bwh/Projects"], hostname: "studio-mac")
+        let otherHost = snapshot(id: "bbbbbbbbbbbbbbbb", paths: ["/Users/bwh/Projects"], hostname: "linux-nas")
+        let otherPath = snapshot(id: "cccccccccccccccc", paths: ["/Users/bwh/Secrets"], hostname: "studio-mac")
+
+        let plan = PurgePlan(
+            destinationId: Self.destinationId,
+            snapshots: [good, otherHost, otherPath],
+            sourcePaths: ["/Users/bwh/Projects"],
+            hostnames: ["studio-mac"],
+            patterns: ["build/**"]
+        )
+
+        #expect(plan.matched.map(\.id) == [good.id])
+        #expect(plan.unattributed.map(\.id) == [otherHost.id, otherPath.id])
+        #expect(plan.patterns == ["build/**"])
+    }
+
+    @Test("raw set source union includes every machine override")
+    func sourceUnion() {
+        let set = BackupSet(
+            id: Self.setId,
+            name: "Projects",
+            sources: ["/shared"],
+            schedule: .daily(hour: 2, minute: 30),
+            destinations: [],
+            machines: [
+                "studio-mac": BackupSetMachineOverride(sources: ["/Users/bwh/Projects"]),
+                "linux-nas": BackupSetMachineOverride(sources: ["/srv/projects"]),
+            ]
+        )
+        let snapshots = [
+            snapshot(id: "aaaaaaaaaaaaaaaa", paths: ["/Users/bwh/Projects"], hostname: "studio-mac"),
+            snapshot(id: "bbbbbbbbbbbbbbbb", paths: ["/srv/projects"], hostname: "linux-nas"),
+        ]
+        let plan = PurgePlan(
+            destinationId: Self.destinationId,
+            snapshots: snapshots,
+            set: set,
+            hostnames: ["studio-mac", "linux-nas"]
+        )
+        #expect(plan.matched.count == 2)
+    }
+
+    @Test("missing hostname history declines otherwise matching paths")
+    func requiresHostnameHistory() {
+        let snapshot = snapshot(
+            id: "aaaaaaaaaaaaaaaa",
+            paths: ["/Users/bwh/Projects"],
+            hostname: "studio-mac"
+        )
+        let plan = PurgePlan(
+            destinationId: Self.destinationId,
+            snapshots: [snapshot],
+            sourcePaths: ["/Users/bwh/Projects"],
+            hostnames: [],
+            patterns: ["build/**"]
+        )
+
+        #expect(plan.matched.isEmpty)
+        #expect(plan.unattributed.map(\.id) == [snapshot.id])
+    }
+}

--- a/Core/Tests/ResticStationCoreTests/Restic/ResticCommandTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Restic/ResticCommandTests.swift
@@ -76,6 +76,44 @@ struct ResticCommandTests {
         #expect(cmd.argv == ["-r", Self.repo, "snapshots", "--json"])
     }
 
+    @Test("rewrite dry-run: forget/dry-run before repeated excludes and explicit ids")
+    func rewriteDryRun() {
+        // restic -r <repo> rewrite [--forget] [--dry-run] [--exclude <pat>]... <id>...
+        let cmd = ResticCommand.rewrite(
+            repo: Self.repo,
+            snapshotIDs: ["09b3295c", "b2435423"],
+            excludes: ["build/**"],
+            dryRun: true
+        )
+        #expect(cmd.argv == [
+            "-r", Self.repo, "rewrite", "--dry-run", "--exclude", "build/**",
+            "09b3295c", "b2435423",
+        ])
+        #expect(cmd.repoURL == Self.repo)
+    }
+
+    @Test("rewrite apply: explicit forget flag is before dry-run and excludes")
+    func rewriteForget() {
+        let cmd = ResticCommand.rewrite(
+            repo: Self.repo,
+            snapshotIDs: ["09b3295c"],
+            excludes: ["build/**", "*.tmp"],
+            forget: true
+        )
+        #expect(cmd.argv == [
+            "-r", Self.repo, "rewrite", "--forget",
+            "--exclude", "build/**", "--exclude", "*.tmp", "09b3295c",
+        ])
+    }
+
+    @Test("standalone prune")
+    func prune() {
+        // restic -r <repo> prune [--dry-run]
+        #expect(ResticCommand.prune(repo: Self.repo, dryRun: true).argv == [
+            "-r", Self.repo, "prune", "--dry-run",
+        ])
+    }
+
     @Test("ls with a directory argument")
     func lsWithPath() {
         // restic -r <repo> ls --json <snapshotID> <dir>

--- a/Core/Tests/ResticStationCoreTests/RewriteResultTests.swift
+++ b/Core/Tests/ResticStationCoreTests/RewriteResultTests.swift
@@ -1,0 +1,24 @@
+import Foundation
+import Testing
+@testable import ResticStationCore
+
+@Suite("rewrite human-output fixtures")
+struct RewriteResultTests {
+    @Test("dry-run fixture identifies every snapshot that would change")
+    func dryRun() throws {
+        let result = parseRewrite(try FixtureLoader.string("rewrite-dry-run.txt"))
+        #expect(result.changedShortIDs == ["09b3295c", "b2435423"])
+        #expect(result.modifiedCount == 2)
+        #expect(result.snapshots.allSatisfy { $0.newSnapshotShortID == nil })
+    }
+
+    @Test("forget fixture preserves old-to-new snapshot mapping")
+    func forgetOutput() throws {
+        let result = parseRewrite(try FixtureLoader.string("rewrite-forget.txt"))
+        #expect(result.snapshots == [
+            RewriteSnapshot(shortID: "09b3295c", newSnapshotShortID: "14a53542"),
+            RewriteSnapshot(shortID: "b2435423", newSnapshotShortID: "3ca2e0a5"),
+        ])
+        #expect(result.modifiedCount == 2)
+    }
+}

--- a/Helper/Sources/Commands/Purge.swift
+++ b/Helper/Sources/Commands/Purge.swift
@@ -1,0 +1,176 @@
+import ArgumentParser
+import Foundation
+import ResticStationCore
+
+/// `purge preview` is intentionally the only purge surface in #87.  Apply is
+/// introduced later, behind a preview token, in #88.
+struct Purge: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "purge",
+        abstract: "Inspect snapshots that purge exclusions would rewrite.",
+        subcommands: [PurgePreview.self]
+    )
+}
+
+struct PurgePreview: AsyncParsableCommand, JSONRenderable {
+    static let configuration = CommandConfiguration(
+        commandName: "preview",
+        abstract: "Preview purge exclusions without modifying a repository."
+    )
+
+    @Option(name: .long, help: "The backup set's UUID.")
+    var set: UUID
+
+    @Option(name: .long, help: "Preview only this destination UUID.")
+    var dest: UUID?
+
+    @Flag(name: .long, help: "Emit JSON. Only JSON reaches stdout in this mode.")
+    var json = false
+
+    private struct SnapshotReport: Encodable {
+        let id: String
+        let shortId: String
+        let time: Date
+        let paths: [String]
+        let hostname: String
+
+        init(_ snapshot: Snapshot) {
+            id = snapshot.id
+            shortId = snapshot.shortId
+            time = snapshot.time
+            paths = snapshot.paths
+            hostname = snapshot.hostname
+        }
+    }
+
+    private struct Report: Encodable {
+        let setId: UUID
+        let destinationId: UUID
+        let label: String
+        let status: PurgePlanResult.Status
+        let patterns: [String]
+        let matched: [SnapshotReport]
+        let changed: [SnapshotReport]
+        let unattributed: [SnapshotReport]
+        let rewriteOutput: String?
+        let message: String?
+
+        private enum CodingKeys: String, CodingKey {
+            case setId, destinationId, label, status, patterns, matched, changed
+            case unattributed, rewriteOutput, message
+        }
+
+        init(setId: UUID, destination: Destination, result: PurgePlanResult) {
+            self.setId = setId
+            self.destinationId = destination.id
+            self.label = destination.label
+            self.status = result.status
+            self.patterns = result.plan.patterns
+            self.matched = result.plan.matched.map(SnapshotReport.init)
+            self.changed = result.changed.map(SnapshotReport.init)
+            self.unattributed = result.plan.unattributed.map(SnapshotReport.init)
+            self.rewriteOutput = result.rewrite?.rawOutput
+            self.message = result.message
+        }
+
+        // The optional fields are part of a reported payload, so they are
+        // explicit null rather than synthesized-encoder omissions.
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(setId, forKey: .setId)
+            try container.encode(destinationId, forKey: .destinationId)
+            try container.encode(label, forKey: .label)
+            try container.encode(status.rawValue, forKey: .status)
+            try container.encode(patterns, forKey: .patterns)
+            try container.encode(matched, forKey: .matched)
+            try container.encode(changed, forKey: .changed)
+            try container.encode(unattributed, forKey: .unattributed)
+            try container.encode(rewriteOutput, forKey: .rewriteOutput)
+            try container.encode(message, forKey: .message)
+        }
+    }
+
+    func run() async throws {
+        let context = try await HelperContext.make()
+        guard let backupSet = context.addressable.set(id: set) else {
+            throw CLIFailure.setNotFound(setId: set)
+        }
+
+        let destinations: [Destination]
+        if let dest {
+            guard let destination = backupSet.destinations.first(where: { $0.id == dest }) else {
+                throw CLIFailure.destinationNotFound(setId: set, destinationId: dest)
+            }
+            destinations = [destination]
+        } else {
+            destinations = backupSet.destinations
+        }
+
+        var reports: [Report] = []
+        for destination in destinations {
+            let result = await context.engine.previewPurge(set: backupSet, destination: destination)
+            try Self.validate(result: result, setId: set, destination: destination)
+            reports.append(Report(setId: set, destination: destination, result: result))
+        }
+
+        if json {
+            CLIJSON.print(reports)
+        } else {
+            for report in reports {
+                Self.printHuman(report)
+            }
+        }
+        HelperExit.code(0)
+    }
+
+    private static func validate(
+        result: PurgePlanResult,
+        setId: UUID,
+        destination: Destination
+    ) throws {
+        switch result.status {
+        case .empty, .ready:
+            return
+        case .busy:
+            throw CLIFailure.setBusy(setId: setId)
+        case .offline:
+            throw CLIFailure(
+                code: .repositoryOffline,
+                message: CLIFailure.bounded("Destination \(destination.label) is offline: \(result.message ?? "try again later")"),
+                details: CLIErrorDetails(setId: setId, destinationId: destination.id)
+            )
+        case .failed:
+            throw CLIFailure(
+                code: .resticFailed,
+                message: CLIFailure.bounded(result.message ?? "Purge preview failed."),
+                details: CLIErrorDetails(setId: setId, destinationId: destination.id)
+            )
+        }
+    }
+
+    private static func printHuman(_ report: Report) {
+        switch report.status {
+        case .empty:
+            print("\"\(report.label)\": nothing to do — purgeExcludes is empty")
+        case .ready:
+            if report.changed.isEmpty {
+                print("\"\(report.label)\": no matching snapshots would change")
+            } else {
+                print("\"\(report.label)\": \(report.changed.count) snapshot(s) would be rewritten")
+                for snapshot in report.changed {
+                    print("  \(snapshot.shortId) — \(snapshot.paths.joined(separator: ", "))")
+                }
+            }
+            if !report.unattributed.isEmpty {
+                print("  declined to attribute \(report.unattributed.count) snapshot(s):")
+                for snapshot in report.unattributed {
+                    print("    \(snapshot.shortId) [\(snapshot.hostname)] — \(snapshot.paths.joined(separator: ", "))")
+                }
+            }
+            print("  space is not reclaimed until a prune runs")
+        case .busy, .offline, .failed:
+            // These states are rejected before a report is printed.
+            break
+        }
+    }
+}

--- a/Helper/Sources/HelperContext.swift
+++ b/Helper/Sources/HelperContext.swift
@@ -63,6 +63,10 @@ struct HelperContext {
     /// The two per-machine views of `config.json`, resolved once. The single
     /// place resolution happens on the helper side.
     struct Views {
+        /// The shared, unresolved config is retained only for purge
+        /// attribution.  The engine still receives the addressable resolved
+        /// config for all repository lookups.
+        let shared: AppConfig
         let scheduled: ResolvedConfig
         let addressable: ResolvedConfig
     }
@@ -78,6 +82,7 @@ struct HelperContext {
         let config = try configStore.load()
         let machine = try MachineStore(paths: paths).load()
         return Views(
+            shared: config,
             scheduled: config.resolved(for: machine),
             addressable: config.addressable(for: machine)
         )
@@ -156,6 +161,24 @@ struct HelperContext {
         // serialized correctly, so the engine needs the superset. What the
         // engine *backs up* is decided by the `BackupSet` its callers hand
         // to `runSet`, and those come from `scheduled`.
+        var purgeSourcePaths: [UUID: Set<String>] = [:]
+        var purgeHostnames: [UUID: Set<String>] = [:]
+        for set in views.shared.sets {
+            var sources = Set(set.sources)
+            var hostnames = Set<String>()
+            if let machines = set.machines {
+                hostnames.formUnion(machines.keys)
+                for override in machines.values {
+                    sources.formUnion(override.sources ?? [])
+                }
+            }
+            purgeSourcePaths[set.id] = sources
+            // Machine ids are generated from hostnames and are the only
+            // fleet-wide hostname inventory persisted by the application.
+            // Include this machine even when the set has no override map.
+            hostnames.insert(views.addressable.machineId)
+            purgeHostnames[set.id] = hostnames
+        }
         let engine = BackupEngine(
             config: views.addressable.config,
             paths: paths,
@@ -163,7 +186,9 @@ struct HelperContext {
             secrets: secrets,
             runStore: runStore,
             stateStore: stateStore,
-            reachability: reachability
+            reachability: reachability,
+            purgeSourcePaths: purgeSourcePaths,
+            purgeHostnames: purgeHostnames
         )
         return .ready(HelperContext(
             paths: paths,

--- a/Helper/Sources/HelperMain.swift
+++ b/Helper/Sources/HelperMain.swift
@@ -129,6 +129,7 @@ struct HelperMain: AsyncParsableCommand {
         var subcommands: [any ParsableCommand.Type] = [
             Tick.self,
             RunSet.self,
+            Purge.self,
             InitSecondary.self,
             Restore.self,
             ProbeRepo.self,

--- a/Helper/Tests/HelperTests/SubcommandRegistrationTests.swift
+++ b/Helper/Tests/HelperTests/SubcommandRegistrationTests.swift
@@ -27,6 +27,7 @@ import Testing
         names == [
             "tick",
             "run-set",
+            "purge",
             "init-secondary",
             "restore",
             "probe-repo",
@@ -48,6 +49,7 @@ import Testing
         names == [
             "tick",
             "run-set",
+            "purge",
             "init-secondary",
             "restore",
             "probe-repo",

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -55,6 +55,7 @@ itself, unwrapped, because its output is meant to be fed straight back into
 | `secret list` | ✅ | array of `{ destId, label, setName, hasPassword, secretEnvCount }` — only destinations that have something stored, the same set human mode prints |
 | `cli status` | ✅ | `CLIInstaller.Status` |
 | `fda-check` | ✅ | `{ applicable, granted, probedPath, checkedAt, context }` |
+| `purge preview` | ✅ | array of per-destination purge plans: matched/changed/unattributed snapshots and patterns |
 | `config export` | — | **Unwrapped by design.** The exported config document itself, so it round-trips into `config import`. |
 | `timer status` (Linux) | — | **Human-only.** Its report is narrative assembled while probing; the machine-readable equivalent is `status --json`'s `.scheduler`, in the same problem vocabulary. |
 | `print-password` | — | Hidden; exists for `RESTIC_PASSWORD_COMMAND` and writes a secret to stdout. |

--- a/docs/fixtures/rewrite-dry-run.txt
+++ b/docs/fixtures/rewrite-dry-run.txt
@@ -1,0 +1,8 @@
+
+snapshot 09b3295c of [/tmp/restic-station-purge-fixture.tyOGmf/source] at 2026-08-19 23:32:12.238741 -0700 PDT by bwh@Bens-Laptop
+would save new snapshot
+
+snapshot b2435423 of [/tmp/restic-station-purge-fixture.tyOGmf/source] at 2026-08-19 23:32:14.083168 -0700 PDT by bwh@Bens-Laptop
+would save new snapshot
+
+would modify 2 snapshots

--- a/docs/fixtures/rewrite-forget.txt
+++ b/docs/fixtures/rewrite-forget.txt
@@ -1,0 +1,11 @@
+create exclusive lock for repository
+
+snapshot 09b3295c of [/tmp/restic-station-purge-fixture.tyOGmf/source] at 2026-08-19 23:32:12.238741 -0700 PDT by bwh@Bens-Laptop
+saved new snapshot 14a53542
+removed old snapshot 09b3295c
+
+snapshot b2435423 of [/tmp/restic-station-purge-fixture.tyOGmf/source] at 2026-08-19 23:32:14.083168 -0700 PDT by bwh@Bens-Laptop
+saved new snapshot 3ca2e0a5
+removed old snapshot b2435423
+
+modified 2 snapshots

--- a/docs/restic-cli.md
+++ b/docs/restic-cli.md
@@ -1,6 +1,6 @@
 # restic CLI contract
 
-Everything in this document was **verified against restic 0.18.1 on macOS (arm64)** — argv, exit codes, and every JSON sample below are captured real output (lightly sanitized paths/hostnames), stored verbatim in [`docs/fixtures/`](fixtures/). Parser implementations MUST be written against these fixtures (copied into `Core/Tests/ResticStationCoreTests/Fixtures/`) and MUST tolerate unknown extra fields (`init(from:)` via keyed containers or plain `Decodable` structs — never `assert` on shape).
+Everything in this document was **verified against restic 0.18.1 on macOS (arm64)** — argv, exit codes, and every JSON sample below are captured real output (lightly sanitized paths/hostnames), stored verbatim in [`docs/fixtures/`](fixtures/). The rewrite transcripts were additionally captured against restic 0.19.1 because that command has no JSON mode. Parser implementations MUST be written against these fixtures (copied into `Core/Tests/ResticStationCoreTests/Fixtures/`) and MUST tolerate unknown extra fields (`init(from:)` via keyed containers or plain `Decodable` structs — never `assert` on shape).
 
 ## General invocation rules
 
@@ -102,6 +102,26 @@ A fully-caught-up copy prints nothing (`copy-noop.txt` is empty) and exits 0. Pa
 restic -r <repo> snapshots --json
 ```
 Single JSON **array** (not NDJSON) — fixture `snapshots.json`. Key fields per element: `id`, `short_id`, `time`, `parent?`, `paths`, `hostname`, `username`, `program_version`, `summary{files_new,files_changed,data_added,total_bytes_processed,backup_start,backup_end,…}`. Copied snapshots additionally carry `original` (id in the source repo).
+
+### rewrite
+```
+restic -r <repo> rewrite [--forget] [--dry-run] [--exclude <pat>]... <snapshotID>...
+```
+`rewrite` has no JSON mode. Snapshot ids are required and are passed explicitly;
+omitting them rewrites every snapshot in the repository. `--exclude` may be
+repeated. `--dry-run` reports the snapshots that would be replaced without
+changing the repository (`rewrite-dry-run.txt`); `--forget` replaces the old
+snapshots and forgets them (`rewrite-forget.txt`). `--forget` does not reclaim
+pack space — only a later repository-wide `prune` does. Exit 0 means the
+requested rewrite completed (including a no-op); nonzero is a restic failure.
+
+### prune
+```
+restic -r <repo> prune [--dry-run]
+```
+Standalone repository-wide space reclamation. `--dry-run` reports the work
+without changing the repository. Exit 0 means prune completed; nonzero is a
+restic failure. Purge previews and purge applies never add `prune` implicitly.
 
 ### ls (lazy directory browsing)
 ```


### PR DESCRIPTION
Closes #87

## Summary

- add the fixed-order `rewrite` and standalone `prune` argv builders with non-empty ID/exclude preconditions
- attribute snapshots by source-path subset and hostname history across shared and machine override config
- add the read-only `purge preview` engine path and CLI, including the `--json` envelope contract
- capture and parse real restic 0.19.1 rewrite transcripts, with normative CLI docs and golden tests

The preview only invokes reachability, `snapshots --json`, and `rewrite --dry-run` with explicit matched snapshot IDs. It never invokes `rewrite --forget`, `prune`, or run-record mutation.

## Validation

- `./scripts/local-ci.sh` — passed all 8 checks
- `./scripts/headless-cli-test.sh` — passed
- `swift test --package-path Core --disable-sandbox` — 627 tests passed
- `swift test` — 89 tests passed
- real restic 0.19.1 scratch-repository fixture capture; docs/Core fixtures are byte-identical

Per #85, stop before #88: data deletion begins there.
