### PR TITLE
Purging exclusions 3/5: destructive purge apply

### DIFF
--- a/App/Sources/Views/Runs/RunHistory.swift
+++ b/App/Sources/Views/Runs/RunHistory.swift
@@ -205,6 +205,7 @@ struct RunFilter: Equatable {
 enum RunPhase {
     static func describe(_ phase: String) -> String {
         if phase.hasPrefix("copying") { return "copying to a mirror" }
+        if phase.hasPrefix("purging") { return "purging excluded files from history" }
         switch phase {
         case "probing": return "checking the repository"
         case "backing-up-primary": return "backing up"
@@ -226,6 +227,7 @@ extension RunKind {
         case .copy: return "Copy"
         case .check: return "Check"
         case .prune: return "Prune"
+        case .purge: return "Purge exclusions"
         case .restore: return "Restore"
         case .`init`: return "Initialize"
         }
@@ -237,6 +239,7 @@ extension RunKind {
         case .copy: return "doc.on.doc"
         case .check: return "checkmark.shield"
         case .prune: return "scissors"
+        case .purge: return "eraser"
         case .restore: return "arrow.uturn.backward"
         case .`init`: return "sparkles"
         }

--- a/Core/Sources/ResticStationCore/Config/AppPaths.swift
+++ b/Core/Sources/ResticStationCore/Config/AppPaths.swift
@@ -184,6 +184,19 @@ public struct AppPaths: Equatable, Sendable {
         stateDir.appendingPathComponent("fda-check.json", isDirectory: false)
     }
 
+    /// `state/preview-tokens.json` — the local, owner-only index behind
+    /// short-lived destructive-operation preview tokens.  This is state,
+    /// not shared configuration: a token is bound to one machine and must
+    /// never be copied with `config.json`.
+    public var previewTokensFile: URL {
+        stateDir.appendingPathComponent("preview-tokens.json", isDirectory: false)
+    }
+
+    /// Serializes destructive-preview token index updates across backup sets.
+    public var previewTokensLockFile: URL {
+        stateDir.appendingPathComponent("preview-tokens.lock", isDirectory: false)
+    }
+
     // MARK: - locks/
 
     public var locksDir: URL {

--- a/Core/Sources/ResticStationCore/Engine/BackupEngine.swift
+++ b/Core/Sources/ResticStationCore/Engine/BackupEngine.swift
@@ -80,7 +80,7 @@ public enum SetRunOutcome: Equatable, Sendable {
 // MARK: - BackupEngine
 
 /// The orchestration heart: scheduled/manual set runs (backup → mirror →
-/// retention), checks, prune, restore and secondary initialization, plus all
+/// retention), purge, checks, prune, restore and secondary initialization, plus all
 /// run-record and state bookkeeping.
 ///
 /// Implements `docs/tasks/T09-backup-engine.md` (the numbered `runSet`
@@ -104,6 +104,10 @@ public enum SetRunOutcome: Equatable, Sendable {
 /// 4. Every restic child the engine spawns streams its raw stdout *and*
 ///    stderr into that run's `log.txt` before any parsing decision is made.
 /// 5. `checkSliceCursor` advances only after a check that succeeded.
+/// 6. `rewrite --forget` is reached only by a valid, unexpired, single-use
+///    preview capability whose attributed snapshot ids are revalidated while
+///    the set lock is held. A stale secondary is purged before a copy, never
+///    afterwards.
 ///
 /// Nothing here reads the wall clock directly: `now` is injected (as are the
 /// process runner, via `ResticRunner`, and every store), which is what makes
@@ -136,6 +140,8 @@ public final class BackupEngine: Sendable {
     private let reachability: Reachability
     private let now: @Sendable () -> Date
     private let uptime: @Sendable () -> TimeInterval
+    private let machineId: String
+    private let previewTokens: PreviewTokenStore
     /// Raw shared-config source/hostname knowledge used by purge attribution.
     /// Resolved configs deliberately strip machine overrides, so the helper
     /// supplies these unions when it constructs the engine.
@@ -153,7 +159,9 @@ public final class BackupEngine: Sendable {
         now: @escaping @Sendable () -> Date = Date.init,
         uptime: @escaping @Sendable () -> TimeInterval = { ProcessInfo.processInfo.systemUptime },
         purgeSourcePaths: [UUID: Set<String>] = [:],
-        purgeHostnames: [UUID: Set<String>] = [:]
+        purgeHostnames: [UUID: Set<String>] = [:],
+        machineId: String = MachineIdentity.generate(),
+        previewTokens: PreviewTokenStore? = nil
     ) {
         self.config = config
         self.paths = paths
@@ -164,6 +172,8 @@ public final class BackupEngine: Sendable {
         self.reachability = reachability
         self.now = now
         self.uptime = uptime
+        self.machineId = machineId
+        self.previewTokens = previewTokens ?? PreviewTokenStore(paths: paths, now: now)
         self.purgeSourcePaths = purgeSourcePaths
         self.purgeHostnames = purgeHostnames
     }
@@ -182,10 +192,11 @@ public final class BackupEngine: Sendable {
     /// 5. `backup` (exit 3 ⇒ `.warning` and continue; exit 11 ⇒ `unlock` +
     ///    exactly one retry; 1/2/10/12 ⇒ `.failed`, stop — no copies, no
     ///    retention);
-    /// 6. every secondary in config order: probe, copy, then retention on
-    ///    that secondary only if its copy succeeded;
-    /// 7. retention on the primary if the policy is non-nil and non-empty;
-    /// 8. clear `current-run`, release the lock (also on every failure path),
+    /// 6. purge the primary if it has newly added purge exclusions;
+    /// 7. every secondary in config order: probe, purge it if needed, copy,
+    ///    then retention only if that copy succeeded;
+    /// 8. retention on the primary if the policy is non-nil and non-empty;
+    /// 9. clear `current-run`, release the lock (also on every failure path),
     ///    group outcome = worst child status.
     public func runSet(_ set: BackupSet, trigger: RunTrigger) async -> SetRunOutcome {
         guard let primary = set.destinations.first(where: { $0.isPrimary }) else {
@@ -273,7 +284,37 @@ public final class BackupEngine: Sendable {
         // in sync as of now.
         markSynced(primary)
 
-        // ── Step 6: secondaries, in config order ────────────────────────
+        // A changed purge rule must rewrite the primary before it can be
+        // copied anywhere. A failed primary purge terminates the group: a
+        // copy would otherwise propagate rewritten snapshots while leaving
+        // their originals on an unpurged mirror.
+        let primaryPurgePatterns = pendingPurgePatterns(
+            setId: set.id,
+            set: set,
+            destinationId: primary.id
+        )
+        if !primaryPurgePatterns.isEmpty {
+            do {
+                let purge = try await runAutomaticPurge(
+                    set: set,
+                    destination: primary,
+                    patterns: primaryPurgePatterns,
+                    trigger: trigger,
+                    groupId: groupId
+                )
+                children.append(contentsOf: purge.children)
+                guard purge.status == .success else {
+                    return .completed(status: .failed, groupId: groupId, children: children)
+                }
+            } catch {
+                logWarning(
+                    "BackupEngine: could not purge primary \"\(primary.label)\" before mirroring: \(error)"
+                )
+                return .completed(status: .failed, groupId: groupId, children: children)
+            }
+        }
+
+        // ── Step 7: secondaries, in config order ────────────────────────
         for secondary in set.destinations where !secondary.isPrimary {
             let probe = await reachability.probe(secondary)
             record(probe: probe, for: secondary)
@@ -286,6 +327,39 @@ public final class BackupEngine: Sendable {
                     "BackupEngine: skipping secondary \"\(secondary.label)\": \(describe(probe))"
                 )
                 continue
+            }
+
+            // A mirror with stale purge state cannot receive a copy: restic
+            // would retain its old snapshots alongside the primary's rewritten
+            // replacements. A failed purge skips only this secondary; another
+            // mirror can still make a safe copy.
+            let secondaryPurgePatterns = pendingPurgePatterns(
+                setId: set.id,
+                set: set,
+                destinationId: secondary.id
+            )
+            if !secondaryPurgePatterns.isEmpty {
+                do {
+                    let purge = try await runAutomaticPurge(
+                        set: set,
+                        destination: secondary,
+                        patterns: secondaryPurgePatterns,
+                        trigger: trigger,
+                        groupId: groupId
+                    )
+                    children.append(contentsOf: purge.children)
+                    guard purge.status == .success else {
+                        logWarning(
+                            "BackupEngine: purge of secondary \"\(secondary.label)\" did not succeed — skipping copy"
+                        )
+                        continue
+                    }
+                } catch {
+                    logWarning(
+                        "BackupEngine: could not purge secondary \"\(secondary.label)\" before copy: \(error)"
+                    )
+                    continue
+                }
             }
 
             let copy = await performChild(
@@ -326,7 +400,7 @@ public final class BackupEngine: Sendable {
             }
         }
 
-        // ── Step 7: retention on the primary ────────────────────────────
+        // ── Step 8: retention on the primary ────────────────────────────
         if let prune = await forgetChild(
             destination: primary,
             policy: set.retention,
@@ -337,7 +411,7 @@ public final class BackupEngine: Sendable {
             children.append(prune.child)
         }
 
-        // ── Step 8: current-run cleared and lock released by the defers ─
+        // ── Step 9: current-run cleared and lock released by the defers ─
         return .completed(
             status: Self.worstStatus(children.map(\.status)),
             groupId: groupId,
@@ -642,6 +716,267 @@ public final class BackupEngine: Sendable {
         return PurgePlanResult(plan: plan, changed: changed, rewrite: rewrite, status: .ready)
     }
 
+    /// Stores the approved result of one or more successful purge previews.
+    /// An empty plan gets no capability: there is nothing destructive to do.
+    public func issuePurgeToken(
+        set: BackupSet,
+        destinations: [Destination],
+        plans: [PurgePlan]
+    ) throws -> PreviewToken? {
+        guard !set.purgeExcludes.isEmpty, destinations.count == plans.count else { return nil }
+        guard Set(plans.map(\.destinationId)).count == plans.count else { return nil }
+        let plansByDestination = Dictionary(uniqueKeysWithValues: plans.map { ($0.destinationId, $0) })
+        guard destinations.allSatisfy({ plansByDestination[$0.id]?.patterns == set.purgeExcludes }) else {
+            return nil
+        }
+        let tokenDestinations = destinations.compactMap { destination -> PreviewTokenDestination? in
+            guard let plan = plansByDestination[destination.id] else { return nil }
+            return PreviewTokenDestination(
+                destinationId: destination.id,
+                snapshotIDs: plan.matched.map(\.id)
+            )
+        }
+        guard tokenDestinations.contains(where: { !$0.snapshotIDs.isEmpty }) else { return nil }
+        return try previewTokens.issue(
+            machineId: machineId,
+            setId: set.id,
+            destinations: tokenDestinations,
+            config: config,
+            patterns: set.purgeExcludes
+        )
+    }
+
+    /// Lets the helper choose exactly the destinations an opaque token bound.
+    /// It does not consume the token; `runPurge` rechecks and consumes it
+    /// under the set lock immediately before the first destructive command.
+    public func purgeTokenDestinationIDs(_ token: String) throws -> [UUID] {
+        do {
+            return try previewTokens.token(token).destinations.map(\.destinationId)
+        } catch let error as PreviewTokenError {
+            throw PurgeApplyError.token(error)
+        } catch {
+            throw PurgeApplyError.unavailable
+        }
+    }
+
+    /// Applies a previously reviewed purge preview.  The token is validated
+    /// against this machine, resolved config, selected destinations, patterns
+    /// and fresh repository snapshot attribution before it is consumed.
+    public func runPurge(
+        set: BackupSet,
+        destinations: [Destination],
+        token: String
+    ) async throws -> PurgeRunResult {
+        let lock = makeSetLock(setId: set.id)
+        guard lock.tryAcquire() else { throw PurgeApplyError.busy }
+        defer { lock.release() }
+        defer { try? stateStore.clearCurrentRun(setId: set.id) }
+        return try await runPurgeLocked(
+            set: set,
+            destinations: destinations,
+            token: token,
+            trigger: .manual,
+            groupId: nil
+        )
+    }
+
+    /// `runSet` owns the set lock already, so automatic purge reaches this
+    /// private path after minting an equally constrained local token.
+    private func runPurgeLocked(
+        set: BackupSet,
+        destinations: [Destination],
+        token: String,
+        trigger: RunTrigger,
+        groupId: String?
+    ) async throws -> PurgeRunResult {
+        let preview: PreviewToken
+        do {
+            preview = try previewTokens.token(token)
+        } catch let error as PreviewTokenError {
+            throw PurgeApplyError.token(error)
+        } catch {
+            throw PurgeApplyError.unavailable
+        }
+
+        let requestedIds = Set(destinations.map(\.id))
+        let tokenIds = Set(preview.destinations.map(\.destinationId))
+        let fingerprint: String
+        do {
+            fingerprint = try PreviewTokenStore.configFingerprint(config)
+        } catch {
+            throw PurgeApplyError.unavailable
+        }
+        guard preview.machineId == machineId,
+              preview.setId == set.id,
+              requestedIds == tokenIds,
+              preview.configFingerprint == fingerprint,
+              Set(preview.patterns).isSubset(of: Set(set.purgeExcludes)) else {
+            throw PurgeApplyError.tokenDoesNotMatchCurrentPlan
+        }
+
+        guard await secretsAvailable(for: destinations) else { throw PurgeApplyError.unavailable }
+
+        var plans: [(destination: Destination, plan: PurgePlan)] = []
+        for destination in destinations.sorted(by: { $0.id.uuidString < $1.id.uuidString }) {
+            let plan = try await currentPurgePlan(
+                set: set,
+                destination: destination,
+                patterns: preview.patterns
+            )
+            guard let tokenDestination = preview.destinations.first(where: { $0.destinationId == destination.id }),
+                  tokenDestination.snapshotIDs.sorted() == plan.matched.map(\.id).sorted() else {
+                throw PurgeApplyError.tokenDoesNotMatchCurrentPlan
+            }
+            plans.append((destination, plan))
+        }
+
+        do {
+            _ = try previewTokens.consume(token)
+        } catch let error as PreviewTokenError {
+            throw PurgeApplyError.token(error)
+        } catch {
+            throw PurgeApplyError.unavailable
+        }
+
+        var children: [SetRunChild] = []
+        var resolvedGroupId = groupId
+        for (destination, plan) in plans {
+            guard !plan.matched.isEmpty else {
+                markPurgePatternsApplied(setId: set.id, destinationId: destination.id, patterns: preview.patterns)
+                continue
+            }
+            guard let purge = await purgeChild(
+                destination: destination,
+                snapshotIDs: plan.matched.map(\.id),
+                patterns: preview.patterns,
+                setId: set.id,
+                trigger: trigger,
+                groupId: resolvedGroupId
+            ) else {
+                return PurgeRunResult(status: .failed, children: children)
+            }
+            children.append(purge.child)
+            if resolvedGroupId == nil { resolvedGroupId = purge.child.runId }
+            if purge.child.status == .success {
+                markPurgePatternsApplied(setId: set.id, destinationId: destination.id, patterns: preview.patterns)
+            }
+        }
+        return PurgeRunResult(status: Self.worstStatus(children.map(\.status)), children: children)
+    }
+
+    /// Obtains a fresh attributed plan for token validation.  It is purposely
+    /// independent of the earlier dry-run transcript: a repository can
+    /// change during the preview window, and the apply must fail closed.
+    private func currentPurgePlan(
+        set: BackupSet,
+        destination: Destination,
+        patterns: [String]
+    ) async throws -> PurgePlan {
+        let probe = await reachability.probe(destination)
+        guard probe == .reachable else {
+            throw PurgeApplyError.destinationOffline(destinationId: destination.id)
+        }
+        let outcome: ResticOutcome
+        do {
+            outcome = try await restic.run(
+                .snapshots(repo: destination.repoURL),
+                for: ResticInvocation(destination: destination)
+            )
+        } catch {
+            throw PurgeApplyError.unavailable
+        }
+        guard outcome.status == .success,
+              let snapshots = try? parseSnapshots(Data(outcome.rawOutput.utf8)) else {
+            throw PurgeApplyError.unavailable
+        }
+        return PurgePlan(
+            destinationId: destination.id,
+            snapshots: snapshots,
+            sourcePaths: sourcePaths(for: set),
+            hostnames: hostnames(for: set),
+            patterns: patterns
+        )
+    }
+
+    /// The only `rewrite --forget` call site.  It receives explicit ids from
+    /// the just-revalidated token and records the old→new mapping in the
+    /// purge run metadata; it never accepts a caller-supplied broad filter.
+    private func purgeChild(
+        destination: Destination,
+        snapshotIDs: [String],
+        patterns: [String],
+        setId: UUID,
+        trigger: RunTrigger,
+        groupId: String?
+    ) async -> ChildRun? {
+        let fullIDByShortID = Dictionary(
+            snapshotIDs.map { (String($0.prefix(8)), $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        return await performChild(
+            kind: .purge,
+            setId: setId,
+            destination: destination,
+            trigger: trigger,
+            groupId: groupId,
+            phase: "purging-\(destination.id.uuidString)",
+            command: .rewrite(
+                repo: destination.repoURL,
+                snapshotIDs: snapshotIDs,
+                excludes: patterns,
+                forget: true
+            ),
+            invocation: ResticInvocation(destination: destination),
+            streamProgress: false,
+            purgeSnapshotRewrites: { outcome in
+                Dictionary(uniqueKeysWithValues: parseRewrite(outcome.rawOutput).snapshots.compactMap { rewrite in
+                    guard let oldID = fullIDByShortID[rewrite.shortID], let newID = rewrite.newSnapshotShortID else {
+                        return nil
+                    }
+                    return (oldID, newID)
+                })
+            }
+        )
+    }
+
+    private func pendingPurgePatterns(setId: UUID, set: BackupSet, destinationId: UUID) -> [String] {
+        let applied = stateStore.readScheduleState()?.sets[setId]?.appliedPurgeExcludes[destinationId] ?? []
+        return set.purgeExcludes.filter { !applied.contains($0) }
+    }
+
+    /// Mints a local token from a fresh plan and consumes it through the same
+    /// `runPurgeLocked` path as manual apply.  Automatic purge therefore has
+    /// no back door around the token validation or audit guarantees.
+    private func runAutomaticPurge(
+        set: BackupSet,
+        destination: Destination,
+        patterns: [String],
+        trigger: RunTrigger,
+        groupId: String
+    ) async throws -> PurgeRunResult {
+        guard await secretsAvailable(for: [destination]) else { throw PurgeApplyError.unavailable }
+        let plan = try await currentPurgePlan(set: set, destination: destination, patterns: patterns)
+        let token: PreviewToken
+        do {
+            token = try previewTokens.issue(
+                machineId: machineId,
+                setId: set.id,
+                destinations: [PreviewTokenDestination(destinationId: destination.id, snapshotIDs: plan.matched.map(\.id))],
+                config: config,
+                patterns: patterns
+            )
+        } catch {
+            throw PurgeApplyError.unavailable
+        }
+        return try await runPurgeLocked(
+            set: set,
+            destinations: [destination],
+            token: token.value,
+            trigger: trigger,
+            groupId: groupId
+        )
+    }
+
     // MARK: - runRestore
 
     /// Restores from one destination under the **set** lock, so a restore
@@ -809,7 +1144,8 @@ public final class BackupEngine: Sendable {
         streamProgress: Bool,
         preflightPhase: String? = nil,
         preflight: (@Sendable (LogWriter?) async -> String?)? = nil,
-        downgradeSuccessToWarning: (@Sendable (ResticOutcome) -> Bool)? = nil
+        downgradeSuccessToWarning: (@Sendable (ResticOutcome) -> Bool)? = nil,
+        purgeSnapshotRewrites: (@Sendable (ResticOutcome) -> [String: String]?)? = nil
     ) async -> ChildRun? {
         var run: ActiveRun
         do {
@@ -887,7 +1223,20 @@ public final class BackupEngine: Sendable {
             }
         }
 
-        finish(run, status: status, stats: stats, errorSummary: errorSummary, resticExitCode: exitCode)
+        let rewrites: [String: String]?
+        if status == .success, case .ranToCompletion(let outcome) = result {
+            rewrites = purgeSnapshotRewrites?(outcome)
+        } else {
+            rewrites = nil
+        }
+        finish(
+            run,
+            status: status,
+            stats: stats,
+            errorSummary: errorSummary,
+            resticExitCode: exitCode,
+            purgeSnapshotRewrites: rewrites
+        )
         return ChildRun(
             child: SetRunChild(runId: run.runId, kind: kind, destId: destination.id, status: status),
             outcome: result.outcome
@@ -972,7 +1321,8 @@ public final class BackupEngine: Sendable {
         status: RunStatus,
         stats: BackupSummary? = nil,
         errorSummary: String? = nil,
-        resticExitCode: Int32? = nil
+        resticExitCode: Int32? = nil,
+        purgeSnapshotRewrites: [String: String]? = nil
     ) {
         do {
             try runStore.finish(
@@ -980,7 +1330,8 @@ public final class BackupEngine: Sendable {
                 status: status,
                 stats: stats,
                 errorSummary: errorSummary,
-                resticExitCode: resticExitCode
+                resticExitCode: resticExitCode,
+                purgeSnapshotRewrites: purgeSnapshotRewrites
             )
         } catch {
             logWarning("BackupEngine: could not finish run \(run.runId): \(error)")
@@ -1036,6 +1387,20 @@ public final class BackupEngine: Sendable {
             try stateStore.updateScheduleState(setId: setId, mutate: mutate)
         } catch {
             logWarning("BackupEngine: could not update schedule state for set \(setId): \(error)")
+        }
+    }
+
+    /// Advances the purge-exclusion watermark only after the matching
+    /// repository rewrite succeeded. Existing snapshots are never inferred
+    /// from this state; it merely prevents a newly added exclusion from
+    /// running again on every scheduled backup.
+    private func markPurgePatternsApplied(setId: UUID, destinationId: UUID, patterns: [String]) {
+        updateScheduleState(setId: setId) { state in
+            var applied = state.appliedPurgeExcludes[destinationId] ?? []
+            for pattern in patterns where !applied.contains(pattern) {
+                applied.append(pattern)
+            }
+            state.appliedPurgeExcludes[destinationId] = applied
         }
     }
 

--- a/Core/Sources/ResticStationCore/Engine/PurgePlan.swift
+++ b/Core/Sources/ResticStationCore/Engine/PurgePlan.swift
@@ -92,3 +92,27 @@ public struct PurgePlanResult: Equatable, Sendable {
         self.message = message
     }
 }
+
+/// A completed token-gated purge group.  `children` are ordinary run records
+/// (`RunKind.purge`), so callers can report and audit every destination
+/// without ever exposing the preview token itself.
+public struct PurgeRunResult: Equatable, Sendable {
+    public let status: RunStatus
+    public let children: [SetRunChild]
+
+    public init(status: RunStatus, children: [SetRunChild]) {
+        self.status = status
+        self.children = children
+    }
+}
+
+/// Failures that prevent a token-gated purge before `rewrite --forget` can
+/// run.  Messages and CLI classification intentionally never carry a token,
+/// path, or repository URL.
+public enum PurgeApplyError: Error, Equatable, Sendable {
+    case token(PreviewTokenError)
+    case tokenDoesNotMatchCurrentPlan
+    case busy
+    case destinationOffline(destinationId: UUID)
+    case unavailable
+}

--- a/Core/Sources/ResticStationCore/Engine/StateStore.swift
+++ b/Core/Sources/ResticStationCore/Engine/StateStore.swift
@@ -78,21 +78,47 @@ public struct SetScheduleState: Codable, Equatable, Sendable {
     /// files carry no version and are regenerable caches
     /// (`docs/data-model.md` §Versioning & migration).
     public var checkCount: Int?
+    /// Per destination, the purge patterns that have already been rewritten
+    /// out of that repository. Removing a pattern deliberately does not
+    /// remove it from this audit state: history cannot be restored, and a
+    /// smaller list must never cause a wasteful rewrite.
+    public var appliedPurgeExcludes: [UUID: [String]]
 
     public init(
         lastBackupStart: Date? = nil,
         lastCheckStart: Date? = nil,
         checkSliceCursor: Int? = nil,
-        checkCount: Int? = nil
+        checkCount: Int? = nil,
+        appliedPurgeExcludes: [UUID: [String]] = [:]
     ) {
         self.lastBackupStart = lastBackupStart
         self.lastCheckStart = lastCheckStart
         self.checkSliceCursor = checkSliceCursor
         self.checkCount = checkCount
+        self.appliedPurgeExcludes = appliedPurgeExcludes
     }
 
     private enum CodingKeys: String, CodingKey {
-        case lastBackupStart, lastCheckStart, checkSliceCursor, checkCount
+        case lastBackupStart, lastCheckStart, checkSliceCursor, checkCount, appliedPurgeExcludes
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        lastBackupStart = try container.decodeIfPresent(Date.self, forKey: .lastBackupStart)
+        lastCheckStart = try container.decodeIfPresent(Date.self, forKey: .lastCheckStart)
+        checkSliceCursor = try container.decodeIfPresent(Int.self, forKey: .checkSliceCursor)
+        checkCount = try container.decodeIfPresent(Int.self, forKey: .checkCount)
+        guard container.contains(.appliedPurgeExcludes), !(try container.decodeNil(forKey: .appliedPurgeExcludes)) else {
+            appliedPurgeExcludes = [:]
+            return
+        }
+        let nested = try container.nestedContainer(keyedBy: DynamicCodingKey.self, forKey: .appliedPurgeExcludes)
+        var values: [UUID: [String]] = [:]
+        for key in nested.allKeys {
+            guard let id = UUID(uuidString: key.stringValue) else { continue }
+            values[id] = try nested.decode([String].self, forKey: key)
+        }
+        appliedPurgeExcludes = values
     }
 
     // Explicit `null` for nil optionals — see AppConfig.encode(to:).
@@ -102,6 +128,11 @@ public struct SetScheduleState: Codable, Equatable, Sendable {
         try container.encode(lastCheckStart, forKey: .lastCheckStart)
         try container.encode(checkSliceCursor, forKey: .checkSliceCursor)
         try container.encode(checkCount, forKey: .checkCount)
+        var nested = container.nestedContainer(keyedBy: DynamicCodingKey.self, forKey: .appliedPurgeExcludes)
+        for (id, patterns) in appliedPurgeExcludes {
+            guard let key = DynamicCodingKey(stringValue: id.uuidString) else { continue }
+            try nested.encode(patterns, forKey: key)
+        }
     }
 }
 
@@ -113,8 +144,9 @@ public struct SetScheduleState: Codable, Equatable, Sendable {
 public struct CurrentRunState: Codable, Equatable, Sendable {
     public var runId: String
     public var kind: RunKind
-    /// `probing` | `backing-up-primary` | `copying-<destId>` | `retention` |
-    /// `checking` — free-form because `copying-<destId>` embeds a
+    /// `probing` | `backing-up-primary` | `purging-<destId>` |
+    /// `copying-<destId>` | `retention` | `checking` — free-form because
+    /// `purging-<destId>` and `copying-<destId>` embed a
     /// destination id, so this is not a fixed-case enum.
     public var phase: String
     public var percentDone: Double

--- a/Core/Sources/ResticStationCore/Runs/RunRecord.swift
+++ b/Core/Sources/ResticStationCore/Runs/RunRecord.swift
@@ -9,6 +9,9 @@ public enum RunKind: String, Codable, Equatable, Sendable, CaseIterable {
     case copy
     case check
     case prune
+    /// A token-gated `restic rewrite --forget` purge. Unlike `prune`, this
+    /// changes snapshot history but does not reclaim pack space.
+    case purge
     case restore
     /// Repository initialization. `init` is a reserved word, hence the
     /// backticks — the raw value (and every persisted representation) is
@@ -152,6 +155,10 @@ public struct RunMetadata: Codable, Equatable, Sendable {
     /// Full decoded summary message where applicable (e.g. a `backup` or
     /// `copy` run). `nil` for kinds with no such summary (e.g. `prune`).
     public var stats: BackupSummary?
+    /// Old full snapshot id → new snapshot id reported by `restic rewrite
+    /// --forget`. Present only for successful/partially successful purge
+    /// runs; historical run records deliberately remain untouched.
+    public var purgeSnapshotRewrites: [String: String]?
 
     public init(
         runId: String,
@@ -171,7 +178,8 @@ public struct RunMetadata: Codable, Equatable, Sendable {
         filesChanged: Int?,
         dataAdded: Int?,
         errorSummary: String?,
-        stats: BackupSummary?
+        stats: BackupSummary?,
+        purgeSnapshotRewrites: [String: String]? = nil
     ) {
         self.runId = runId
         self.kind = kind
@@ -191,12 +199,13 @@ public struct RunMetadata: Codable, Equatable, Sendable {
         self.dataAdded = dataAdded
         self.errorSummary = errorSummary
         self.stats = stats
+        self.purgeSnapshotRewrites = purgeSnapshotRewrites
     }
 
     private enum CodingKeys: String, CodingKey {
         case runId, kind, setId, destId, groupId, status, trigger, start, end
         case pid, resticExitCode, argvRedacted
-        case snapshotId, filesNew, filesChanged, dataAdded, errorSummary, stats
+        case snapshotId, filesNew, filesChanged, dataAdded, errorSummary, stats, purgeSnapshotRewrites
     }
 
     // Explicit `null` for nil optionals — see AppConfig.encode(to:).
@@ -220,6 +229,7 @@ public struct RunMetadata: Codable, Equatable, Sendable {
         try container.encode(dataAdded, forKey: .dataAdded)
         try container.encode(errorSummary, forKey: .errorSummary)
         try container.encode(stats, forKey: .stats)
+        try container.encode(purgeSnapshotRewrites, forKey: .purgeSnapshotRewrites)
     }
 
     /// The compact index-line projection of this metadata, appended to

--- a/Core/Sources/ResticStationCore/Runs/RunStore.swift
+++ b/Core/Sources/ResticStationCore/Runs/RunStore.swift
@@ -175,7 +175,8 @@ public struct RunStore: Sendable {
             filesChanged: nil,
             dataAdded: nil,
             errorSummary: nil,
-            stats: nil
+            stats: nil,
+            purgeSnapshotRewrites: nil
         )
         try FileManager.default.createDirectory(at: paths.runDir(runId: runId), withIntermediateDirectories: true)
         try writeMetadataAtomic(metadata)
@@ -200,7 +201,8 @@ public struct RunStore: Sendable {
         status: RunStatus,
         stats: BackupSummary? = nil,
         errorSummary: String? = nil,
-        resticExitCode: Int32? = nil
+        resticExitCode: Int32? = nil,
+        purgeSnapshotRewrites: [String: String]? = nil
     ) throws {
         let metadata = RunMetadata(
             runId: run.runId,
@@ -220,7 +222,8 @@ public struct RunStore: Sendable {
             filesChanged: stats?.filesChanged,
             dataAdded: stats?.dataAdded,
             errorSummary: errorSummary,
-            stats: stats
+            stats: stats,
+            purgeSnapshotRewrites: purgeSnapshotRewrites
         )
         try writeMetadataAtomic(metadata)
         try appendIndexEntry(metadata.indexEntry)

--- a/Core/Sources/ResticStationCore/Support/CLIError.swift
+++ b/Core/Sources/ResticStationCore/Support/CLIError.swift
@@ -119,6 +119,9 @@ public enum CLIErrorCode: String, Sendable, Codable, CaseIterable, Equatable {
     /// `restic_failed` told an agent the opposite of what the same failure
     /// told a person.
     case operationTimedOut = "operation_timed_out"
+    /// A destructive-preview capability passed its bounded lifetime. A new
+    /// read-only preview is required before anything can be changed.
+    case previewExpired = "preview_expired"
 
     // ── Refused on purpose ────────────────────────────────────────────────
 
@@ -157,7 +160,7 @@ extension CLIErrorCode {
              .repositoryLocked, .secretUnavailable, .secretRejected,
              .secretNotConfigured,
              .repositoryNotInitialized, .resticNotFound, .resticUnsupported,
-             .resticFailed, .operationTimedOut, .operationNotAllowed,
+             .resticFailed, .operationTimedOut, .previewExpired, .operationNotAllowed,
              .internalError:
             return .error
         }
@@ -180,7 +183,7 @@ extension CLIErrorCode {
              .destinationNotFound, .destinationDisabledHere, .runNotFound,
              .secretRejected, .secretNotConfigured,
              .repositoryNotInitialized, .resticNotFound,
-             .resticUnsupported, .resticFailed, .operationNotAllowed,
+             .resticUnsupported, .resticFailed, .previewExpired, .operationNotAllowed,
              .internalError:
             return false
         case .operationTimedOut:
@@ -387,6 +390,43 @@ public struct CLIFailure: Error, Equatable, Sendable {
 /// invent its own code *and* its own wording, which is precisely the drift
 /// this contract exists to prevent.
 extension CLIFailure {
+
+    /// Error mapping for token-gated destructive operations. Token material
+    /// never reaches the envelope; ids make the refusal actionable without
+    /// disclosing a capability or repository path.
+    public static func classifyPurgeApply(_ error: any Error, setId: UUID) -> CLIFailure {
+        guard let purgeError = error as? PurgeApplyError else {
+            return classify(error)
+        }
+        switch purgeError {
+        case .token(.expired):
+            return CLIFailure(
+                code: .previewExpired,
+                message: "The purge preview has expired. Run purge preview again.",
+                details: CLIErrorDetails(setId: setId)
+            )
+        case .token, .tokenDoesNotMatchCurrentPlan:
+            return CLIFailure(
+                code: .operationNotAllowed,
+                message: "The purge preview does not match the current plan. Run purge preview again.",
+                details: CLIErrorDetails(setId: setId)
+            )
+        case .busy:
+            return CLIFailure.setBusy(setId: setId)
+        case .destinationOffline(let destinationId):
+            return CLIFailure(
+                code: .repositoryOffline,
+                message: "The destination is offline. Reconnect it and run purge preview again.",
+                details: CLIErrorDetails(setId: setId, destinationId: destinationId)
+            )
+        case .unavailable:
+            return CLIFailure(
+                code: .secretUnavailable,
+                message: "The purge could not be prepared. Try again after checking secret storage.",
+                details: CLIErrorDetails(setId: setId)
+            )
+        }
+    }
 
     public static func invalidArguments(_ message: String) -> CLIFailure {
         CLIFailure(code: .invalidArguments, message: bounded(message))

--- a/Core/Sources/ResticStationCore/Support/PreviewToken.swift
+++ b/Core/Sources/ResticStationCore/Support/PreviewToken.swift
@@ -1,0 +1,253 @@
+import Foundation
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
+
+/// One destination's exact, attributed snapshot ids in a destructive preview.
+public struct PreviewTokenDestination: Codable, Equatable, Sendable {
+    public let destinationId: UUID
+    public let snapshotIDs: [String]
+
+    public init(destinationId: UUID, snapshotIDs: [String]) {
+        self.destinationId = destinationId
+        self.snapshotIDs = snapshotIDs.sorted()
+    }
+}
+
+/// The persisted capability behind a destructive purge/retention action.
+///
+/// The opaque `value` is intentionally only ever written to the owner-only
+/// ``PreviewTokenStore`` index and returned by a successful preview.  It
+/// never belongs in a run record, run log, or error envelope.
+public struct PreviewToken: Codable, Equatable, Sendable {
+    public let value: String
+    public let machineId: String
+    public let setId: UUID
+    public let destinations: [PreviewTokenDestination]
+    public let configFingerprint: String
+    public let patterns: [String]
+    public let createdAt: Date
+    public let expiresAt: Date
+    public var usedAt: Date?
+
+    public init(
+        value: String,
+        machineId: String,
+        setId: UUID,
+        destinations: [PreviewTokenDestination],
+        configFingerprint: String,
+        patterns: [String],
+        createdAt: Date,
+        expiresAt: Date,
+        usedAt: Date? = nil
+    ) {
+        self.value = value
+        self.machineId = machineId
+        self.setId = setId
+        self.destinations = destinations.sorted { $0.destinationId.uuidString < $1.destinationId.uuidString }
+        self.configFingerprint = configFingerprint
+        self.patterns = patterns
+        self.createdAt = createdAt
+        self.expiresAt = expiresAt
+        self.usedAt = usedAt
+    }
+}
+
+/// Fail-closed failures while looking up or consuming a destructive preview.
+/// None carries the token value: an error can safely reach a bounded CLI
+/// message without leaking a live capability.
+public enum PreviewTokenError: Error, Equatable, Sendable {
+    case unavailable
+    case unknown
+    case expired
+    case alreadyUsed
+}
+
+/// Owner-only on-disk store for short-lived destructive-operation previews.
+///
+/// The token value is a 256-bit CSPRNG capability.  Entries are retained
+/// briefly after use/expiry so a replay gets a deliberate refusal rather than
+/// looking like a missing token; old entries are swept during every write.
+public struct PreviewTokenStore: Sendable {
+    public static let defaultLifetime: TimeInterval = 15 * 60
+    private static let retentionAfterExpiry: TimeInterval = 24 * 60 * 60
+
+    public let paths: AppPaths
+    private let now: @Sendable () -> Date
+
+    public init(paths: AppPaths, now: @escaping @Sendable () -> Date = Date.init) {
+        self.paths = paths
+        self.now = now
+    }
+
+    public func issue(
+        machineId: String,
+        setId: UUID,
+        destinations: [PreviewTokenDestination],
+        config: AppConfig,
+        patterns: [String],
+        lifetime: TimeInterval = defaultLifetime
+    ) throws -> PreviewToken {
+        try withStoreLock {
+            let createdAt = now()
+            var index = try readIndex()
+            discardExpiredEntries(from: &index, at: createdAt)
+            let token = PreviewToken(
+                value: Self.randomValue(),
+                machineId: machineId,
+                setId: setId,
+                destinations: destinations,
+                configFingerprint: try Self.configFingerprint(config),
+                patterns: patterns,
+                createdAt: createdAt,
+                expiresAt: createdAt.addingTimeInterval(lifetime)
+            )
+            index.tokens[token.value] = token
+            try writeIndex(index)
+            return token
+        }
+    }
+
+    /// Reads a token without consuming it.  Callers must perform every
+    /// repository/config check before invoking ``consume(_:)``.
+    public func token(_ value: String) throws -> PreviewToken {
+        try withStoreLock {
+            let index = try readIndex()
+            guard let token = index.tokens[value] else { throw PreviewTokenError.unknown }
+            if token.expiresAt <= now() { throw PreviewTokenError.expired }
+            if token.usedAt != nil { throw PreviewTokenError.alreadyUsed }
+            return token
+        }
+    }
+
+    /// Atomically-ish records consumption after the caller has revalidated
+    /// the plan, making any later replay fail closed.  The set lock held by
+    /// the engine serializes competing applies for the same set.
+    public func consume(_ value: String) throws -> PreviewToken {
+        try withStoreLock {
+            var index = try readIndex()
+            guard var token = index.tokens[value] else { throw PreviewTokenError.unknown }
+            let consumedAt = now()
+            if token.expiresAt <= consumedAt { throw PreviewTokenError.expired }
+            if token.usedAt != nil { throw PreviewTokenError.alreadyUsed }
+            token.usedAt = consumedAt
+            index.tokens[value] = token
+            discardExpiredEntries(from: &index, at: consumedAt)
+            try writeIndex(index)
+            return token
+        }
+    }
+
+    /// SHA-256 of the canonical persisted configuration bytes.  A full
+    /// config change invalidates a destructive preview rather than trying to
+    /// guess whether the changed field was relevant to an operation.
+    public static func configFingerprint(_ config: AppConfig) throws -> String {
+        let data = try ConfigStore.makeEncoder().encode(config)
+        return SHA256Digest.hex(data)
+    }
+
+    private struct Index: Codable, Sendable {
+        var tokens: [String: PreviewToken] = [:]
+    }
+
+    /// The token index is global to the local machine, while set locks are
+    /// per backup set. This separate lock prevents two previews for different
+    /// sets from losing one another's entries, and makes consume/replay
+    /// behavior single-use even across helper processes.
+    private func withStoreLock<T>(_ body: () throws -> T) throws -> T {
+        do {
+            try paths.ensureDirectories()
+            let lock = FileLock(path: paths.previewTokensLockFile)
+            guard lock.tryAcquire() else { throw PreviewTokenError.unavailable }
+            defer { lock.release() }
+            return try body()
+        } catch let error as PreviewTokenError {
+            throw error
+        } catch {
+            throw PreviewTokenError.unavailable
+        }
+    }
+
+    private func readIndex() throws -> Index {
+        let url = paths.previewTokensFile
+        guard FileManager.default.fileExists(atPath: url.path) else { return Index() }
+        guard Self.isOwnerOnly(url) else { throw PreviewTokenError.unavailable }
+        do {
+            return try ConfigStore.makeDecoder().decode(Index.self, from: Data(contentsOf: url))
+        } catch {
+            throw PreviewTokenError.unavailable
+        }
+    }
+
+    private func writeIndex(_ index: Index) throws {
+        do {
+            try paths.ensureDirectories()
+            let target = paths.previewTokensFile
+            let temp = target.deletingLastPathComponent()
+                .appendingPathComponent(target.lastPathComponent + ".tmp", isDirectory: false)
+            let data = try ConfigStore.makeEncoder().encode(index)
+            try Self.writeOwnerOnly(data, to: temp)
+            try AtomicFile.rename(from: temp, to: target)
+            _ = chmod(target.path, 0o600)
+        } catch {
+            throw PreviewTokenError.unavailable
+        }
+    }
+
+    private func discardExpiredEntries(from index: inout Index, at date: Date) {
+        index.tokens = index.tokens.filter { _, token in
+            token.expiresAt.addingTimeInterval(Self.retentionAfterExpiry) > date
+        }
+    }
+
+    private static func randomValue() -> String {
+        var generator = SystemRandomNumberGenerator()
+        let bytes = (0..<32).map { _ in UInt8.random(in: UInt8.min...UInt8.max, using: &generator) }
+        return Data(bytes)
+            .base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    private static func isOwnerOnly(_ url: URL) -> Bool {
+        guard let attributes = try? FileManager.default.attributesOfItem(atPath: url.path),
+              let mode = attributes[.posixPermissions] as? NSNumber else {
+            return false
+        }
+        return mode.intValue & 0o077 == 0
+    }
+
+    private static func writeOwnerOnly(_ data: Data, to url: URL) throws {
+        let path = url.path
+        _ = unlink(path)
+        let fd = path.withCString { open($0, O_WRONLY | O_CREAT | O_TRUNC, 0o600) }
+        guard fd >= 0 else { throw PreviewTokenError.unavailable }
+        defer {
+            #if canImport(Darwin)
+            _ = Darwin.close(fd)
+            #elseif canImport(Glibc)
+            _ = Glibc.close(fd)
+            #elseif canImport(Musl)
+            _ = Musl.close(fd)
+            #endif
+        }
+        let wroteAll = data.withUnsafeBytes { raw -> Bool in
+            guard var pointer = raw.baseAddress?.assumingMemoryBound(to: UInt8.self) else { return data.isEmpty }
+            var remaining = data.count
+            while remaining > 0 {
+                let written = write(fd, pointer, remaining)
+                if written <= 0 { return false }
+                pointer += written
+                remaining -= written
+            }
+            return true
+        }
+        guard wroteAll, chmod(path, 0o600) == 0 else { throw PreviewTokenError.unavailable }
+    }
+}

--- a/Core/Sources/ResticStationCore/Support/SHA256Digest.swift
+++ b/Core/Sources/ResticStationCore/Support/SHA256Digest.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+/// Minimal dependency-free SHA-256 for fingerprints that must be identical
+/// on macOS and the `swift:6.1` Linux container. The token store needs a
+/// collision-resistant config binding, but Core deliberately has no
+/// swift-crypto package dependency.
+enum SHA256Digest {
+    static func hex(_ data: Data) -> String {
+        digest(data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    static func digest(_ data: Data) -> [UInt8] {
+        var message = Array(data)
+        let bitLength = UInt64(message.count) &* 8
+        message.append(0x80)
+        while message.count % 64 != 56 { message.append(0) }
+        message.append(contentsOf: withUnsafeBytes(of: bitLength.bigEndian, Array.init))
+
+        var state: [UInt32] = [
+            0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
+            0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+        ]
+        for offset in stride(from: 0, to: message.count, by: 64) {
+            var words = Array(repeating: UInt32(0), count: 64)
+            for index in 0..<16 {
+                let start = offset + index * 4
+                words[index] = (UInt32(message[start]) << 24)
+                    | (UInt32(message[start + 1]) << 16)
+                    | (UInt32(message[start + 2]) << 8)
+                    | UInt32(message[start + 3])
+            }
+            for index in 16..<64 {
+                let small0 = rotateRight(words[index - 15], by: 7)
+                    ^ rotateRight(words[index - 15], by: 18) ^ (words[index - 15] >> 3)
+                let small1 = rotateRight(words[index - 2], by: 17)
+                    ^ rotateRight(words[index - 2], by: 19) ^ (words[index - 2] >> 10)
+                words[index] = words[index - 16] &+ small0 &+ words[index - 7] &+ small1
+            }
+
+            var a = state[0], b = state[1], c = state[2], d = state[3]
+            var e = state[4], f = state[5], g = state[6], h = state[7]
+            for index in 0..<64 {
+                let upper1 = rotateRight(e, by: 6) ^ rotateRight(e, by: 11) ^ rotateRight(e, by: 25)
+                let choose = (e & f) ^ ((~e) & g)
+                let temp1 = h &+ upper1 &+ choose &+ constants[index] &+ words[index]
+                let upper0 = rotateRight(a, by: 2) ^ rotateRight(a, by: 13) ^ rotateRight(a, by: 22)
+                let majority = (a & b) ^ (a & c) ^ (b & c)
+                let temp2 = upper0 &+ majority
+                h = g; g = f; f = e; e = d &+ temp1
+                d = c; c = b; b = a; a = temp1 &+ temp2
+            }
+            state[0] &+= a; state[1] &+= b; state[2] &+= c; state[3] &+= d
+            state[4] &+= e; state[5] &+= f; state[6] &+= g; state[7] &+= h
+        }
+        return state.flatMap { withUnsafeBytes(of: $0.bigEndian, Array.init) }
+    }
+
+    private static func rotateRight(_ value: UInt32, by count: UInt32) -> UInt32 {
+        (value >> count) | (value << (32 - count))
+    }
+
+    private static let constants: [UInt32] = [
+        0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+        0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+        0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+        0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+        0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+        0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+        0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+        0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+    ]
+}

--- a/Core/Tests/ResticStationCoreTests/Engine/BackupEngineTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Engine/BackupEngineTests.swift
@@ -92,6 +92,7 @@ struct BackupEngineTests {
         let runStore: RunStore
         let stateStore: StateStore
         let engine: BackupEngine
+        let machineId: String
         let set: BackupSet
         let primary: Destination
         let secondaries: [Destination]
@@ -137,7 +138,8 @@ struct BackupEngineTests {
         startingAt: Date = t0,
         onSpawn: (@Sendable ([String]) -> Void)? = nil,
         purgeSourcePaths: [UUID: Set<String>] = [:],
-        purgeHostnames: [UUID: Set<String>] = [:]
+        purgeHostnames: [UUID: Set<String>] = [:],
+        machineId: String = "example-machine"
     ) -> Env {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("restic-station-engine-\(UUID().uuidString)", isDirectory: true)
@@ -210,7 +212,8 @@ struct BackupEngineTests {
             reachability: Reachability(restic: restic),
             now: clock.now,
             purgeSourcePaths: purgeSourcePaths,
-            purgeHostnames: purgeHostnames
+            purgeHostnames: purgeHostnames,
+            machineId: machineId
         )
 
         return Env(
@@ -221,6 +224,7 @@ struct BackupEngineTests {
             runStore: runStore,
             stateStore: stateStore,
             engine: engine,
+            machineId: machineId,
             set: set,
             primary: primary,
             secondaries: secondaries
@@ -271,6 +275,14 @@ struct BackupEngineTests {
 
     static func forgetArgv(_ repo: String, keepLast: Int = 3) -> [String] {
         ["-r", repo, "forget", "--json", "--keep-last", String(keepLast), "--prune"]
+    }
+
+    static func rewriteArgv(_ repo: String, snapshotIDs: [String], patterns: [String]) -> [String] {
+        var argv = ["-r", repo, "rewrite", "--forget"]
+        for pattern in patterns {
+            argv += ["--exclude", pattern]
+        }
+        return argv + snapshotIDs
     }
 
     static func backupStream() -> [String] {
@@ -778,6 +790,15 @@ struct BackupEngineTests {
         )
         env.fake.script = script
 
+        // This case is about backup argv construction, not the scheduled
+        // purge phase. Seed its already-applied watermark so no additional
+        // repository commands obscure that assertion.
+        try env.stateStore.updateScheduleState(setId: Self.setId) { state in
+            for destination in env.set.destinations {
+                state.appliedPurgeExcludes[destination.id] = Array(expectedExcludes.suffix(2))
+            }
+        }
+
         let outcome = await env.engine.runSet(env.set, trigger: .scheduled)
 
         #expect(env.resticArgvs == [[Self.resticPath] + Self.backupArgv(env.primary.repoURL, excludes: expectedExcludes)])
@@ -1238,6 +1259,210 @@ struct BackupEngineTests {
     }
 
     // MARK: - purge preview
+
+    /// The destructive path starts with an already-reviewed plan. These
+    /// tests deliberately build it from the captured snapshots fixture so
+    /// the only ids a `rewrite --forget` can ever receive are the pure
+    /// attribution result, never a caller-supplied filter.
+    @Test("runPurge: a valid token revalidates ids, records rewrite mapping, and is single-use")
+    func purgeApplyUsesTokenAndRecordsMapping() async throws {
+        let sourcePaths = [Self.setId: Set(["/Users/user/example/src"])]
+        let hostnames = [Self.setId: Set(["example-mac.local"])]
+        let env = Self.makeEnv(
+            script: [], retention: nil, purgeExcludes: ["build/**"], reachableSecondaries: [],
+            purgeSourcePaths: sourcePaths, purgeHostnames: hostnames
+        )
+        defer { env.cleanUp() }
+
+        let snapshotsJSON = try FixtureLoader.string("snapshots.json")
+        let snapshots = try parseSnapshots(Data(snapshotsJSON.utf8))
+        let plan = PurgePlan(
+            destinationId: env.primary.id, snapshots: snapshots,
+            sourcePaths: sourcePaths[Self.setId]!, hostnames: hostnames[Self.setId]!, patterns: env.set.purgeExcludes
+        )
+        let token = try #require(try env.engine.issuePurgeToken(
+            set: env.set, destinations: [env.primary], plans: [plan]
+        ))
+        // A repository can hold snapshots from another backup set. Fresh
+        // validation sees this one, but attribution declines it and its id
+        // must never reach the destructive argv.
+        let foreignSnapshot = "{\"time\":\"2026-07-26T16:57:06Z\",\"id\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"short_id\":\"aaaaaaaa\",\"paths\":[\"/unrelated\"],\"hostname\":\"other-machine\",\"username\":\"other\"}"
+        let snapshotsAtApply = String(snapshotsJSON.trimmingCharacters(in: .whitespacesAndNewlines).dropLast())
+            + ",\(foreignSnapshot)]"
+        let rewrite = try FixtureLoader.string("rewrite-forget.txt")
+            .replacingOccurrences(of: "09b3295c", with: snapshots[0].shortId)
+            .replacingOccurrences(of: "b2435423", with: snapshots[1].shortId)
+        env.fake.script = Self.resticCall(
+            ["-r", env.primary.repoURL, "snapshots", "--json"], dest: Self.primaryId, stdoutLines: [snapshotsAtApply]
+        ) + Self.resticCall(
+            Self.rewriteArgv(env.primary.repoURL, snapshotIDs: snapshots.map(\.id), patterns: env.set.purgeExcludes),
+            dest: Self.primaryId, stdoutLines: rewrite.split(separator: "\n").map(String.init)
+        )
+
+        let result = try await env.engine.runPurge(set: env.set, destinations: [env.primary], token: token.value)
+
+        #expect(result.status == .success)
+        #expect(env.resticArgvs == [
+            [Self.resticPath, "-r", env.primary.repoURL, "snapshots", "--json"],
+            [Self.resticPath] + Self.rewriteArgv(
+                env.primary.repoURL, snapshotIDs: snapshots.map(\.id), patterns: env.set.purgeExcludes
+            ),
+        ])
+        let purgeRun = try #require(env.entries(kind: .purge).first)
+        let metadata = try env.runStore.metadata(runId: purgeRun.runId)
+        #expect(metadata.purgeSnapshotRewrites?[snapshots[0].id] == "14a53542")
+        #expect(metadata.purgeSnapshotRewrites?[snapshots[1].id] == "3ca2e0a5")
+        #expect(!env.log(runId: purgeRun.runId).contains(token.value))
+        #expect(env.resticArgvs.last?.contains("aaaaaaaa") == false)
+
+        do {
+            _ = try await env.engine.runPurge(set: env.set, destinations: [env.primary], token: token.value)
+            Issue.record("a consumed token must be refused")
+        } catch let error as PurgeApplyError {
+            #expect(error == .token(.alreadyUsed))
+        }
+        #expect(env.resticArgvs.count == 2, "a replay must not spawn restic")
+    }
+
+    @Test("runPurge: absent, expired, and changed snapshot-list tokens fail closed")
+    func purgeApplyRefusesInvalidTokens() async throws {
+        let sourcePaths = [Self.setId: Set(["/Users/user/example/src"])]
+        let hostnames = [Self.setId: Set(["example-mac.local"])]
+        let env = Self.makeEnv(
+            script: [], retention: nil, purgeExcludes: ["build/**"], reachableSecondaries: [],
+            purgeSourcePaths: sourcePaths, purgeHostnames: hostnames
+        )
+        defer { env.cleanUp() }
+        let snapshotsJSON = try FixtureLoader.string("snapshots.json")
+        let snapshots = try parseSnapshots(Data(snapshotsJSON.utf8))
+        let plan = PurgePlan(
+            destinationId: env.primary.id, snapshots: snapshots,
+            sourcePaths: sourcePaths[Self.setId]!, hostnames: hostnames[Self.setId]!, patterns: env.set.purgeExcludes
+        )
+
+        do {
+            _ = try await env.engine.runPurge(set: env.set, destinations: [env.primary], token: "")
+            Issue.record("an absent token must be refused")
+        } catch let error as PurgeApplyError {
+            #expect(error == .token(.unknown))
+        }
+
+        let expired = try #require(try env.engine.issuePurgeToken(
+            set: env.set, destinations: [env.primary], plans: [plan]
+        ))
+        env.clock.advance(PreviewTokenStore.defaultLifetime + 1)
+        do {
+            _ = try await env.engine.runPurge(set: env.set, destinations: [env.primary], token: expired.value)
+            Issue.record("an expired token must be refused")
+        } catch let error as PurgeApplyError {
+            #expect(error == .token(.expired))
+        }
+
+        let changed = try #require(try env.engine.issuePurgeToken(
+            set: env.set, destinations: [env.primary], plans: [plan]
+        ))
+        var snapshotObjects = try #require(JSONSerialization.jsonObject(with: Data(snapshotsJSON.utf8)) as? [[String: Any]])
+        snapshotObjects.removeLast()
+        let changedSnapshots = String(
+            decoding: try JSONSerialization.data(withJSONObject: snapshotObjects), as: UTF8.self
+        )
+        env.fake.script = Self.resticCall(
+            ["-r", env.primary.repoURL, "snapshots", "--json"], dest: Self.primaryId, stdoutLines: [changedSnapshots]
+        )
+        do {
+            _ = try await env.engine.runPurge(set: env.set, destinations: [env.primary], token: changed.value)
+            Issue.record("a changed snapshot list must be refused")
+        } catch let error as PurgeApplyError {
+            #expect(error == .tokenDoesNotMatchCurrentPlan)
+        }
+        #expect(env.resticArgvs == [[Self.resticPath, "-r", env.primary.repoURL, "snapshots", "--json"]])
+        #expect(env.entries(kind: .purge).isEmpty, "failed validation cannot create a purge run")
+    }
+
+    @Test("row purge 1: scheduled primary and stale secondary purge before copy exactly once")
+    func automaticPurgePrecedesCopy() async throws {
+        let sourcePaths = [Self.setId: Set(["/Users/user/example/src"])]
+        let hostnames = [Self.setId: Set(["example-mac.local"])]
+        let env = Self.makeEnv(
+            script: [], retention: nil, purgeExcludes: ["build/**"], reachableSecondaries: [true],
+            purgeSourcePaths: sourcePaths, purgeHostnames: hostnames
+        )
+        defer { env.cleanUp() }
+        let snapshotsJSON = try FixtureLoader.string("snapshots.json")
+        let snapshots = try parseSnapshots(Data(snapshotsJSON.utf8))
+        let rewrite = try FixtureLoader.string("rewrite-forget.txt")
+            .replacingOccurrences(of: "09b3295c", with: snapshots[0].shortId)
+            .replacingOccurrences(of: "b2435423", with: snapshots[1].shortId)
+        let rewriteLines = rewrite.split(separator: "\n").map(String.init)
+        let secondary = env.secondaries[0]
+        env.fake.script = Self.resticCall(Self.backupArgv(env.primary.repoURL, excludes: env.set.purgeExcludes), dest: Self.primaryId, stdoutLines: Self.backupStream())
+            + Self.resticCall(["-r", env.primary.repoURL, "snapshots", "--json"], dest: Self.primaryId, stdoutLines: [snapshotsJSON])
+            + Self.resticCall(["-r", env.primary.repoURL, "snapshots", "--json"], dest: Self.primaryId, stdoutLines: [snapshotsJSON])
+            + Self.resticCall(Self.rewriteArgv(env.primary.repoURL, snapshotIDs: snapshots.map(\.id), patterns: env.set.purgeExcludes), dest: Self.primaryId, stdoutLines: rewriteLines)
+            + Self.resticCall(["-r", secondary.repoURL, "snapshots", "--json"], dest: secondary.id, stdoutLines: [snapshotsJSON])
+            + Self.resticCall(["-r", secondary.repoURL, "snapshots", "--json"], dest: secondary.id, stdoutLines: [snapshotsJSON])
+            + Self.resticCall(Self.rewriteArgv(secondary.repoURL, snapshotIDs: snapshots.map(\.id), patterns: env.set.purgeExcludes), dest: secondary.id, stdoutLines: rewriteLines)
+            + Self.resticCall(Self.copyArgv(to: secondary.repoURL, from: env.primary.repoURL), dest: secondary.id, from: env.primary.id)
+
+        let outcome = await env.engine.runSet(env.set, trigger: .scheduled)
+
+        let expectedArgvs: [[String]] = [
+            [Self.resticPath] + Self.backupArgv(env.primary.repoURL, excludes: env.set.purgeExcludes),
+            [Self.resticPath, "-r", env.primary.repoURL, "snapshots", "--json"],
+            [Self.resticPath, "-r", env.primary.repoURL, "snapshots", "--json"],
+            [Self.resticPath] + Self.rewriteArgv(env.primary.repoURL, snapshotIDs: snapshots.map(\.id), patterns: env.set.purgeExcludes),
+            [Self.resticPath, "-r", secondary.repoURL, "snapshots", "--json"],
+            [Self.resticPath, "-r", secondary.repoURL, "snapshots", "--json"],
+            [Self.resticPath] + Self.rewriteArgv(secondary.repoURL, snapshotIDs: snapshots.map(\.id), patterns: env.set.purgeExcludes),
+            [Self.resticPath] + Self.copyArgv(to: secondary.repoURL, from: env.primary.repoURL),
+        ]
+        #expect(env.resticArgvs == expectedArgvs)
+        guard case .completed(let status, _, let children) = outcome else {
+            Issue.record("expected .completed, got \(outcome)")
+            return
+        }
+        #expect(status == .success)
+        #expect(children.map(\.kind) == [.backup, .purge, .purge, .copy])
+        let applied = env.stateStore.readScheduleState()?.sets[Self.setId]?.appliedPurgeExcludes
+        #expect(applied?[env.primary.id] == env.set.purgeExcludes)
+        #expect(applied?[secondary.id] == env.set.purgeExcludes)
+    }
+
+    @Test("row purge 2: a stale secondary whose purge fails is never copied or marked applied")
+    func failedSecondaryPurgeSkipsCopy() async throws {
+        let sourcePaths = [Self.setId: Set(["/Users/user/example/src"])]
+        let hostnames = [Self.setId: Set(["example-mac.local"])]
+        let env = Self.makeEnv(
+            script: [], retention: nil, purgeExcludes: ["build/**"], reachableSecondaries: [true],
+            purgeSourcePaths: sourcePaths, purgeHostnames: hostnames
+        )
+        defer { env.cleanUp() }
+        let snapshotsJSON = try FixtureLoader.string("snapshots.json")
+        let snapshots = try parseSnapshots(Data(snapshotsJSON.utf8))
+        let rewrite = try FixtureLoader.string("rewrite-forget.txt")
+            .replacingOccurrences(of: "09b3295c", with: snapshots[0].shortId)
+            .replacingOccurrences(of: "b2435423", with: snapshots[1].shortId)
+        let secondary = env.secondaries[0]
+        env.fake.script = Self.resticCall(Self.backupArgv(env.primary.repoURL, excludes: env.set.purgeExcludes), dest: Self.primaryId, stdoutLines: Self.backupStream())
+            + Self.resticCall(["-r", env.primary.repoURL, "snapshots", "--json"], dest: Self.primaryId, stdoutLines: [snapshotsJSON])
+            + Self.resticCall(["-r", env.primary.repoURL, "snapshots", "--json"], dest: Self.primaryId, stdoutLines: [snapshotsJSON])
+            + Self.resticCall(Self.rewriteArgv(env.primary.repoURL, snapshotIDs: snapshots.map(\.id), patterns: env.set.purgeExcludes), dest: Self.primaryId, stdoutLines: rewrite.split(separator: "\n").map(String.init))
+            + Self.resticCall(["-r", secondary.repoURL, "snapshots", "--json"], dest: secondary.id, stdoutLines: [snapshotsJSON])
+            + Self.resticCall(["-r", secondary.repoURL, "snapshots", "--json"], dest: secondary.id, stdoutLines: [snapshotsJSON])
+            + Self.resticCall(Self.rewriteArgv(secondary.repoURL, snapshotIDs: snapshots.map(\.id), patterns: env.set.purgeExcludes), dest: secondary.id, stderr: "rewrite failed", exitCode: 1)
+
+        let outcome = await env.engine.runSet(env.set, trigger: .scheduled)
+
+        guard case .completed(let status, _, _) = outcome else {
+            Issue.record("expected .completed, got \(outcome)")
+            return
+        }
+        #expect(status == .failed)
+        #expect(env.resticArgvs.allSatisfy { !$0.contains("copy") })
+        let applied = env.stateStore.readScheduleState()?.sets[Self.setId]?.appliedPurgeExcludes
+        #expect(applied?[env.primary.id] == env.set.purgeExcludes)
+        #expect(applied?[secondary.id] == nil)
+    }
 
     @Test("previewPurge: snapshots then rewrite dry-run only, with explicit attributed ids")
     func purgePreviewIsReadOnly() async throws {

--- a/Core/Tests/ResticStationCoreTests/Support/CLIErrorTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Support/CLIErrorTests.swift
@@ -50,12 +50,12 @@ private let representative: [CLIErrorCode: CLIFailure] = [
     ),
     .resticFailed: .classify(exitClass: .fatal(stderrSummary: "repository is damaged")),
     .operationTimedOut: .classify(ResticRunnerError.timedOut),
+    .previewExpired: .classifyPurgeApply(PurgeApplyError.token(.expired), setId: setId),
     .internalError: .classify(ConfigStoreError.renameFailed(errno: 13, from: "a", to: "b")),
-    // These two have no typed error yet: `repositoryOffline` is produced by
-    // a `Reachability` *result* (#79 wires it), and `operationNotAllowed` by
-    // engine invariants that today refuse before throwing. Constructed
-    // directly and deliberately, so `everyCodeIsReachable` stays meaningful
-    // for the rest.
+    // `repositoryOffline` is a `Reachability` result rather than an Error,
+    // so this representative remains direct. `operationNotAllowed` is also
+    // reachable from `PurgeApplyError`, but stays direct here because the
+    // public code-table test deliberately does not import an engine fixture.
     .repositoryOffline: CLIFailure(
         code: .repositoryOffline,
         message: "The destination did not answer.",
@@ -103,9 +103,10 @@ struct CLIErrorContractTests {
         #expect(CLIErrorCode.resticUnsupported.rawValue == "restic_unsupported")
         #expect(CLIErrorCode.resticFailed.rawValue == "restic_failed")
         #expect(CLIErrorCode.operationTimedOut.rawValue == "operation_timed_out")
+        #expect(CLIErrorCode.previewExpired.rawValue == "preview_expired")
         #expect(CLIErrorCode.operationNotAllowed.rawValue == "operation_not_allowed")
         #expect(CLIErrorCode.internalError.rawValue == "internal_error")
-        #expect(CLIErrorCode.allCases.count == 20)
+        #expect(CLIErrorCode.allCases.count == 21)
     }
 
     @Test("only busy and offline leave exit 1 — the coarse shell contract is unchanged")
@@ -137,12 +138,26 @@ struct CLIErrorContractTests {
         #expect(rejected.code == .secretRejected)
         #expect(!rejected.retryable)
         #expect(CLIErrorCode.secretUnavailable.retryable)
+        #expect(!CLIErrorCode.previewExpired.retryable)
         // And a destination whose password was never stored: the backend
         // answered, the answer will not change on its own, and a caller
         // told `retryable: true` would loop until a human runs `secret set`.
         let missing = CLIFailure.classify(SecretStoreError.itemNotFound)
         #expect(missing.code == .secretNotConfigured)
         #expect(!missing.retryable)
+    }
+
+    @Test("purge token refusals use safe, actionable envelope codes")
+    func purgeTokenClassification() {
+        let expired = CLIFailure.classifyPurgeApply(PurgeApplyError.token(.expired), setId: setId)
+        #expect(expired.code == .previewExpired)
+        #expect(expired.details.setId == setId)
+        #expect(!expired.retryable)
+
+        let stale = CLIFailure.classifyPurgeApply(PurgeApplyError.tokenDoesNotMatchCurrentPlan, setId: setId)
+        #expect(stale.code == .operationNotAllowed)
+        #expect(stale.details.setId == setId)
+        #expect(!stale.message.contains("token"), "capabilities never appear in an envelope")
     }
 }
 

--- a/Core/Tests/ResticStationCoreTests/Support/PreviewTokenTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Support/PreviewTokenTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Testing
+@testable import ResticStationCore
+
+@Suite("PreviewTokenStore")
+struct PreviewTokenStoreTests {
+    private final class Clock: @unchecked Sendable {
+        private let lock = NSLock()
+        private var date: Date
+
+        init(_ date: Date) { self.date = date }
+
+        var now: @Sendable () -> Date {
+            { [self] in
+                lock.lock()
+                defer { lock.unlock() }
+                return date
+            }
+        }
+
+        func advance(_ interval: TimeInterval) {
+            lock.lock()
+            date = date.addingTimeInterval(interval)
+            lock.unlock()
+        }
+    }
+
+    @Test("SHA-256 config fingerprint primitive matches published vectors")
+    func sha256Vectors() {
+        #expect(SHA256Digest.hex(Data()) == "e3b0c44298fc1c149afbf4c8996fb924"
+            + "27ae41e4649b934ca495991b7852b855")
+        #expect(SHA256Digest.hex(Data("abc".utf8)) == "ba7816bf8f01cfea414140de5dae2223"
+            + "b00361a396177a9cb410ff61f20015ad")
+    }
+
+    @Test("tokens are random, owner-only, scoped, expiring, and single-use")
+    func lifecycle() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("restic-station-preview-token-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let paths = AppPaths(root: root)
+        let clock = Clock(Date(timeIntervalSince1970: 1_784_000_000))
+        let store = PreviewTokenStore(paths: paths, now: clock.now)
+        let setId = UUID()
+        let destinationId = UUID()
+        let config = AppConfig(resticPath: "/opt/homebrew/bin/restic", sets: [])
+
+        let token = try store.issue(
+            machineId: "example-machine",
+            setId: setId,
+            destinations: [PreviewTokenDestination(destinationId: destinationId, snapshotIDs: ["b", "a"])],
+            config: config,
+            patterns: ["DerivedData"]
+        )
+
+        #expect(token.value.count >= 43, "a URL-safe encoding of 256 random bits")
+        #expect(token.destinations[0].snapshotIDs == ["a", "b"])
+        #expect(token.expiresAt == clock.now().addingTimeInterval(PreviewTokenStore.defaultLifetime))
+        let attributes = try FileManager.default.attributesOfItem(atPath: paths.previewTokensFile.path)
+        let mode = try #require(attributes[.posixPermissions] as? NSNumber)
+        #expect(mode.intValue & 0o777 == 0o600)
+        #expect(try store.token(token.value) == token)
+
+        _ = try store.consume(token.value)
+        #expect(throws: PreviewTokenError.alreadyUsed) { try store.token(token.value) }
+
+        let expiring = try store.issue(
+            machineId: "example-machine",
+            setId: setId,
+            destinations: [PreviewTokenDestination(destinationId: destinationId, snapshotIDs: [])],
+            config: config,
+            patterns: ["DerivedData"],
+            lifetime: 1
+        )
+        clock.advance(1)
+        #expect(throws: PreviewTokenError.expired) { try store.token(expiring.value) }
+    }
+}

--- a/Helper/Sources/Commands/Purge.swift
+++ b/Helper/Sources/Commands/Purge.swift
@@ -2,13 +2,11 @@ import ArgumentParser
 import Foundation
 import ResticStationCore
 
-/// `purge preview` is intentionally the only purge surface in #87.  Apply is
-/// introduced later, behind a preview token, in #88.
 struct Purge: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "purge",
         abstract: "Inspect snapshots that purge exclusions would rewrite.",
-        subcommands: [PurgePreview.self]
+        subcommands: [PurgePreview.self, PurgeApply.self]
     )
 }
 
@@ -54,13 +52,22 @@ struct PurgePreview: AsyncParsableCommand, JSONRenderable {
         let unattributed: [SnapshotReport]
         let rewriteOutput: String?
         let message: String?
+        /// One capability shared by every destination in this preview. It is
+        /// intentionally data (a human must carry it to `purge apply`), not
+        /// an error detail or a run-record field.
+        let previewToken: String?
 
         private enum CodingKeys: String, CodingKey {
             case setId, destinationId, label, status, patterns, matched, changed
-            case unattributed, rewriteOutput, message
+            case unattributed, rewriteOutput, message, previewToken
         }
 
-        init(setId: UUID, destination: Destination, result: PurgePlanResult) {
+        init(
+            setId: UUID,
+            destination: Destination,
+            result: PurgePlanResult,
+            previewToken: String?
+        ) {
             self.setId = setId
             self.destinationId = destination.id
             self.label = destination.label
@@ -71,6 +78,7 @@ struct PurgePreview: AsyncParsableCommand, JSONRenderable {
             self.unattributed = result.plan.unattributed.map(SnapshotReport.init)
             self.rewriteOutput = result.rewrite?.rawOutput
             self.message = result.message
+            self.previewToken = previewToken
         }
 
         // The optional fields are part of a reported payload, so they are
@@ -87,6 +95,7 @@ struct PurgePreview: AsyncParsableCommand, JSONRenderable {
             try container.encode(unattributed, forKey: .unattributed)
             try container.encode(rewriteOutput, forKey: .rewriteOutput)
             try container.encode(message, forKey: .message)
+            try container.encode(previewToken, forKey: .previewToken)
         }
     }
 
@@ -106,11 +115,19 @@ struct PurgePreview: AsyncParsableCommand, JSONRenderable {
             destinations = backupSet.destinations
         }
 
-        var reports: [Report] = []
+        var results: [(destination: Destination, result: PurgePlanResult)] = []
         for destination in destinations {
             let result = await context.engine.previewPurge(set: backupSet, destination: destination)
             try Self.validate(result: result, setId: set, destination: destination)
-            reports.append(Report(setId: set, destination: destination, result: result))
+            results.append((destination, result))
+        }
+        let previewToken = try context.engine.issuePurgeToken(
+            set: backupSet,
+            destinations: results.map(\.destination),
+            plans: results.map { $0.result.plan }
+        )?.value
+        let reports = results.map {
+            Report(setId: set, destination: $0.destination, result: $0.result, previewToken: previewToken)
         }
 
         if json {
@@ -168,9 +185,106 @@ struct PurgePreview: AsyncParsableCommand, JSONRenderable {
                 }
             }
             print("  space is not reclaimed until a prune runs")
+            if let previewToken = report.previewToken {
+                print("  apply with: purge apply --set \(report.setId.uuidString) --preview-token \(previewToken)")
+            }
         case .busy, .offline, .failed:
             // These states are rejected before a report is printed.
             break
         }
+    }
+}
+
+/// The token-gated destructive half of purge. There is intentionally no
+/// force/yes/environment bypass: `BackupEngine` refuses every request that
+/// is not bound to a successful, current preview.
+struct PurgeApply: AsyncParsableCommand, JSONRenderable {
+    static let configuration = CommandConfiguration(
+        commandName: "apply",
+        abstract: "Apply a reviewed purge preview token."
+    )
+
+    @Option(name: .long, help: "The backup set's UUID.")
+    var set: UUID
+
+    @Option(name: .long, help: "The short-lived token returned by purge preview.")
+    var previewToken: String
+
+    @Flag(name: .long, help: "Emit JSON. Only JSON reaches stdout in this mode.")
+    var json = false
+
+    private struct ChildReport: Encodable {
+        let runId: String
+        let kind: RunKind
+        let destinationId: UUID
+        let status: RunStatus
+    }
+
+    private struct Report: Encodable {
+        let setId: UUID
+        let status: RunStatus
+        let children: [ChildReport]
+    }
+
+    func run() async throws {
+        let context = try await HelperContext.make()
+        guard let backupSet = context.addressable.set(id: set) else {
+            throw CLIFailure.setNotFound(setId: set)
+        }
+
+        let destinationIDs: [UUID]
+        do {
+            destinationIDs = try context.engine.purgeTokenDestinationIDs(previewToken)
+        } catch {
+            throw CLIFailure.classifyPurgeApply(error, setId: set)
+        }
+        let destinations = destinationIDs.compactMap { id in
+            backupSet.destinations.first(where: { $0.id == id })
+        }
+        guard destinations.count == destinationIDs.count else {
+            throw CLIFailure(
+                code: .operationNotAllowed,
+                message: "The purge preview does not match the current backup set.",
+                details: CLIErrorDetails(setId: set)
+            )
+        }
+
+        let result: PurgeRunResult
+        do {
+            result = try await context.engine.runPurge(
+                set: backupSet,
+                destinations: destinations,
+                token: previewToken
+            )
+        } catch {
+            throw CLIFailure.classifyPurgeApply(error, setId: set)
+        }
+
+        guard result.status == .success else {
+            throw CLIFailure(
+                code: .resticFailed,
+                message: "Purge failed. See the run record for details.",
+                details: CLIErrorDetails(
+                    setId: set,
+                    diagnosticReference: result.children.first?.runId
+                )
+            )
+        }
+
+        let report = Report(
+            setId: set,
+            status: result.status,
+            children: result.children.map {
+                ChildReport(runId: $0.runId, kind: $0.kind, destinationId: $0.destId, status: $0.status)
+            }
+        )
+        if json {
+            CLIJSON.print(report)
+        } else if result.children.isEmpty {
+            print("purge completed: no attributed snapshots needed rewriting")
+        } else {
+            print("purge \(result.status.rawValue): \(result.children.count) destination(s) processed")
+        }
+        HelperExit.code(0)
     }
 }

--- a/Helper/Sources/HelperContext.swift
+++ b/Helper/Sources/HelperContext.swift
@@ -188,7 +188,8 @@ struct HelperContext {
             stateStore: stateStore,
             reachability: reachability,
             purgeSourcePaths: purgeSourcePaths,
-            purgeHostnames: purgeHostnames
+            purgeHostnames: purgeHostnames,
+            machineId: views.addressable.machineId
         )
         return .ready(HelperContext(
             paths: paths,

--- a/Helper/Tests/HelperTests/SubcommandRegistrationTests.swift
+++ b/Helper/Tests/HelperTests/SubcommandRegistrationTests.swift
@@ -104,6 +104,13 @@ import Testing
     #expect(names == ["list", "show"])
 }
 
+@Test func purgeExposesPreviewAndTokenGatedApply() {
+    let names: [String?] = Purge.configuration.subcommands.map { subcommand in
+        subcommand.configuration.commandName
+    }
+    #expect(names == ["preview", "apply"])
+}
+
 /// T28 (issue #30): the `restic-station` PATH symlink manager.
 @Test func cliExposesItsThreeSubcommands() {
     let names: [String?] = Cli.configuration.subcommands.map { subcommand in

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,12 +28,12 @@ Secrets: macOS login Keychain (service "restic-station")
 ```
 
 1. **`ResticStationCore`** — local Swift package at `Core/`. Contains **all** logic: config model + store, keychain client, restic runner + command builders + parsers, restic discovery, schedule math, run store, file locking, backup engine, reachability, state store. No UI. Depends only on Foundation (+ swift-argument-parser is *not* here; it's a Helper dependency). `Package.swift` declares `platforms: [.macOS(.v14)]` so `swift test --package-path Core` works standalone.
-2. **`restic-station-helper`** — command-line executable target, embedded in the app bundle at `Contents/MacOS/restic-station-helper`. Uses swift-argument-parser. Subcommands: `tick`, `run-set`, `init-secondary`, `restore`, `probe-repo`, `unlock`, `fda-check`, `secret`, `config`, `status`, `sets`, `runs`, `timer` (Linux only), `version`. Each invocation does its work and **exits** — it never daemonizes. launchd re-fires it via `StartInterval`; on Linux a systemd `--user` timer does (`timer install`, T26). The last four (`config`, `status`, `sets`, `runs`, T27) are the headless CLI surface: on Linux, where there is no app, they are the entire user interface for moving a shared `config.json` between machines and observing what happened; they are available and identical on macOS too.
+2. **`restic-station-helper`** — command-line executable target, embedded in the app bundle at `Contents/MacOS/restic-station-helper`. Uses swift-argument-parser. Subcommands: `tick`, `run-set`, `purge preview`/token-gated `purge apply`, `init-secondary`, `restore`, `probe-repo`, `unlock`, `fda-check`, `secret`, `config`, `status`, `sets`, `runs`, `timer` (Linux only), `version`. Each invocation does its work and **exits** — it never daemonizes. launchd re-fires it via `StartInterval`; on Linux a systemd `--user` timer does (`timer install`, T26). The last four (`config`, `status`, `sets`, `runs`, T27) are the headless CLI surface: on Linux, where there is no app, they are the entire user interface for moving a shared `config.json` between machines and observing what happened; they are available and identical on macOS too.
 3. **`Restic Station.app`** — SwiftUI app. Regular app (Dock icon + windows) plus a `MenuBarExtra`. Registers the helper's LaunchAgent via `SMAppService`.
 
 ## The single-code-path rule
 
-**Every restic operation that mutates a repository goes through the helper binary.** The app never runs `restic backup`, `copy`, `forget`, `restore`, `init`, or `unlock` itself — for manual actions ("Back Up Now", restore, prune-now, init-secondary) it spawns the embedded helper with the corresponding subcommand. This guarantees identical behavior for scheduled and manual runs: same locking, same run recording, same state updates.
+**Every restic operation that mutates a repository goes through the helper binary.** The app never runs `restic backup`, `copy`, `forget`, `rewrite --forget`, `restore`, `init`, or `unlock` itself — for manual actions ("Back Up Now", restore, purge, prune-now, init-secondary) it spawns the embedded helper with the corresponding subcommand. This guarantees identical behavior for scheduled and manual runs: same locking, same run recording, same state updates. `rewrite --forget` has an additional boundary: it is reachable only through `BackupEngine.runPurge`, using explicit snapshot ids revalidated from a short-lived, single-use local preview token.
 
 **The one sanctioned exception:** the app MAY execute **read-only** restic queries directly (`snapshots`, `ls`, `find`, `stats`, `cat config`, `version`) for interactive browsing in the Restore and Maintenance screens, using the same `ResticRunner` from Core. Read-only queries take no repository lock that matters and produce no run records.
 
@@ -155,6 +155,7 @@ State — not config — is the right XDG base dir for `root`: `config.json` is 
 | `runs/<runId>/log.txt` | full streamed log of the run |
 | `runs/index.jsonl` | append-only, one summary JSON line per finished run |
 | `state/schedule-state.json` | last-start times + check-slice cursors per set |
+| `state/preview-tokens.json` | owner-only (`0600`) short-lived destructive-preview capabilities; never copied into runs or logs |
 | `state/current-run-<setId>.json` | live progress plus an independent 30-second awake-time heartbeat (deleted on completion) |
 | `state/repo-status-<destId>.json` | reachability + last-synced info per destination |
 | `state/fda-check.json` | result of the helper's Full Disk Access probe |

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -56,6 +56,7 @@ itself, unwrapped, because its output is meant to be fed straight back into
 | `cli status` | ✅ | `CLIInstaller.Status` |
 | `fda-check` | ✅ | `{ applicable, granted, probedPath, checkedAt, context }` |
 | `purge preview` | ✅ | array of per-destination purge plans: matched/changed/unattributed snapshots and patterns |
+| `purge apply` | ✅ | `{ setId, status, children }` for the token-gated destructive purge |
 | `config export` | — | **Unwrapped by design.** The exported config document itself, so it round-trips into `config import`. |
 | `timer status` (Linux) | — | **Human-only.** Its report is narrative assembled while probing; the machine-readable equivalent is `status --json`'s `.scheduler`, in the same problem vocabulary. |
 | `print-password` | — | Hidden; exists for `RESTIC_PASSWORD_COMMAND` and writes a secret to stdout. |
@@ -115,6 +116,7 @@ never match on it. `details` is omitted entirely when empty.
 | `restic_unsupported` | no | 1 | A restic was found and ran, but is below the minimum or is not restic. |
 | `restic_failed` | no | 1 | restic ran and failed. |
 | `operation_timed_out` | **yes** | 1 | The operation exceeded the caller's timeout and was stopped; restic never reported. A stalled network or a spinning-up remote clears on its own. |
+| `preview_expired` | no | 1 | A destructive preview token has expired. Run a fresh preview; the old token can never be applied. |
 | `operation_not_allowed` | no | 1 | Refused by a safety invariant — `forget` with an empty retention policy, `prune` on a mirror behind its primary (`architecture.md` §Invariants). |
 | `internal_error` | no | 1 | An unexpected failure. Bounded; never a serialized object description. |
 
@@ -271,9 +273,9 @@ arrive:
 
 - **`config_missing`** — a missing `config.json` is not an error.
   `ConfigStore.load()` returns an empty `AppConfig`.
-- **`preview_required` / `preview_expired` / `preview_stale` /
-  `preview_already_used`** — the preview-token mechanism lands with #82/#88;
-  the codes land with it.
+- **`preview_required` / `preview_stale` / `preview_already_used`** — these
+  may be useful for a future preview-token operation, but no current path
+  produces them. `preview_expired` is defined above because purge does.
 - **`cloud_repository_not_hydrated`** — no detector exists. Inferring it would
   mean matching restic's English stderr, which is exactly the practice this
   contract exists to stop.

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -290,11 +290,11 @@ Secret-env item is optional (absent for local/sftp destinations without credenti
 {"runId":"20260726T205704Z-backup-6f9619ff","kind":"backup","setId":"6F9619FF-...","destId":"0A1B2C3D-...","status":"success","start":"2026-07-26T20:57:04Z","end":"2026-07-26T20:58:11Z","trigger":"scheduled","snapshotId":"f391ba97c096...","filesNew":3,"filesChanged":1,"dataAdded":67860,"errorSummary":null}
 ```
 
-`kind`: `backup` | `copy` | `check` | `prune` | `restore` | `init`. A scheduled set run produces **multiple** index lines: one `backup` (primary), one `copy` per attempted secondary, one `prune` per repo where retention ran. They share a `groupId` field (= the backup's runId) so the UI can nest them.
+`kind`: `backup` | `copy` | `check` | `prune` | `purge` | `restore` | `init`. A scheduled set run produces **multiple** index lines: one `backup` (primary), an optional `purge` per destination with newly added `purgeExcludes`, one `copy` per attempted secondary, one `prune` per repo where retention ran. They share a `groupId` field (= the backup's runId) so the UI can nest them.
 
 ## runs/<runId>/metadata.json — `RunMetadata`
 
-Superset of the index line, plus: `pid`, `resticExitCode`, `argvRedacted` (argv with env not included), `stats` (full decoded summary message where applicable), `groupId`. Written once at start (`status: "running"`, no `end`) and atomically rewritten on completion.
+Superset of the index line, plus: `pid`, `resticExitCode`, `argvRedacted` (argv with env not included), `stats` (full decoded summary message where applicable), `groupId`. A successful `purge` run additionally carries `purgeSnapshotRewrites`, an old full snapshot id → new snapshot id mapping. It is an audit record only: older run records continue to name their historical snapshot ids. Written once at start (`status: "running"`, no `end`) and atomically rewritten on completion.
 
 ## state/schedule-state.json
 
@@ -304,13 +304,16 @@ Superset of the index line, plus: `pid`, `resticExitCode`, `argvRedacted` (argv 
     "6F9619FF-...": {
       "lastBackupStart": "2026-07-26T20:57:04Z",
       "lastCheckStart": "2026-07-20T03:00:00Z",
-      "checkSliceCursor": 7
+      "checkSliceCursor": 7,
+      "appliedPurgeExcludes": {
+        "0A1B2C3D-...": ["DerivedData"]
+      }
     }
   }
 }
 ```
 
-`lastBackupStart` is the *start* time of the last **attempted** scheduled backup (success or failure) — due-computation keys off attempts, so a failing set retries at its next slot, not every tick. Manual runs also update it (a manual backup satisfies the schedule). `checkSliceCursor` is the `n` most recently used in `--read-data-subset=n/t`.
+`lastBackupStart` is the *start* time of the last **attempted** scheduled backup (success or failure) — due-computation keys off attempts, so a failing set retries at its next slot, not every tick. Manual runs also update it (a manual backup satisfies the schedule). `checkSliceCursor` is the `n` most recently used in `--read-data-subset=n/t`. `appliedPurgeExcludes` records, per destination UUID, only patterns whose `rewrite --forget` child succeeded. Removing a pattern never removes it from this watermark: history cannot be restored, and a smaller list must not trigger a pointless rewrite.
 
 ## state/repo-status-<destId>.json
 
@@ -345,7 +348,7 @@ Superset of the index line, plus: `pid`, `resticExitCode`, `argvRedacted` (argv 
 }
 ```
 
-`phase`: `probing` | `backing-up-primary` | `copying-<destId>` | `retention` | `checking`.
+`phase`: `probing` | `backing-up-primary` | `purging-<destId>` | `copying-<destId>` | `retention` | `checking`.
 
 **Presence does not mean "running".** The file is deleted by a `defer` at the
 end of every run, so a `SIGKILL`, an OOM kill or a power cut leaves it behind

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -282,6 +282,26 @@ Rules (anacron semantics):
 
 **Check scheduling:** fixed weekly cadence. `checkIsDue` = `lastCheckStart == nil || now − lastCheckStart ≥ 7 days`, evaluated only when no backup for the same set is due in the same tick (backup wins; check runs on a later tick). Each scheduled check uses `--read-data-subset=<cursor+1 mod t>/<t>` against the **primary**, advancing `checkSliceCursor` on success only. Secondaries are checked structure-only (no `--read-data-subset`) every 4th check *if reachable*.
 
+## Purge-exclusion ordering
+
+When a set has a `purgeExcludes` pattern absent from a destination's
+`appliedPurgeExcludes` state, the next successful backup run adds a purge
+phase. The fixed order is:
+
+1. back up the primary with the effective forward excludes;
+2. purge the primary with `rewrite --forget` over newly attributed snapshot
+   ids;
+3. for each reachable secondary, purge it first when stale, then copy from
+   the primary;
+4. run ordinary retention only where its existing freshness rules permit it.
+
+The primary purge failure stops mirroring. A secondary purge failure skips
+that secondary's copy but allows another mirror to proceed. Copying into an
+unpurged secondary would leave its old snapshots alongside the primary's
+rewritten replacements, so it is never allowed. The per-destination pattern
+watermark advances only after that destination's purge child succeeds; a
+removed pattern stays recorded and is never used to trigger a rewrite.
+
 ## Locking
 
 Two levels, both `flock(2)` `LOCK_EX | LOCK_NB` on files under `locks/` (advisory; auto-released by the kernel on process death — no stale-lock cleanup needed; the files themselves persist, their existence means nothing):

--- a/scripts/headless-cli-test.sh
+++ b/scripts/headless-cli-test.sh
@@ -722,6 +722,21 @@ for CMD in "status" "sets list" "config show" "secret list"; do
 done
 ok "every --json command reports an unloadable config.json as config_invalid, exit 1"
 
+# Purge has required operands, so it cannot share the no-argument loop
+# above. These two calls pin the setup path instead: `HelperContext.make()`
+# must surface a broken config as the usual envelope before a read-only
+# preview or a token-gated apply can touch a repository.
+for CMD in \
+    "purge preview --set 6F9619FF-8B86-D011-B42D-00C04FC964FF" \
+    "purge apply --set 6F9619FF-8B86-D011-B42D-00C04FC964FF --preview-token deliberately-invalid"; do
+    # shellcheck disable=SC2086
+    RESTIC_STATION_DATA_DIR="$ENVELOPE_DATA" run_helper_split $CMD --json
+    expect_rc 1
+    jq -e '.ok == false and .error.code == "config_invalid"' "$OUT_FILE" >/dev/null \
+        || fail "\`$CMD --json\` on a broken config did not emit config_invalid"
+done
+ok "purge preview/apply --json preserve the setup-failure envelope"
+
 # `config validate --json` has a second setup failure of its own: with no
 # `--machine`, the answer comes from this host's `machine.json`, and an
 # unreadable one used to exit with prose rather than an envelope. The config


### PR DESCRIPTION
Implements #88.

- Adds owner-only, expiring, single-use preview capabilities bound to machine/config/destinations/exact snapshot IDs.
- Applies `rewrite --forget` only after fresh attribution validation; records old-to-new snapshot mapping.
- Purges primary before mirror copies and skips a stale secondary when its purge cannot succeed.
- Adds `purge apply --set --preview-token [--json]`, JSON error classification, docs, UI run presentation, and regression coverage.

Validation:
- `./scripts/local-ci.sh` (all eight macOS/headless checks passed; local Linux cross-compile skipped because its SDK is not installed)
- real restic 0.19.1 rewrite --forget smoke test in a disposable `/tmp` repo