### PR TITLE
Fix standalone prune review follow-ups

### DIFF
--- a/App/Sources/Support/HelperInvoker.swift
+++ b/App/Sources/Support/HelperInvoker.swift
@@ -60,12 +60,12 @@ public struct HelperInvoker: Sendable {
         setId: UUID,
         destId: UUID?,
         dryRun: Bool,
-        expectedRepository: String? = nil
+        expectedDestination: String? = nil
     ) async -> HelperResult {
         await run(.maintenancePrune(
             setId: setId,
             destId: destId,
-            expectedRepository: expectedRepository,
+            expectedDestination: expectedDestination,
             dryRun: dryRun
         ))
     }

--- a/App/Sources/Support/HelperInvoker.swift
+++ b/App/Sources/Support/HelperInvoker.swift
@@ -70,6 +70,33 @@ public struct HelperInvoker: Sendable {
         ))
     }
 
+    /// Runs the non-mutating reclaim preview and decodes the opaque binding
+    /// that only the helper can construct from the effective destination and
+    /// its secret environment. Confirmation returns that binding to the
+    /// helper, which revalidates it after reloading configuration.
+    func previewReclaimSpace(setId: UUID, destId: UUID) async -> ReclaimPreviewResult {
+        let result = await run(.maintenancePrune(
+            setId: setId,
+            destId: destId,
+            expectedDestination: nil,
+            dryRun: true,
+            json: true
+        ))
+        guard case .ok(let output) = result else {
+            return ReclaimPreviewResult(result: Self.humanResult(result), confirmationBinding: nil)
+        }
+        guard let decoded = try? JSONDecoder().decode(ReclaimPreviewEnvelope.self, from: Data(output.utf8)),
+              decoded.ok,
+              let binding = decoded.data.confirmationBinding,
+              !binding.isEmpty else {
+            return ReclaimPreviewResult(
+                result: .failed(output: "The reclaim preview did not return a confirmation binding. Run a new preview before reclaiming space."),
+                confirmationBinding: nil
+            )
+        }
+        return ReclaimPreviewResult(result: .ok(output: decoded.data.summary), confirmationBinding: binding)
+    }
+
     public func check(setId: UUID) async -> HelperResult {
         await run(.check(setId: setId))
     }
@@ -187,6 +214,50 @@ public struct HelperInvoker: Sendable {
             return .failed(output: output.isEmpty
                 ? "The helper failed (exit \(process.terminationStatus))."
                 : output)
+        }
+    }
+}
+
+struct ReclaimPreviewResult: Sendable {
+    let result: HelperResult
+    let confirmationBinding: String?
+}
+
+private extension HelperInvoker {
+    struct ReclaimPreviewEnvelope: Decodable {
+        let ok: Bool
+        let data: Data
+
+        struct Data: Decodable {
+            let label: String
+            let dryRun: Bool
+            let status: RunStatus
+            let confirmationBinding: String?
+
+            var summary: String {
+                let qualifier = dryRun ? "dry run " : ""
+                return "\"\(label)\": prune \(qualifier)\(status.rawValue)"
+            }
+        }
+    }
+
+    struct JSONFailureEnvelope: Decodable {
+        let error: Error
+
+        struct Error: Decodable {
+            let message: String
+        }
+    }
+
+    static func humanResult(_ result: HelperResult) -> HelperResult {
+        func message(_ output: String) -> String {
+            (try? JSONDecoder().decode(JSONFailureEnvelope.self, from: Data(output.utf8)))?.error.message ?? output
+        }
+        return switch result {
+        case .ok: result
+        case .busy: result
+        case .offline(let output): .offline(output: message(output))
+        case .failed(let output): .failed(output: message(output))
         }
     }
 }

--- a/App/Sources/Support/HelperInvoker.swift
+++ b/App/Sources/Support/HelperInvoker.swift
@@ -75,17 +75,21 @@ public struct HelperInvoker: Sendable {
     /// its secret environment. Confirmation returns that binding to the
     /// helper, which revalidates it after reloading configuration.
     func previewReclaimSpace(setId: UUID, destId: UUID) async -> ReclaimPreviewResult {
-        let result = await run(.maintenancePrune(
+        let invocation = await runDetailed(.maintenancePrune(
             setId: setId,
             destId: destId,
             expectedDestination: nil,
             dryRun: true,
             json: true
         ))
-        guard case .ok(let output) = result else {
+        let result = invocation.result
+        guard case .ok = result else {
             return ReclaimPreviewResult(result: Self.humanResult(result), confirmationBinding: nil)
         }
-        guard let decoded = try? JSONDecoder().decode(ReclaimPreviewEnvelope.self, from: Data(output.utf8)),
+        guard let decoded = try? JSONDecoder().decode(
+            ReclaimPreviewEnvelope.self,
+            from: Data(invocation.stdout.utf8)
+        ),
               decoded.ok,
               let binding = decoded.data.confirmationBinding,
               !binding.isEmpty,
@@ -144,8 +148,12 @@ public struct HelperInvoker: Sendable {
     /// through the T10 contract. Never throws: every failure mode becomes
     /// a `HelperResult` the UI can render.
     func run(_ command: HelperCommand) async -> HelperResult {
+        await runDetailed(command).result
+    }
+
+    private func runDetailed(_ command: HelperCommand) async -> HelperInvocation {
         let executable = helperURL
-        return await withCheckedContinuation { (continuation: CheckedContinuation<HelperResult, Never>) in
+        return await withCheckedContinuation { (continuation: CheckedContinuation<HelperInvocation, Never>) in
             // The whole spawn + drain + wait happens on a utility queue:
             // `waitUntilExit()` blocks its thread, so it must never run on
             // a Swift-concurrency cooperative thread (or the main one).
@@ -155,10 +163,13 @@ public struct HelperInvoker: Sendable {
         }
     }
 
-    private static func runBlocking(executable: URL, command: HelperCommand) -> HelperResult {
+    private static func runBlocking(executable: URL, command: HelperCommand) -> HelperInvocation {
         guard FileManager.default.isExecutableFile(atPath: executable.path) else {
-            return .failed(output: "The Restic Station helper is missing from this copy of the app "
-                + "(expected at \(executable.path)). Reinstall Restic Station.")
+            return HelperInvocation(
+                result: .failed(output: "The Restic Station helper is missing from this copy of the app "
+                    + "(expected at \(executable.path)). Reinstall Restic Station."),
+                stdout: ""
+            )
         }
 
         let process = Process()
@@ -178,7 +189,10 @@ public struct HelperInvoker: Sendable {
         do {
             try process.run()
         } catch {
-            return .failed(output: "Could not start the helper: \(error.localizedDescription)")
+            return HelperInvocation(
+                result: .failed(output: "Could not start the helper: \(error.localizedDescription)"),
+                stdout: ""
+            )
         }
 
         // Both pipes are drained concurrently: a helper that writes enough
@@ -198,6 +212,7 @@ public struct HelperInvoker: Sendable {
         process.waitUntilExit()
 
         let output = collector.combinedText()
+        let stdout = collector.stdoutText()
 
         // A signalled process reports the *signal number* in
         // `terminationStatus` on Darwin — without this check a helper
@@ -205,22 +220,36 @@ public struct HelperInvoker: Sendable {
         // ("busy"), and SIGQUIT (3) as "offline".
         if process.terminationReason == .uncaughtSignal {
             let detail = output.isEmpty ? "" : "\n\(output)"
-            return .failed(output: "The helper was terminated by signal \(process.terminationStatus).\(detail)")
+            return HelperInvocation(
+                result: .failed(output: "The helper was terminated by signal \(process.terminationStatus).\(detail)"),
+                stdout: stdout
+            )
         }
 
         switch HelperExitCode.interpret(process.terminationStatus) {
         case .ok:
-            return .ok(output: output)
+            return HelperInvocation(result: .ok(output: output), stdout: stdout)
         case .busy:
-            return .busy
+            return HelperInvocation(result: .busy, stdout: stdout)
         case .offline:
-            return .offline(output: output)
+            return HelperInvocation(result: .offline(output: output), stdout: stdout)
         case .failed:
-            return .failed(output: output.isEmpty
-                ? "The helper failed (exit \(process.terminationStatus))."
-                : output)
+            return HelperInvocation(
+                result: .failed(output: output.isEmpty
+                    ? "The helper failed (exit \(process.terminationStatus))."
+                    : output),
+                stdout: stdout
+            )
         }
     }
+}
+
+/// Keeps JSON-mode stdout distinct from incidental helper diagnostics. The
+/// UI still renders combined output for human-mode failures, but structured
+/// envelopes are decoded exclusively from stdout by their contract.
+private struct HelperInvocation: Sendable {
+    let result: HelperResult
+    let stdout: String
 }
 
 struct ReclaimPreviewResult: Sendable {
@@ -348,5 +377,12 @@ private final class OutputCollector: @unchecked Sendable {
             .map { String(decoding: $0, as: UTF8.self).trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty }
         return parts.joined(separator: "\n")
+    }
+
+    func stdoutText() -> String {
+        lock.lock()
+        defer { lock.unlock() }
+        return String(decoding: stdout, as: UTF8.self)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }

--- a/App/Sources/Support/HelperInvoker.swift
+++ b/App/Sources/Support/HelperInvoker.swift
@@ -88,13 +88,18 @@ public struct HelperInvoker: Sendable {
         guard let decoded = try? JSONDecoder().decode(ReclaimPreviewEnvelope.self, from: Data(output.utf8)),
               decoded.ok,
               let binding = decoded.data.confirmationBinding,
-              !binding.isEmpty else {
+              !binding.isEmpty,
+              !decoded.data.destinationFingerprint.isEmpty else {
             return ReclaimPreviewResult(
                 result: .failed(output: "The reclaim preview did not return a confirmation binding. Run a new preview before reclaiming space."),
                 confirmationBinding: nil
             )
         }
-        return ReclaimPreviewResult(result: .ok(output: decoded.data.summary), confirmationBinding: binding)
+        return ReclaimPreviewResult(
+            result: .ok(output: decoded.data.summary),
+            confirmationBinding: binding,
+            destinationFingerprint: decoded.data.destinationFingerprint
+        )
     }
 
     public func check(setId: UUID) async -> HelperResult {
@@ -221,6 +226,13 @@ public struct HelperInvoker: Sendable {
 struct ReclaimPreviewResult: Sendable {
     let result: HelperResult
     let confirmationBinding: String?
+    let destinationFingerprint: String?
+
+    init(result: HelperResult, confirmationBinding: String?, destinationFingerprint: String? = nil) {
+        self.result = result
+        self.confirmationBinding = confirmationBinding
+        self.destinationFingerprint = destinationFingerprint
+    }
 }
 
 private extension HelperInvoker {
@@ -233,6 +245,7 @@ private extension HelperInvoker {
             let dryRun: Bool
             let status: RunStatus
             let confirmationBinding: String?
+            let destinationFingerprint: String
 
             var summary: String {
                 let qualifier = dryRun ? "dry run " : ""

--- a/App/Sources/Support/HelperInvoker.swift
+++ b/App/Sources/Support/HelperInvoker.swift
@@ -84,7 +84,10 @@ public struct HelperInvoker: Sendable {
         ))
         let result = invocation.result
         guard case .ok = result else {
-            return ReclaimPreviewResult(result: Self.humanResult(result), confirmationBinding: nil)
+            return ReclaimPreviewResult(
+                result: Self.humanResult(result, jsonOutput: invocation.stdout),
+                confirmationBinding: nil
+            )
         }
         guard let decoded = try? JSONDecoder().decode(
             ReclaimPreviewEnvelope.self,
@@ -291,9 +294,10 @@ private extension HelperInvoker {
         }
     }
 
-    static func humanResult(_ result: HelperResult) -> HelperResult {
+    static func humanResult(_ result: HelperResult, jsonOutput: String? = nil) -> HelperResult {
         func message(_ output: String) -> String {
-            (try? JSONDecoder().decode(JSONFailureEnvelope.self, from: Data(output.utf8)))?.error.message ?? output
+            let json = jsonOutput ?? output
+            return (try? JSONDecoder().decode(JSONFailureEnvelope.self, from: Data(json.utf8)))?.error.message ?? output
         }
         return switch result {
         case .ok: result

--- a/App/Sources/Support/HelperInvoker.swift
+++ b/App/Sources/Support/HelperInvoker.swift
@@ -56,8 +56,18 @@ public struct HelperInvoker: Sendable {
 
     /// Reclaims unused packs without applying retention. The helper owns the
     /// lock, mirror-freshness guard, reachability probe, and run record.
-    public func pruneRepository(setId: UUID, destId: UUID?, dryRun: Bool) async -> HelperResult {
-        await run(.maintenancePrune(setId: setId, destId: destId, dryRun: dryRun))
+    public func pruneRepository(
+        setId: UUID,
+        destId: UUID?,
+        dryRun: Bool,
+        expectedRepository: String? = nil
+    ) async -> HelperResult {
+        await run(.maintenancePrune(
+            setId: setId,
+            destId: destId,
+            expectedRepository: expectedRepository,
+            dryRun: dryRun
+        ))
     }
 
     public func check(setId: UUID) async -> HelperResult {

--- a/App/Sources/ViewModels/AppModel+Maintenance.swift
+++ b/App/Sources/ViewModels/AppModel+Maintenance.swift
@@ -547,7 +547,10 @@ final class MaintenanceModel: ObservableObject {
                     title: "Check reclaim space",
                     subject: set.name,
                     result: result,
-                    run: MaintenanceLookup.lastRun(model, setId: set.id, kind: .prune)
+                    // Standalone prune previews are deliberately unrecorded,
+                    // including a busy refusal. Never attach an unrelated
+                    // historical prune to this preview failure.
+                    run: nil
                 )
                 return
             }
@@ -591,7 +594,14 @@ final class MaintenanceModel: ObservableObject {
             }
             destIds = [destination.id]
             title = "Reclaim space"
-            resultTask = { await model.helper.pruneRepository(setId: plan.setId, destId: destination.id, dryRun: false) }
+            resultTask = {
+                await model.helper.pruneRepository(
+                    setId: plan.setId,
+                    destId: destination.id,
+                    dryRun: false,
+                    expectedRepository: previewedDestination.repoURL
+                )
+            }
         }
         busyAction = .prune(setId: plan.setId)
         let existingPruneRunIds = Set(

--- a/App/Sources/ViewModels/AppModel+Maintenance.swift
+++ b/App/Sources/ViewModels/AppModel+Maintenance.swift
@@ -593,19 +593,21 @@ final class MaintenanceModel: ObservableObject {
     /// which goes through the helper, never through this process
     /// (`docs/architecture.md` §The single-code-path rule).
     func confirmApplyRetention(_ plan: PrunePlan, in model: AppModel) {
-        prunePlan = nil
         guard let set = MaintenanceLookup.set(model, id: plan.setId) else { return }
         let destIds: [UUID]
         let title: String
         let resultTask: () async -> HelperResult
+        let retainsPlanWhenBusy: Bool
         switch plan.action {
         case .retention:
             destIds = set.destinations.map(\.id)
             title = "Apply retention"
             resultTask = { await model.helper.prune(setId: plan.setId) }
+            retainsPlanWhenBusy = false
         case .reclaimSpace(let previewedDestination, _, let confirmationBinding):
             guard let destination = set.destinations.first(where: { $0.id == previewedDestination.id }),
                   destination == previewedDestination else {
+                self.prunePlan = nil
                 self.activity = Self.activity(
                     title: "Reclaim space",
                     subject: plan.setName,
@@ -616,6 +618,7 @@ final class MaintenanceModel: ObservableObject {
             }
             destIds = [destination.id]
             title = "Reclaim space"
+            retainsPlanWhenBusy = true
             resultTask = {
                 await model.helper.pruneRepository(
                     setId: plan.setId,
@@ -635,6 +638,9 @@ final class MaintenanceModel: ObservableObject {
             let result = await resultTask()
             guard let self else { return }
             self.busyAction = nil
+            if result != .busy || !retainsPlanWhenBusy {
+                self.prunePlan = nil
+            }
             model.refresh()
             let latestPrune = MaintenanceLookup.lastRun(model, setId: set.id, kind: .prune)
             let recordedRun: RunIndexEntry?

--- a/App/Sources/ViewModels/AppModel+Maintenance.swift
+++ b/App/Sources/ViewModels/AppModel+Maintenance.swift
@@ -565,11 +565,12 @@ final class MaintenanceModel: ObservableObject {
                 )
                 return
             }
-            guard let confirmationBinding = preview.confirmationBinding else {
+            guard let confirmationBinding = preview.confirmationBinding,
+                  preview.destinationFingerprint == destination.pruneConfirmationFingerprint(secretEnv: [:]) else {
                 self.activity = Self.activity(
                     title: "Check reclaim space",
                     subject: set.name,
-                    result: .failed(output: "The reclaim preview did not return a confirmation binding. Run it again before reclaiming space."),
+                    result: .failed(output: "The reclaim preview no longer matches this destination. Reload settings and run it again before reclaiming space."),
                     run: nil
                 )
                 return

--- a/App/Sources/ViewModels/AppModel+Maintenance.swift
+++ b/App/Sources/ViewModels/AppModel+Maintenance.swift
@@ -599,7 +599,7 @@ final class MaintenanceModel: ObservableObject {
                     setId: plan.setId,
                     destId: destination.id,
                     dryRun: false,
-                    expectedRepository: previewedDestination.repoURL
+                    expectedDestination: previewedDestination.pruneConfirmationFingerprint()
                 )
             }
         }

--- a/App/Sources/ViewModels/AppModel+Maintenance.swift
+++ b/App/Sources/ViewModels/AppModel+Maintenance.swift
@@ -215,7 +215,7 @@ struct PrunePlan: Identifiable, Equatable {
         /// Confirm revalidates this value before it asks the helper to make
         /// changes, so a concurrent config edit cannot redirect the prune to
         /// another repository after the user has read the warning.
-        case reclaimSpace(destination: Destination, isICloud: Bool)
+        case reclaimSpace(destination: Destination, isICloud: Bool, confirmationBinding: String)
     }
 
     let id = UUID()
@@ -231,11 +231,21 @@ struct PrunePlan: Identifiable, Equatable {
         action = .retention
     }
 
-    init(setId: UUID, setName: String, destination: Destination, isICloud: Bool) {
+    init(
+        setId: UUID,
+        setName: String,
+        destination: Destination,
+        isICloud: Bool,
+        confirmationBinding: String
+    ) {
         self.setId = setId
         self.setName = setName
         previews = []
-        action = .reclaimSpace(destination: destination, isICloud: isICloud)
+        action = .reclaimSpace(
+            destination: destination,
+            isICloud: isICloud,
+            confirmationBinding: confirmationBinding
+        )
     }
 
     var confirmationTitle: String {
@@ -279,7 +289,7 @@ struct PrunePlan: Identifiable, Equatable {
     /// one line per destination ("This will permanently delete N snapshots
     /// from <dest>."); the rest satisfies the destructive-confirmation rule.
     var confirmationMessage: String {
-        if case .reclaimSpace(let destination, let isICloud) = action {
+        if case .reclaimSpace(let destination, let isICloud, _) = action {
             var lines = [
                 "This runs restic prune for \(destination.label). It removes only pack data no current snapshot references; it does not change snapshot retention or touch source files.",
                 "Stop other repository activity until it finishes. Prune can take a long time."
@@ -539,7 +549,8 @@ final class MaintenanceModel: ObservableObject {
     func prepareReclaimSpace(for set: BackupSet, destination: Destination, in model: AppModel) {
         isPreparingPrune = true
         Task { [weak self] in
-            let result = await model.helper.pruneRepository(setId: set.id, destId: destination.id, dryRun: true)
+            let preview = await model.helper.previewReclaimSpace(setId: set.id, destId: destination.id)
+            let result = preview.result
             guard let self else { return }
             self.isPreparingPrune = false
             guard result.isSuccess else {
@@ -554,11 +565,21 @@ final class MaintenanceModel: ObservableObject {
                 )
                 return
             }
+            guard let confirmationBinding = preview.confirmationBinding else {
+                self.activity = Self.activity(
+                    title: "Check reclaim space",
+                    subject: set.name,
+                    result: .failed(output: "The reclaim preview did not return a confirmation binding. Run it again before reclaiming space."),
+                    run: nil
+                )
+                return
+            }
             self.prunePlan = PrunePlan(
                 setId: set.id,
                 setName: set.name,
                 destination: destination,
-                isICloud: Self.isICloudRepository(destination)
+                isICloud: Self.isICloudRepository(destination),
+                confirmationBinding: confirmationBinding
             )
         }
     }
@@ -581,7 +602,7 @@ final class MaintenanceModel: ObservableObject {
             destIds = set.destinations.map(\.id)
             title = "Apply retention"
             resultTask = { await model.helper.prune(setId: plan.setId) }
-        case .reclaimSpace(let previewedDestination, _):
+        case .reclaimSpace(let previewedDestination, _, let confirmationBinding):
             guard let destination = set.destinations.first(where: { $0.id == previewedDestination.id }),
                   destination == previewedDestination else {
                 self.activity = Self.activity(
@@ -599,7 +620,7 @@ final class MaintenanceModel: ObservableObject {
                     setId: plan.setId,
                     destId: destination.id,
                     dryRun: false,
-                    expectedDestination: previewedDestination.pruneConfirmationFingerprint()
+                    expectedDestination: confirmationBinding
                 )
             }
         }

--- a/App/Sources/ViewModels/AppModel+Maintenance.swift
+++ b/App/Sources/ViewModels/AppModel+Maintenance.swift
@@ -638,7 +638,12 @@ final class MaintenanceModel: ObservableObject {
             let result = await resultTask()
             guard let self else { return }
             self.busyAction = nil
-            if result != .busy || !retainsPlanWhenBusy {
+            if result == .busy, retainsPlanWhenBusy {
+                // SwiftUI closes the confirmation alert before this Task
+                // returns. Restore the still-valid capability so transient
+                // helper/token-store contention can be retried directly.
+                self.prunePlan = plan
+            } else {
                 self.prunePlan = nil
             }
             model.refresh()
@@ -722,6 +727,7 @@ final class MaintenanceModel: ObservableObject {
         _ destination: Destination,
         iCloudRoot: String
     ) -> Bool {
+        guard destination.kind == .localPath else { return false }
         let path = URL(fileURLWithPath: destination.repoURL)
             .resolvingSymlinksInPath()
             .standardizedFileURL

--- a/App/Sources/ViewModels/AppModel+Maintenance.swift
+++ b/App/Sources/ViewModels/AppModel+Maintenance.swift
@@ -704,9 +704,18 @@ final class MaintenanceModel: ObservableObject {
     /// Normalize before deciding whether destructive-maintenance warnings
     /// are required.
     nonisolated static func isICloudRepository(_ destination: Destination) -> Bool {
-        let iCloudRoot = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent("Library/Mobile Documents", isDirectory: true)
-            .path
+        isICloudRepository(
+            destination,
+            iCloudRoot: FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent("Library/Mobile Documents", isDirectory: true)
+                .path
+        )
+    }
+
+    nonisolated static func isICloudRepository(
+        _ destination: Destination,
+        iCloudRoot: String
+    ) -> Bool {
         let path = URL(fileURLWithPath: destination.repoURL)
             .resolvingSymlinksInPath()
             .standardizedFileURL

--- a/App/Sources/ViewModels/AppModel+Maintenance.swift
+++ b/App/Sources/ViewModels/AppModel+Maintenance.swift
@@ -707,7 +707,10 @@ final class MaintenanceModel: ObservableObject {
         let iCloudRoot = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent("Library/Mobile Documents", isDirectory: true)
             .path
-        let path = (destination.repoURL as NSString).standardizingPath
+        let path = URL(fileURLWithPath: destination.repoURL)
+            .resolvingSymlinksInPath()
+            .standardizedFileURL
+            .path
         return path == iCloudRoot || path.hasPrefix(iCloudRoot + "/")
     }
 

--- a/App/Sources/ViewModels/AppModel+Maintenance.swift
+++ b/App/Sources/ViewModels/AppModel+Maintenance.swift
@@ -211,7 +211,11 @@ enum RetentionPreviewState: Equatable {
 struct PrunePlan: Identifiable, Equatable {
     enum Action: Equatable {
         case retention
-        case reclaimSpace(destinationId: UUID, label: String, isICloud: Bool)
+        /// The exact addressable destination that the dry-run described.
+        /// Confirm revalidates this value before it asks the helper to make
+        /// changes, so a concurrent config edit cannot redirect the prune to
+        /// another repository after the user has read the warning.
+        case reclaimSpace(destination: Destination, isICloud: Bool)
     }
 
     let id = UUID()
@@ -231,7 +235,7 @@ struct PrunePlan: Identifiable, Equatable {
         self.setId = setId
         self.setName = setName
         previews = []
-        action = .reclaimSpace(destinationId: destination.id, label: destination.label, isICloud: isICloud)
+        action = .reclaimSpace(destination: destination, isICloud: isICloud)
     }
 
     var confirmationTitle: String {
@@ -275,9 +279,9 @@ struct PrunePlan: Identifiable, Equatable {
     /// one line per destination ("This will permanently delete N snapshots
     /// from <dest>."); the rest satisfies the destructive-confirmation rule.
     var confirmationMessage: String {
-        if case .reclaimSpace(_, let label, let isICloud) = action {
+        if case .reclaimSpace(let destination, let isICloud) = action {
             var lines = [
-                "This runs restic prune for \(label). It removes only pack data no current snapshot references; it does not change snapshot retention or touch source files.",
+                "This runs restic prune for \(destination.label). It removes only pack data no current snapshot references; it does not change snapshot retention or touch source files.",
                 "Stop other repository activity until it finishes. Prune can take a long time."
             ]
             if isICloud {
@@ -566,12 +570,6 @@ final class MaintenanceModel: ObservableObject {
     func confirmApplyRetention(_ plan: PrunePlan, in model: AppModel) {
         prunePlan = nil
         guard let set = MaintenanceLookup.set(model, id: plan.setId) else { return }
-        busyAction = .prune(setId: plan.setId)
-        let existingPruneRunIds = Set(
-            model.stateWatcher.recentRuns.lazy
-                .filter { $0.kind == .prune && $0.setId == set.id }
-                .map(\.runId)
-        )
         let destIds: [UUID]
         let title: String
         let resultTask: () async -> HelperResult
@@ -580,11 +578,27 @@ final class MaintenanceModel: ObservableObject {
             destIds = set.destinations.map(\.id)
             title = "Apply retention"
             resultTask = { await model.helper.prune(setId: plan.setId) }
-        case .reclaimSpace(let destinationId, _, _):
-            destIds = [destinationId]
+        case .reclaimSpace(let previewedDestination, _):
+            guard let destination = set.destinations.first(where: { $0.id == previewedDestination.id }),
+                  destination == previewedDestination else {
+                self.activity = Self.activity(
+                    title: "Reclaim space",
+                    subject: plan.setName,
+                    result: .failed(output: "The destination changed after the reclaim preview. Review the updated repository and run a new dry run before confirming."),
+                    run: nil
+                )
+                return
+            }
+            destIds = [destination.id]
             title = "Reclaim space"
-            resultTask = { await model.helper.pruneRepository(setId: plan.setId, destId: destinationId, dryRun: false) }
+            resultTask = { await model.helper.pruneRepository(setId: plan.setId, destId: destination.id, dryRun: false) }
         }
+        busyAction = .prune(setId: plan.setId)
+        let existingPruneRunIds = Set(
+            model.stateWatcher.recentRuns.lazy
+                .filter { $0.kind == .prune && $0.setId == set.id }
+                .map(\.runId)
+        )
         Task { [weak self] in
             let result = await resultTask()
             guard let self else { return }
@@ -653,11 +667,16 @@ final class MaintenanceModel: ObservableObject {
         return previews
     }
 
-    private nonisolated static func isICloudRepository(_ destination: Destination) -> Bool {
+    /// Matches the destination editor's path handling: a valid local path
+    /// can spell the iCloud root with harmless `.` or `..` components.
+    /// Normalize before deciding whether destructive-maintenance warnings
+    /// are required.
+    nonisolated static func isICloudRepository(_ destination: Destination) -> Bool {
         let iCloudRoot = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent("Library/Mobile Documents", isDirectory: true)
             .path
-        return destination.repoURL == iCloudRoot || destination.repoURL.hasPrefix(iCloudRoot + "/")
+        let path = (destination.repoURL as NSString).standardizingPath
+        return path == iCloudRoot || path.hasPrefix(iCloudRoot + "/")
     }
 
     // MARK: - Integrity

--- a/App/Sources/Views/Maintenance/RetentionSection.swift
+++ b/App/Sources/Views/Maintenance/RetentionSection.swift
@@ -32,12 +32,7 @@ struct RetentionSection: View {
     }
 
     private var hasICloudRepository: Bool {
-        let root = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent("Library/Mobile Documents", isDirectory: true)
-            .path
-        return backupSet.destinations.contains { destination in
-            destination.repoURL == root || destination.repoURL.hasPrefix(root + "/")
-        }
+        backupSet.destinations.contains(where: MaintenanceModel.isICloudRepository)
     }
 
     var body: some View {

--- a/App/Tests/AppModelMachineOverrideTests.swift
+++ b/App/Tests/AppModelMachineOverrideTests.swift
@@ -33,6 +33,27 @@ struct AppModelMachineOverrideTests {
         #expect(binding == "preview-binding")
     }
 
+    @Test("reclaim plan recognizes repositories reached through an iCloud symlink")
+    func reclaimPlanRecognizesICloudSymlink() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("restic-station-icloud-link-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let iCloudRoot = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Mobile Documents", isDirectory: true)
+        let alias = root.appendingPathComponent("repository-alias", isDirectory: true)
+        try FileManager.default.createSymbolicLink(at: alias, withDestinationURL: iCloudRoot)
+        let destination = Destination(
+            id: UUID(),
+            label: "iCloud repository",
+            repoURL: alias.appendingPathComponent("restic", isDirectory: true).path,
+            isPrimary: true
+        )
+
+        #expect(MaintenanceModel.isICloudRepository(destination))
+    }
+
     @Test("known machines and effective-plan preview include exclusions and replacements")
     func effectivePlanPreview() throws {
         let setId = UUID()

--- a/App/Tests/AppModelMachineOverrideTests.swift
+++ b/App/Tests/AppModelMachineOverrideTests.swift
@@ -58,6 +58,12 @@ struct AppModelMachineOverrideTests {
         #expect(MaintenanceModel.isICloudRepository(destination, iCloudRoot: iCloudRoot.path))
     }
 
+    @Test("reclaim plan never treats remote repository URLs as iCloud paths")
+    func reclaimPlanDoesNotClassifyRemoteURLAsICloud() {
+        let destination = Destination(id: UUID(), label: "Remote", repoURL: "s3:bucket/prefix", isPrimary: true)
+        #expect(!MaintenanceModel.isICloudRepository(destination, iCloudRoot: "/tmp"))
+    }
+
     @Test("reclaim preview decodes its JSON envelope without stderr diagnostics")
     func reclaimPreviewUsesStdoutForJSON() async throws {
         let root = FileManager.default.temporaryDirectory

--- a/App/Tests/AppModelMachineOverrideTests.swift
+++ b/App/Tests/AppModelMachineOverrideTests.swift
@@ -40,8 +40,12 @@ struct AppModelMachineOverrideTests {
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: root) }
 
-        let iCloudRoot = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent("Library/Mobile Documents", isDirectory: true)
+        let iCloudRoot = root.appendingPathComponent("Mobile Documents", isDirectory: true)
+        try FileManager.default.createDirectory(at: iCloudRoot, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: iCloudRoot.appendingPathComponent("restic", isDirectory: true),
+            withIntermediateDirectories: true
+        )
         let alias = root.appendingPathComponent("repository-alias", isDirectory: true)
         try FileManager.default.createSymbolicLink(at: alias, withDestinationURL: iCloudRoot)
         let destination = Destination(
@@ -51,7 +55,7 @@ struct AppModelMachineOverrideTests {
             isPrimary: true
         )
 
-        #expect(MaintenanceModel.isICloudRepository(destination))
+        #expect(MaintenanceModel.isICloudRepository(destination, iCloudRoot: iCloudRoot.path))
     }
 
     @Test("known machines and effective-plan preview include exclusions and replacements")

--- a/App/Tests/AppModelMachineOverrideTests.swift
+++ b/App/Tests/AppModelMachineOverrideTests.swift
@@ -6,6 +6,31 @@ import Testing
 @Suite("AppModel machine override wiring", .serialized)
 @MainActor
 struct AppModelMachineOverrideTests {
+    @Test("reclaim plan retains its previewed destination and recognizes normalized iCloud paths")
+    func reclaimPlanCapturesDestinationIdentity() throws {
+        let destination = Destination(
+            id: UUID(),
+            label: "iCloud repository",
+            repoURL: FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent("Library/Temporary/../Mobile Documents/restic", isDirectory: true)
+                .path,
+            isPrimary: true
+        )
+        let plan = PrunePlan(
+            setId: UUID(),
+            setName: "Documents",
+            destination: destination,
+            isICloud: MaintenanceModel.isICloudRepository(destination)
+        )
+
+        guard case .reclaimSpace(let previewedDestination, let isICloud) = plan.action else {
+            Issue.record("expected a reclaim plan")
+            return
+        }
+        #expect(previewedDestination == destination)
+        #expect(isICloud)
+    }
+
     @Test("known machines and effective-plan preview include exclusions and replacements")
     func effectivePlanPreview() throws {
         let setId = UUID()

--- a/App/Tests/AppModelMachineOverrideTests.swift
+++ b/App/Tests/AppModelMachineOverrideTests.swift
@@ -20,15 +20,17 @@ struct AppModelMachineOverrideTests {
             setId: UUID(),
             setName: "Documents",
             destination: destination,
-            isICloud: MaintenanceModel.isICloudRepository(destination)
+            isICloud: MaintenanceModel.isICloudRepository(destination),
+            confirmationBinding: "preview-binding"
         )
 
-        guard case .reclaimSpace(let previewedDestination, let isICloud) = plan.action else {
+        guard case .reclaimSpace(let previewedDestination, let isICloud, let binding) = plan.action else {
             Issue.record("expected a reclaim plan")
             return
         }
         #expect(previewedDestination == destination)
         #expect(isICloud)
+        #expect(binding == "preview-binding")
     }
 
     @Test("known machines and effective-plan preview include exclusions and replacements")

--- a/App/Tests/AppModelMachineOverrideTests.swift
+++ b/App/Tests/AppModelMachineOverrideTests.swift
@@ -58,6 +58,31 @@ struct AppModelMachineOverrideTests {
         #expect(MaintenanceModel.isICloudRepository(destination, iCloudRoot: iCloudRoot.path))
     }
 
+    @Test("reclaim preview decodes its JSON envelope without stderr diagnostics")
+    func reclaimPreviewUsesStdoutForJSON() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("restic-station-preview-helper-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let helper = root.appendingPathComponent("helper", isDirectory: false)
+        let script = """
+        #!/bin/sh
+        printf '%s\\n' '{"ok":true,"data":{"label":"Primary","dryRun":true,"status":"success","confirmationBinding":"opaque-binding","destinationFingerprint":"public-fingerprint"}}'
+        printf '%s\\n' 'diagnostic emitted on stderr' >&2
+        """
+        try script.write(to: helper, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: helper.path)
+
+        let preview = await HelperInvoker(helperURL: helper).previewReclaimSpace(
+            setId: UUID(),
+            destId: UUID()
+        )
+
+        #expect(preview.result.isSuccess)
+        #expect(preview.confirmationBinding == "opaque-binding")
+        #expect(preview.destinationFingerprint == "public-fingerprint")
+    }
+
     @Test("known machines and effective-plan preview include exclusions and replacements")
     func effectivePlanPreview() throws {
         let setId = UUID()

--- a/App/Tests/AppModelMachineOverrideTests.swift
+++ b/App/Tests/AppModelMachineOverrideTests.swift
@@ -83,6 +83,31 @@ struct AppModelMachineOverrideTests {
         #expect(preview.destinationFingerprint == "public-fingerprint")
     }
 
+    @Test("reclaim preview decodes its JSON failure envelope without stderr diagnostics")
+    func reclaimPreviewUsesStdoutForJSONFailure() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("restic-station-preview-helper-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let helper = root.appendingPathComponent("helper", isDirectory: false)
+        let script = """
+        #!/bin/sh
+        printf '%s\\n' '{"schemaVersion":1,"ok":false,"data":null,"error":{"code":"stale_mirror","message":"Mirror 1 is behind the primary; run a new backup first."}}'
+        printf '%s\\n' 'diagnostic emitted on stderr' >&2
+        exit 1
+        """
+        try script.write(to: helper, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: helper.path)
+
+        let preview = await HelperInvoker(helperURL: helper).previewReclaimSpace(
+            setId: UUID(),
+            destId: UUID()
+        )
+
+        #expect(preview.result == .failed(output: "Mirror 1 is behind the primary; run a new backup first."))
+        #expect(preview.confirmationBinding == nil)
+    }
+
     @Test("known machines and effective-plan preview include exclusions and replacements")
     func effectivePlanPreview() throws {
         let setId = UUID()

--- a/Core/Sources/ResticStationCore/Config/Models.swift
+++ b/Core/Sources/ResticStationCore/Config/Models.swift
@@ -359,11 +359,15 @@ public extension Destination {
     /// supplies the stored secret environment, so the binding covers every
     /// destination value that affects a restic invocation without ever
     /// exposing a secret on argv or in app memory.
-    func pruneConfirmationFingerprint(secretEnv: [String: String]) -> String {
+    func pruneConfirmationFingerprint(
+        secretEnv: [String: String],
+        executableIdentity: String? = nil
+    ) -> String {
         struct EffectiveDestination: Codable {
             let repoURL: String
             let nonSecretEnv: [String: String]
             let secretEnv: [String: String]
+            let executableIdentity: String?
         }
 
         let encoder = JSONEncoder()
@@ -371,7 +375,8 @@ public extension Destination {
         let effective = EffectiveDestination(
             repoURL: pruneRepositoryURL(),
             nonSecretEnv: nonSecretEnv,
-            secretEnv: secretEnv
+            secretEnv: secretEnv,
+            executableIdentity: executableIdentity
         )
         // Encoding an in-memory String dictionary cannot fail in practice;
         // fail closed with an impossible-to-match fingerprint if it ever did.

--- a/Core/Sources/ResticStationCore/Config/Models.swift
+++ b/Core/Sources/ResticStationCore/Config/Models.swift
@@ -331,6 +331,27 @@ public struct Destination: Codable, Equatable, Identifiable, Sendable {
     }
 }
 
+public extension Destination {
+    /// Stable binding for a destructive maintenance confirmation. These are
+    /// the complete destination values that affect a restic invocation after
+    /// machine resolution: the repository address and its non-secret
+    /// environment. It hashes rather than placing environment values on argv.
+    func pruneConfirmationFingerprint() -> String {
+        struct EffectiveDestination: Codable {
+            let repoURL: String
+            let nonSecretEnv: [String: String]
+        }
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let effective = EffectiveDestination(repoURL: repoURL, nonSecretEnv: nonSecretEnv)
+        // Encoding an in-memory String dictionary cannot fail in practice;
+        // fail closed with an impossible-to-match fingerprint if it ever did.
+        guard let data = try? encoder.encode(effective) else { return "" }
+        return SHA256Digest.hex(data)
+    }
+}
+
 public enum DestinationKind: Equatable, Sendable {
     /// No scheme prefix; includes `/Volumes/...` and iCloud paths.
     case localPath

--- a/Core/Sources/ResticStationCore/Config/Models.swift
+++ b/Core/Sources/ResticStationCore/Config/Models.swift
@@ -332,19 +332,24 @@ public struct Destination: Codable, Equatable, Identifiable, Sendable {
 }
 
 public extension Destination {
-    /// Stable binding for a destructive maintenance confirmation. These are
-    /// the complete destination values that affect a restic invocation after
-    /// machine resolution: the repository address and its non-secret
-    /// environment. It hashes rather than placing environment values on argv.
-    func pruneConfirmationFingerprint() -> String {
+    /// Stable binding for a destructive maintenance confirmation. The helper
+    /// supplies the stored secret environment, so the binding covers every
+    /// destination value that affects a restic invocation without ever
+    /// exposing a secret on argv or in app memory.
+    func pruneConfirmationFingerprint(secretEnv: [String: String]) -> String {
         struct EffectiveDestination: Codable {
             let repoURL: String
             let nonSecretEnv: [String: String]
+            let secretEnv: [String: String]
         }
 
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys]
-        let effective = EffectiveDestination(repoURL: repoURL, nonSecretEnv: nonSecretEnv)
+        let effective = EffectiveDestination(
+            repoURL: repoURL,
+            nonSecretEnv: nonSecretEnv,
+            secretEnv: secretEnv
+        )
         // Encoding an in-memory String dictionary cannot fail in practice;
         // fail closed with an impossible-to-match fingerprint if it ever did.
         guard let data = try? encoder.encode(effective) else { return "" }

--- a/Core/Sources/ResticStationCore/Config/Models.swift
+++ b/Core/Sources/ResticStationCore/Config/Models.swift
@@ -332,6 +332,29 @@ public struct Destination: Codable, Equatable, Identifiable, Sendable {
 }
 
 public extension Destination {
+    /// The repository identity a maintenance preview authorizes. Local paths
+    /// are resolved before binding so a symlink retarget between preview and
+    /// confirmation invalidates the capability instead of redirecting prune
+    /// to an unpreviewed repository. Remote URLs are opaque to Foundation
+    /// and must remain verbatim.
+    func pruneRepositoryURL() -> String {
+        guard kind == .localPath else { return repoURL }
+        return URL(fileURLWithPath: repoURL)
+            .resolvingSymlinksInPath()
+            .standardizedFileURL
+            .path
+    }
+
+    /// The exact destination passed to the preview and destructive prune.
+    /// Keeping the resolved local URL in the invocation closes the remaining
+    /// time-of-check/time-of-use gap after its fingerprint was validated.
+    func pruneInvocationDestination() -> Destination {
+        guard kind == .localPath else { return self }
+        var resolved = self
+        resolved.repoURL = pruneRepositoryURL()
+        return resolved
+    }
+
     /// Stable binding for a destructive maintenance confirmation. The helper
     /// supplies the stored secret environment, so the binding covers every
     /// destination value that affects a restic invocation without ever
@@ -346,7 +369,7 @@ public extension Destination {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys]
         let effective = EffectiveDestination(
-            repoURL: repoURL,
+            repoURL: pruneRepositoryURL(),
             nonSecretEnv: nonSecretEnv,
             secretEnv: secretEnv
         )

--- a/Core/Sources/ResticStationCore/Engine/BackupEngine.swift
+++ b/Core/Sources/ResticStationCore/Engine/BackupEngine.swift
@@ -718,7 +718,7 @@ public final class BackupEngine: Sendable {
             }
         }
 
-        let previewValidation: (@Sendable (LogWriter?) async -> PreflightFailure?)?
+        let consumePreviewToken: (@Sendable () throws -> Void)?
         if let authorization {
             let previewTokens = previewTokens
             let token = authorization.token
@@ -726,29 +726,17 @@ public final class BackupEngine: Sendable {
             let effectiveDestinationFingerprint = authorization.effectiveDestinationFingerprint
             let setId = set.id
             let destinationId = destination.id
-            previewValidation = { _ in
-                do {
-                    try previewTokens.consumeMaintenancePrune(
-                        token,
-                        machineId: machineId,
-                        setId: setId,
-                        destinationId: destinationId,
-                        effectiveDestinationFingerprint: effectiveDestinationFingerprint
-                    )
-                    return nil
-                } catch let error as PreviewTokenError {
-                    switch error {
-                    case .unavailable:
-                        return .previewUnavailable
-                    case .unknown, .expired, .alreadyUsed:
-                        return .previewChanged
-                    }
-                } catch {
-                    return .previewChanged
-                }
+            consumePreviewToken = {
+                try previewTokens.consumeMaintenancePrune(
+                    token,
+                    machineId: machineId,
+                    setId: setId,
+                    destinationId: destinationId,
+                    effectiveDestinationFingerprint: effectiveDestinationFingerprint
+                )
             }
         } else {
-            previewValidation = nil
+            consumePreviewToken = nil
         }
 
         let prune = await performChild(
@@ -767,7 +755,7 @@ public final class BackupEngine: Sendable {
             ),
             streamProgress: false,
             preflightPhase: authorization == nil ? nil : "validating preview",
-            preflight: previewValidation
+            beforeLaunch: consumePreviewToken
         )
         guard let prune else { return .failed(.didNotRun) }
         switch prune.preflightFailure {
@@ -1350,6 +1338,7 @@ public final class BackupEngine: Sendable {
         streamProgress: Bool,
         preflightPhase: String? = nil,
         preflight: (@Sendable (LogWriter?) async -> PreflightFailure?)? = nil,
+        beforeLaunch: (@Sendable () throws -> Void)? = nil,
         downgradeSuccessToWarning: (@Sendable (ResticOutcome) -> Bool)? = nil,
         purgeSnapshotRewrites: (@Sendable (ResticOutcome) -> [String: String]?)? = nil
     ) async -> ChildRun? {
@@ -1410,8 +1399,30 @@ public final class BackupEngine: Sendable {
             command,
             invocation: invocation,
             logWriter: logWriter,
-            reporter: streamProgress ? reporter : nil
+            reporter: streamProgress ? reporter : nil,
+            beforeLaunch: beforeLaunch
         )
+
+        if case .didNotRun(_, let launchPreflightFailure?) = result {
+            if case .previewUnavailable = launchPreflightFailure {
+                do {
+                    try runStore.discardUnstarted(run)
+                    return ChildRun(
+                        child: SetRunChild(runId: run.runId, kind: kind, destId: destination.id, status: .skipped),
+                        outcome: nil,
+                        preflightFailure: launchPreflightFailure
+                    )
+                } catch {
+                    logWarning("BackupEngine: could not discard unavailable launch preflight run \(run.runId): \(error)")
+                }
+            }
+            finish(run, status: .failed, errorSummary: launchPreflightFailure.message)
+            return ChildRun(
+                child: SetRunChild(runId: run.runId, kind: kind, destId: destination.id, status: .failed),
+                outcome: nil,
+                preflightFailure: launchPreflightFailure
+            )
+        }
 
         let status: RunStatus
         var errorSummary: String?
@@ -1419,7 +1430,7 @@ public final class BackupEngine: Sendable {
         var exitCode: Int32?
 
         switch result {
-        case .didNotRun(let reason):
+        case .didNotRun(let reason, _):
             status = .failed
             errorSummary = reason
         case .ranToCompletion(let outcome):
@@ -1468,7 +1479,7 @@ public final class BackupEngine: Sendable {
         case ranToCompletion(ResticOutcome)
         /// restic produced no outcome at all (launch failure, timeout,
         /// secret read failure mid-run, cancellation).
-        case didNotRun(reason: String)
+        case didNotRun(reason: String, preflightFailure: PreflightFailure? = nil)
 
         var outcome: ResticOutcome? {
             if case .ranToCompletion(let outcome) = self { return outcome }
@@ -1485,9 +1496,16 @@ public final class BackupEngine: Sendable {
         _ command: ResticCommand,
         invocation: ResticInvocation,
         logWriter: LogWriter?,
-        reporter: ProgressReporter?
+        reporter: ProgressReporter?,
+        beforeLaunch: (@Sendable () throws -> Void)? = nil
     ) async -> ExecuteResult {
-        let first = await spawn(command, invocation: invocation, logWriter: logWriter, reporter: reporter)
+        let first = await spawn(
+            command,
+            invocation: invocation,
+            logWriter: logWriter,
+            reporter: reporter,
+            beforeLaunch: beforeLaunch
+        )
         guard case .ranToCompletion(let outcome) = first, outcome.status == .repoLocked else {
             return first
         }
@@ -1515,7 +1533,8 @@ public final class BackupEngine: Sendable {
         _ command: ResticCommand,
         invocation: ResticInvocation,
         logWriter: LogWriter?,
-        reporter: ProgressReporter?
+        reporter: ProgressReporter?,
+        beforeLaunch: (@Sendable () throws -> Void)? = nil
     ) async -> ExecuteResult {
         do {
             let outcome = try await restic.run(
@@ -1527,9 +1546,14 @@ public final class BackupEngine: Sendable {
                 },
                 onRawLine: { line in
                     logWriter?.appendLine(line)
-                }
+                },
+                beforeLaunch: beforeLaunch
             )
             return .ranToCompletion(outcome)
+        } catch let error as PreviewTokenError {
+            let failure: PreflightFailure = error == .unavailable ? .previewUnavailable : .previewChanged
+            logWriter?.appendLine("restic did not run: \(failure.message)")
+            return .didNotRun(reason: failure.message, preflightFailure: failure)
         } catch let error as ResticRunnerError {
             logWriter?.appendLine("restic did not run: \(error.description)")
             return .didNotRun(reason: error.userFacingMessage)

--- a/Core/Sources/ResticStationCore/Engine/BackupEngine.swift
+++ b/Core/Sources/ResticStationCore/Engine/BackupEngine.swift
@@ -638,7 +638,13 @@ public final class BackupEngine: Sendable {
 
         let lock = makeSetLock(setId: set.id)
         guard lock.tryAcquire() else {
-            recordSkipped(kind: .prune, setId: set.id, destId: destination.id, trigger: .manual)
+            // A preview is an unrecorded read-only query, even when it is
+            // refused because another set operation holds the lock. Recording
+            // that refusal as a prune would replace the last real cleanup in
+            // status/history despite no restic prune having run.
+            if !dryRun {
+                recordSkipped(kind: .prune, setId: set.id, destId: destination.id, trigger: .manual)
+            }
             return .skipped(.busy)
         }
         defer { lock.release() }

--- a/Core/Sources/ResticStationCore/Engine/BackupEngine.swift
+++ b/Core/Sources/ResticStationCore/Engine/BackupEngine.swift
@@ -752,6 +752,7 @@ public final class BackupEngine: Sendable {
             preflight: previewValidation
         )
         guard let prune else { return .failed(.didNotRun) }
+        if prune.preflightFailed { return .skipped(.previewChanged) }
         guard prune.child.status == .failed else { return .completed(prune.child.status) }
         if let outcome = prune.outcome {
             return .failed(.restic(outcome.status))
@@ -1279,6 +1280,7 @@ public final class BackupEngine: Sendable {
     private struct ChildRun {
         let child: SetRunChild
         let outcome: ResticOutcome?
+        let preflightFailed: Bool
     }
 
     /// Runs one restic command as one recorded run: `begin` → open the run
@@ -1342,7 +1344,8 @@ public final class BackupEngine: Sendable {
             finish(run, status: .failed, errorSummary: reason)
             return ChildRun(
                 child: SetRunChild(runId: run.runId, kind: kind, destId: destination.id, status: .failed),
-                outcome: nil
+                outcome: nil,
+                preflightFailed: true
             )
         }
 
@@ -1402,7 +1405,8 @@ public final class BackupEngine: Sendable {
         )
         return ChildRun(
             child: SetRunChild(runId: run.runId, kind: kind, destId: destination.id, status: status),
-            outcome: result.outcome
+            outcome: result.outcome,
+            preflightFailed: false
         )
     }
 

--- a/Core/Sources/ResticStationCore/Engine/BackupEngine.swift
+++ b/Core/Sources/ResticStationCore/Engine/BackupEngine.swift
@@ -635,6 +635,7 @@ public final class BackupEngine: Sendable {
         destinationSecretEnv: [String: String]? = nil,
         authorization: MaintenancePruneAuthorization? = nil,
         resticExecutablePath: String? = nil,
+        resticExecutableIdentity: String? = nil,
         dryRun: Bool = false
     ) async -> PruneRepositoryResult {
         guard set.destinations.contains(where: { $0.id == destination.id }) else {
@@ -643,6 +644,7 @@ public final class BackupEngine: Sendable {
         }
         guard await secretsAvailable(for: [destination]) else { return .skipped(.secretUnavailable) }
         let executablePath = authorization?.resticExecutablePath ?? resticExecutablePath
+        let executableIdentity = authorization?.resticExecutableIdentity ?? resticExecutableIdentity
 
         let lock = makeSetLock(setId: set.id)
         guard lock.tryAcquire() else {
@@ -696,7 +698,8 @@ public final class BackupEngine: Sendable {
                 invocation: ResticInvocation(
                     destination: destination,
                     destinationSecretEnv: destinationSecretEnv,
-                    resticPathOverride: executablePath
+                    resticPathOverride: executablePath,
+                    expectedExecutableIdentity: executableIdentity
                 ),
                 logWriter: nil,
                 reporter: nil
@@ -759,7 +762,8 @@ public final class BackupEngine: Sendable {
             invocation: ResticInvocation(
                 destination: destination,
                 destinationSecretEnv: destinationSecretEnv,
-                resticPathOverride: executablePath
+                resticPathOverride: executablePath,
+                expectedExecutableIdentity: executableIdentity
             ),
             streamProgress: false,
             preflightPhase: authorization == nil ? nil : "validating preview",
@@ -1497,7 +1501,8 @@ public final class BackupEngine: Sendable {
             invocation: ResticInvocation(
                 destination: invocation.destination,
                 destinationSecretEnv: invocation.destinationSecretEnv,
-                resticPathOverride: invocation.resticPathOverride
+                resticPathOverride: invocation.resticPathOverride,
+                expectedExecutableIdentity: invocation.expectedExecutableIdentity
             ),
             logWriter: logWriter,
             reporter: nil

--- a/Core/Sources/ResticStationCore/Engine/BackupEngine.swift
+++ b/Core/Sources/ResticStationCore/Engine/BackupEngine.swift
@@ -634,6 +634,7 @@ public final class BackupEngine: Sendable {
         destination: Destination,
         destinationSecretEnv: [String: String]? = nil,
         authorization: MaintenancePruneAuthorization? = nil,
+        resticExecutablePath: String? = nil,
         dryRun: Bool = false
     ) async -> PruneRepositoryResult {
         guard set.destinations.contains(where: { $0.id == destination.id }) else {
@@ -641,6 +642,7 @@ public final class BackupEngine: Sendable {
             return .failed(.didNotRun)
         }
         guard await secretsAvailable(for: [destination]) else { return .skipped(.secretUnavailable) }
+        let executablePath = authorization?.resticExecutablePath ?? resticExecutablePath
 
         let lock = makeSetLock(setId: set.id)
         guard lock.tryAcquire() else {
@@ -693,7 +695,8 @@ public final class BackupEngine: Sendable {
                 .prune(repo: destination.repoURL, dryRun: true),
                 invocation: ResticInvocation(
                     destination: destination,
-                    destinationSecretEnv: destinationSecretEnv
+                    destinationSecretEnv: destinationSecretEnv,
+                    resticPathOverride: executablePath
                 ),
                 logWriter: nil,
                 reporter: nil
@@ -755,7 +758,8 @@ public final class BackupEngine: Sendable {
             command: .prune(repo: destination.repoURL, dryRun: false),
             invocation: ResticInvocation(
                 destination: destination,
-                destinationSecretEnv: destinationSecretEnv
+                destinationSecretEnv: destinationSecretEnv,
+                resticPathOverride: executablePath
             ),
             streamProgress: false,
             preflightPhase: authorization == nil ? nil : "validating preview",
@@ -1374,6 +1378,18 @@ public final class BackupEngine: Sendable {
 
         if let preflight, let failure = await preflight(logWriter) {
             logWriter?.appendLine("aborted: \(failure.message)")
+            if case .previewUnavailable = failure {
+                do {
+                    try runStore.discardUnstarted(run)
+                    return ChildRun(
+                        child: SetRunChild(runId: run.runId, kind: kind, destId: destination.id, status: .skipped),
+                        outcome: nil,
+                        preflightFailure: failure
+                    )
+                } catch {
+                    logWarning("BackupEngine: could not discard unavailable preflight run \(run.runId): \(error)")
+                }
+            }
             finish(run, status: .failed, errorSummary: failure.message)
             return ChildRun(
                 child: SetRunChild(runId: run.runId, kind: kind, destId: destination.id, status: .failed),
@@ -1480,7 +1496,8 @@ public final class BackupEngine: Sendable {
             .unlock(repo: invocation.destination.repoURL),
             invocation: ResticInvocation(
                 destination: invocation.destination,
-                destinationSecretEnv: invocation.destinationSecretEnv
+                destinationSecretEnv: invocation.destinationSecretEnv,
+                resticPathOverride: invocation.resticPathOverride
             ),
             logWriter: logWriter,
             reporter: nil

--- a/Core/Sources/ResticStationCore/Engine/BackupEngine.swift
+++ b/Core/Sources/ResticStationCore/Engine/BackupEngine.swift
@@ -1445,7 +1445,10 @@ public final class BackupEngine: Sendable {
         )
         _ = await spawn(
             .unlock(repo: invocation.destination.repoURL),
-            invocation: ResticInvocation(destination: invocation.destination),
+            invocation: ResticInvocation(
+                destination: invocation.destination,
+                destinationSecretEnv: invocation.destinationSecretEnv
+            ),
             logWriter: logWriter,
             reporter: nil
         )

--- a/Core/Sources/ResticStationCore/Engine/BackupEngine.swift
+++ b/Core/Sources/ResticStationCore/Engine/BackupEngine.swift
@@ -653,20 +653,6 @@ public final class BackupEngine: Sendable {
         defer { lock.release() }
         defer { try? stateStore.clearCurrentRun(setId: set.id) }
 
-        if let authorization {
-            do {
-                try previewTokens.consumeMaintenancePrune(
-                    authorization.token,
-                    machineId: authorization.machineId,
-                    setId: set.id,
-                    destinationId: destination.id,
-                    effectiveDestinationFingerprint: authorization.effectiveDestinationFingerprint
-                )
-            } catch {
-                return .skipped(.previewChanged)
-            }
-        }
-
         // Read both timestamps only while the set lock is held. A backup can
         // advance the primary and leave a mirror behind, so checking before
         // lock acquisition would create a prune-after-stale race.
@@ -682,7 +668,10 @@ public final class BackupEngine: Sendable {
             }
         }
 
-        let probe = await reachability.probe(destination)
+        let probe = await reachability.probe(
+            destination,
+            destinationSecretEnv: destinationSecretEnv
+        )
         record(probe: probe, for: destination)
         switch probe {
         case .reachable:
@@ -720,6 +709,32 @@ public final class BackupEngine: Sendable {
             }
         }
 
+        let previewValidation: (@Sendable (LogWriter?) async -> String?)?
+        if let authorization {
+            let previewTokens = previewTokens
+            let token = authorization.token
+            let machineId = authorization.machineId
+            let effectiveDestinationFingerprint = authorization.effectiveDestinationFingerprint
+            let setId = set.id
+            let destinationId = destination.id
+            previewValidation = { _ in
+                do {
+                    try previewTokens.consumeMaintenancePrune(
+                        token,
+                        machineId: machineId,
+                        setId: setId,
+                        destinationId: destinationId,
+                        effectiveDestinationFingerprint: effectiveDestinationFingerprint
+                    )
+                    return nil
+                } catch {
+                    return "Destination configuration changed after the reclaim preview. Run a new dry run before pruning."
+                }
+            }
+        } else {
+            previewValidation = nil
+        }
+
         let prune = await performChild(
             kind: .prune,
             setId: set.id,
@@ -732,7 +747,9 @@ public final class BackupEngine: Sendable {
                 destination: destination,
                 destinationSecretEnv: destinationSecretEnv
             ),
-            streamProgress: false
+            streamProgress: false,
+            preflightPhase: authorization == nil ? nil : "validating preview",
+            preflight: previewValidation
         )
         guard let prune else { return .failed(.didNotRun) }
         guard prune.child.status == .failed else { return .completed(prune.child.status) }

--- a/Core/Sources/ResticStationCore/Engine/BackupEngine.swift
+++ b/Core/Sources/ResticStationCore/Engine/BackupEngine.swift
@@ -89,6 +89,7 @@ public enum PruneRepositorySkipReason: Equatable, Sendable {
     case busy
     case secretUnavailable
     case staleMirror
+    case previewChanged
 }
 
 public enum PruneRepositoryFailure: Equatable, Sendable {
@@ -629,6 +630,7 @@ public final class BackupEngine: Sendable {
         set: BackupSet,
         destination: Destination,
         destinationSecretEnv: [String: String]? = nil,
+        authorization: MaintenancePruneAuthorization? = nil,
         dryRun: Bool = false
     ) async -> PruneRepositoryResult {
         guard set.destinations.contains(where: { $0.id == destination.id }) else {
@@ -650,6 +652,20 @@ public final class BackupEngine: Sendable {
         }
         defer { lock.release() }
         defer { try? stateStore.clearCurrentRun(setId: set.id) }
+
+        if let authorization {
+            do {
+                try previewTokens.consumeMaintenancePrune(
+                    authorization.token,
+                    machineId: authorization.machineId,
+                    setId: set.id,
+                    destinationId: destination.id,
+                    effectiveDestinationFingerprint: authorization.effectiveDestinationFingerprint
+                )
+            } catch {
+                return .skipped(.previewChanged)
+            }
+        }
 
         // Read both timestamps only while the set lock is held. A backup can
         // advance the primary and leave a mirror behind, so checking before

--- a/Core/Sources/ResticStationCore/Engine/BackupEngine.swift
+++ b/Core/Sources/ResticStationCore/Engine/BackupEngine.swift
@@ -90,6 +90,9 @@ public enum PruneRepositorySkipReason: Equatable, Sendable {
     case secretUnavailable
     case staleMirror
     case previewChanged
+    /// The preview token could not be read because another helper briefly
+    /// owns the machine-global token-store lock.  It remains valid to retry.
+    case previewUnavailable
 }
 
 public enum PruneRepositoryFailure: Equatable, Sendable {
@@ -282,7 +285,7 @@ public final class BackupEngine: Sendable {
                 logWriter?.appendLine("probe primary \"\(primary.label)\": \(describe(probe))")
                 record(probe: probe, for: primary)
                 guard probe == .reachable else {
-                    return "primary unreachable: \(describe(probe))"
+                    return .reason("primary unreachable: \(describe(probe))")
                 }
                 return nil
             }
@@ -709,7 +712,7 @@ public final class BackupEngine: Sendable {
             }
         }
 
-        let previewValidation: (@Sendable (LogWriter?) async -> String?)?
+        let previewValidation: (@Sendable (LogWriter?) async -> PreflightFailure?)?
         if let authorization {
             let previewTokens = previewTokens
             let token = authorization.token
@@ -727,8 +730,15 @@ public final class BackupEngine: Sendable {
                         effectiveDestinationFingerprint: effectiveDestinationFingerprint
                     )
                     return nil
+                } catch let error as PreviewTokenError {
+                    switch error {
+                    case .unavailable:
+                        return .previewUnavailable
+                    case .unknown, .expired, .alreadyUsed:
+                        return .previewChanged
+                    }
                 } catch {
-                    return "Destination configuration changed after the reclaim preview. Run a new dry run before pruning."
+                    return .previewChanged
                 }
             }
         } else {
@@ -752,7 +762,14 @@ public final class BackupEngine: Sendable {
             preflight: previewValidation
         )
         guard let prune else { return .failed(.didNotRun) }
-        if prune.preflightFailed { return .skipped(.previewChanged) }
+        switch prune.preflightFailure {
+        case .previewChanged:
+            return .skipped(.previewChanged)
+        case .previewUnavailable:
+            return .skipped(.previewUnavailable)
+        case .reason, .none:
+            break
+        }
         guard prune.child.status == .failed else { return .completed(prune.child.status) }
         if let outcome = prune.outcome {
             return .failed(.restic(outcome.status))
@@ -1280,7 +1297,23 @@ public final class BackupEngine: Sendable {
     private struct ChildRun {
         let child: SetRunChild
         let outcome: ResticOutcome?
-        let preflightFailed: Bool
+        let preflightFailure: PreflightFailure?
+    }
+
+    private enum PreflightFailure: Sendable {
+        case reason(String)
+        case previewChanged
+        case previewUnavailable
+
+        var message: String {
+            switch self {
+            case .reason(let reason): return reason
+            case .previewChanged:
+                return "Destination configuration changed after the reclaim preview. Run a new dry run before pruning."
+            case .previewUnavailable:
+                return "The reclaim confirmation is temporarily unavailable. Try confirming again."
+            }
+        }
     }
 
     /// Runs one restic command as one recorded run: `begin` → open the run
@@ -1292,7 +1325,7 @@ public final class BackupEngine: Sendable {
     ///
     /// - Parameters:
     ///   - preflightPhase: written to `current-run` before `preflight` runs.
-    ///   - preflight: returns a failure reason to abort the run *before*
+    ///   - preflight: returns a failure classification to abort the run *before*
     ///     spawning restic (used for the primary reachability probe), or
     ///     `nil` to proceed.
     ///   - downgradeSuccessToWarning: inspected on an otherwise successful
@@ -1308,7 +1341,7 @@ public final class BackupEngine: Sendable {
         invocation: ResticInvocation,
         streamProgress: Bool,
         preflightPhase: String? = nil,
-        preflight: (@Sendable (LogWriter?) async -> String?)? = nil,
+        preflight: (@Sendable (LogWriter?) async -> PreflightFailure?)? = nil,
         downgradeSuccessToWarning: (@Sendable (ResticOutcome) -> Bool)? = nil,
         purgeSnapshotRewrites: (@Sendable (ResticOutcome) -> [String: String]?)? = nil
     ) async -> ChildRun? {
@@ -1339,13 +1372,13 @@ public final class BackupEngine: Sendable {
         reporter.startHeartbeat()
         defer { reporter.stopHeartbeat() }
 
-        if let preflight, let reason = await preflight(logWriter) {
-            logWriter?.appendLine("aborted: \(reason)")
-            finish(run, status: .failed, errorSummary: reason)
+        if let preflight, let failure = await preflight(logWriter) {
+            logWriter?.appendLine("aborted: \(failure.message)")
+            finish(run, status: .failed, errorSummary: failure.message)
             return ChildRun(
                 child: SetRunChild(runId: run.runId, kind: kind, destId: destination.id, status: .failed),
                 outcome: nil,
-                preflightFailed: true
+                preflightFailure: failure
             )
         }
 
@@ -1406,7 +1439,7 @@ public final class BackupEngine: Sendable {
         return ChildRun(
             child: SetRunChild(runId: run.runId, kind: kind, destId: destination.id, status: status),
             outcome: result.outcome,
-            preflightFailed: false
+            preflightFailure: nil
         )
     }
 

--- a/Core/Sources/ResticStationCore/Engine/BackupEngine.swift
+++ b/Core/Sources/ResticStationCore/Engine/BackupEngine.swift
@@ -628,6 +628,7 @@ public final class BackupEngine: Sendable {
     public func runPruneRepository(
         set: BackupSet,
         destination: Destination,
+        destinationSecretEnv: [String: String]? = nil,
         dryRun: Bool = false
     ) async -> PruneRepositoryResult {
         guard set.destinations.contains(where: { $0.id == destination.id }) else {
@@ -682,7 +683,10 @@ public final class BackupEngine: Sendable {
             // make the Runs screen claim that pack space was reclaimed.
             switch await execute(
                 .prune(repo: destination.repoURL, dryRun: true),
-                invocation: ResticInvocation(destination: destination),
+                invocation: ResticInvocation(
+                    destination: destination,
+                    destinationSecretEnv: destinationSecretEnv
+                ),
                 logWriter: nil,
                 reporter: nil
             ) {
@@ -708,7 +712,10 @@ public final class BackupEngine: Sendable {
             groupId: nil,
             phase: "pruning",
             command: .prune(repo: destination.repoURL, dryRun: false),
-            invocation: ResticInvocation(destination: destination),
+            invocation: ResticInvocation(
+                destination: destination,
+                destinationSecretEnv: destinationSecretEnv
+            ),
             streamProgress: false
         )
         guard let prune else { return .failed(.didNotRun) }

--- a/Core/Sources/ResticStationCore/Engine/Reachability.swift
+++ b/Core/Sources/ResticStationCore/Engine/Reachability.swift
@@ -35,11 +35,14 @@ public struct Reachability: Sendable {
         self.restic = restic
     }
 
-    public func probe(_ dest: Destination) async -> RepoProbeResult {
+    public func probe(
+        _ dest: Destination,
+        destinationSecretEnv: [String: String]? = nil
+    ) async -> RepoProbeResult {
         if dest.kind == .localPath {
             return Self.probeLocal(dest)
         }
-        return await probeRemote(dest)
+        return await probeRemote(dest, destinationSecretEnv: destinationSecretEnv)
     }
 
     // MARK: - Local
@@ -71,11 +74,17 @@ public struct Reachability: Sendable {
 
     // MARK: - Remote
 
-    private func probeRemote(_ dest: Destination) async -> RepoProbeResult {
+    private func probeRemote(
+        _ dest: Destination,
+        destinationSecretEnv: [String: String]?
+    ) async -> RepoProbeResult {
         do {
             let outcome = try await restic.run(
                 .catConfig(repo: dest.repoURL),
-                for: ResticInvocation(destination: dest),
+                for: ResticInvocation(
+                    destination: dest,
+                    destinationSecretEnv: destinationSecretEnv
+                ),
                 timeout: Self.probeTimeout
             )
             if outcome.status == .success {

--- a/Core/Sources/ResticStationCore/Restic/ResticRunner.swift
+++ b/Core/Sources/ResticStationCore/Restic/ResticRunner.swift
@@ -16,17 +16,22 @@ public struct ResticInvocation: Sendable {
     /// preview/confirmation. Normal calls leave this nil and use the runner's
     /// configured path unchanged.
     public let resticPathOverride: String?
+    /// Opaque digest binding for a helper-confirmed maintenance executable.
+    /// The runner rechecks it immediately before the child is spawned.
+    public let expectedExecutableIdentity: String?
 
     public init(
         destination: Destination,
         fromDestination: Destination? = nil,
         destinationSecretEnv: [String: String]? = nil,
-        resticPathOverride: String? = nil
+        resticPathOverride: String? = nil,
+        expectedExecutableIdentity: String? = nil
     ) {
         self.destination = destination
         self.fromDestination = fromDestination
         self.destinationSecretEnv = destinationSecretEnv
         self.resticPathOverride = resticPathOverride
+        self.expectedExecutableIdentity = expectedExecutableIdentity
     }
 }
 
@@ -152,6 +157,7 @@ public final class ResticRunner: Sendable {
             cmd,
             env: env,
             executablePath: inv.resticPathOverride,
+            expectedExecutableIdentity: inv.expectedExecutableIdentity,
             onLine: onLine,
             onRawLine: onRawLine,
             timeout: timeout
@@ -191,15 +197,7 @@ public final class ResticRunner: Sendable {
     /// It is intentionally an opaque input to the helper's preview binding,
     /// never emitted in a report or run log.
     public func maintenanceExecutable() -> MaintenanceExecutable? {
-        guard resticPath.hasPrefix("/") else { return nil }
-        let executable = URL(fileURLWithPath: resticPath)
-            .resolvingSymlinksInPath()
-            .standardizedFileURL
-        guard let data = try? Data(contentsOf: executable) else { return nil }
-        return MaintenanceExecutable(
-            path: executable.path,
-            identity: "\(executable.path):\(SHA256Digest.hex(data))"
-        )
+        maintenanceExecutable(path: resticPath)
     }
 
     // MARK: - Secret-store pre-flight
@@ -293,11 +291,17 @@ public final class ResticRunner: Sendable {
         _ cmd: ResticCommand,
         env: [String: String],
         executablePath: String? = nil,
+        expectedExecutableIdentity: String? = nil,
         onLine: (@Sendable (ResticMessage) -> Void)?,
         onRawLine: (@Sendable (String) -> Void)?,
         timeout: TimeInterval?
     ) async throws -> ResticOutcome {
-        let argv = [executablePath ?? resticPath] + cmd.argv
+        let resolvedExecutablePath = executablePath ?? resticPath
+        if let expectedExecutableIdentity,
+           maintenanceExecutable(path: resolvedExecutablePath)?.identity != expectedExecutableIdentity {
+            throw ResticRunnerError.launchFailed("the restic executable changed after the maintenance preview")
+        }
+        let argv = [resolvedExecutablePath] + cmd.argv
         let collector = MessageCollector()
         let decoder = self.decoder
 
@@ -337,6 +341,18 @@ public final class ResticRunner: Sendable {
             status: Self.status(exitCode: result.exitCode, messages: messages, stderr: stderrText),
             messages: messages,
             rawOutput: stdoutText + stderrText
+        )
+    }
+
+    private func maintenanceExecutable(path: String) -> MaintenanceExecutable? {
+        guard path.hasPrefix("/") else { return nil }
+        let executable = URL(fileURLWithPath: path)
+            .resolvingSymlinksInPath()
+            .standardizedFileURL
+        guard let data = try? Data(contentsOf: executable) else { return nil }
+        return MaintenanceExecutable(
+            path: executable.path,
+            identity: "\(executable.path):\(SHA256Digest.hex(data))"
         )
     }
 

--- a/Core/Sources/ResticStationCore/Restic/ResticRunner.swift
+++ b/Core/Sources/ResticStationCore/Restic/ResticRunner.swift
@@ -167,6 +167,19 @@ public final class ResticRunner: Sendable {
         secrets.backend
     }
 
+    /// A stable identity for the executable that will receive a destructive
+    /// maintenance command.  The resolved path catches symlink changes and
+    /// the content digest catches an in-place replacement at the same path.
+    /// It is intentionally an opaque input to the helper's preview binding,
+    /// never emitted in a report or run log.
+    public func maintenanceExecutableIdentity() -> String? {
+        let executable = URL(fileURLWithPath: resticPath)
+            .resolvingSymlinksInPath()
+            .standardizedFileURL
+        guard let data = try? Data(contentsOf: executable) else { return nil }
+        return "\(executable.path):\(SHA256Digest.hex(data))"
+    }
+
     // MARK: - Secret-store pre-flight
 
     private func preflightSecrets(destination: Destination) async throws {

--- a/Core/Sources/ResticStationCore/Restic/ResticRunner.swift
+++ b/Core/Sources/ResticStationCore/Restic/ResticRunner.swift
@@ -138,7 +138,8 @@ public final class ResticRunner: Sendable {
         for inv: ResticInvocation,
         onLine: (@Sendable (ResticMessage) -> Void)? = nil,
         onRawLine: (@Sendable (String) -> Void)? = nil,
-        timeout: TimeInterval? = nil
+        timeout: TimeInterval? = nil,
+        beforeLaunch: (@Sendable () throws -> Void)? = nil
     ) async throws -> ResticOutcome {
         try Task.checkCancellation()
 
@@ -158,6 +159,7 @@ public final class ResticRunner: Sendable {
             env: env,
             executablePath: inv.resticPathOverride,
             expectedExecutableIdentity: inv.expectedExecutableIdentity,
+            beforeLaunch: beforeLaunch,
             onLine: onLine,
             onRawLine: onRawLine,
             timeout: timeout
@@ -292,6 +294,7 @@ public final class ResticRunner: Sendable {
         env: [String: String],
         executablePath: String? = nil,
         expectedExecutableIdentity: String? = nil,
+        beforeLaunch: (@Sendable () throws -> Void)? = nil,
         onLine: (@Sendable (ResticMessage) -> Void)?,
         onRawLine: (@Sendable (String) -> Void)?,
         timeout: TimeInterval?
@@ -301,6 +304,11 @@ public final class ResticRunner: Sendable {
            maintenanceExecutable(path: resolvedExecutablePath)?.identity != expectedExecutableIdentity {
             throw ResticRunnerError.launchFailed("the restic executable changed after the maintenance preview")
         }
+        // Destructive preview tokens are consumed here, after every launch
+        // prerequisite has passed but immediately before the process runner
+        // receives the argv. A failed secret read or executable revalidation
+        // must leave confirmation retryable.
+        try beforeLaunch?()
         let argv = [resolvedExecutablePath] + cmd.argv
         let collector = MessageCollector()
         let decoder = self.decoder

--- a/Core/Sources/ResticStationCore/Restic/ResticRunner.swift
+++ b/Core/Sources/ResticStationCore/Restic/ResticRunner.swift
@@ -12,15 +12,21 @@ public struct ResticInvocation: Sendable {
     /// flows use this to ensure the environment they validate is exactly the
     /// one passed to restic; ordinary invocations read the current store value.
     public let destinationSecretEnv: [String: String]?
+    /// A helper-validated, canonical restic executable for a destructive
+    /// preview/confirmation. Normal calls leave this nil and use the runner's
+    /// configured path unchanged.
+    public let resticPathOverride: String?
 
     public init(
         destination: Destination,
         fromDestination: Destination? = nil,
-        destinationSecretEnv: [String: String]? = nil
+        destinationSecretEnv: [String: String]? = nil,
+        resticPathOverride: String? = nil
     ) {
         self.destination = destination
         self.fromDestination = fromDestination
         self.destinationSecretEnv = destinationSecretEnv
+        self.resticPathOverride = resticPathOverride
     }
 }
 
@@ -97,6 +103,11 @@ public final class ResticRunner: Sendable {
     private let runner: ProcessRunning
     private let decoder = ResticMessageDecoder()
 
+    public struct MaintenanceExecutable: Equatable, Sendable {
+        public let path: String
+        public let identity: String
+    }
+
     public init(resticPath: String, paths: AppPaths, secrets: any SecretStore, runner: ProcessRunning) {
         self.resticPath = resticPath
         self.paths = paths
@@ -137,7 +148,14 @@ public final class ResticRunner: Sendable {
         }
 
         let env = try await environment(for: inv)
-        return try await execute(cmd, env: env, onLine: onLine, onRawLine: onRawLine, timeout: timeout)
+        return try await execute(
+            cmd,
+            env: env,
+            executablePath: inv.resticPathOverride,
+            onLine: onLine,
+            onRawLine: onRawLine,
+            timeout: timeout
+        )
     }
 
     /// Runs a command that targets no repository — currently only
@@ -172,12 +190,16 @@ public final class ResticRunner: Sendable {
     /// the content digest catches an in-place replacement at the same path.
     /// It is intentionally an opaque input to the helper's preview binding,
     /// never emitted in a report or run log.
-    public func maintenanceExecutableIdentity() -> String? {
+    public func maintenanceExecutable() -> MaintenanceExecutable? {
+        guard resticPath.hasPrefix("/") else { return nil }
         let executable = URL(fileURLWithPath: resticPath)
             .resolvingSymlinksInPath()
             .standardizedFileURL
         guard let data = try? Data(contentsOf: executable) else { return nil }
-        return "\(executable.path):\(SHA256Digest.hex(data))"
+        return MaintenanceExecutable(
+            path: executable.path,
+            identity: "\(executable.path):\(SHA256Digest.hex(data))"
+        )
     }
 
     // MARK: - Secret-store pre-flight
@@ -270,11 +292,12 @@ public final class ResticRunner: Sendable {
     private func execute(
         _ cmd: ResticCommand,
         env: [String: String],
+        executablePath: String? = nil,
         onLine: (@Sendable (ResticMessage) -> Void)?,
         onRawLine: (@Sendable (String) -> Void)?,
         timeout: TimeInterval?
     ) async throws -> ResticOutcome {
-        let argv = [resticPath] + cmd.argv
+        let argv = [executablePath ?? resticPath] + cmd.argv
         let collector = MessageCollector()
         let decoder = self.decoder
 

--- a/Core/Sources/ResticStationCore/Restic/ResticRunner.swift
+++ b/Core/Sources/ResticStationCore/Restic/ResticRunner.swift
@@ -8,10 +8,19 @@ import Foundation
 public struct ResticInvocation: Sendable {
     public let destination: Destination
     public let fromDestination: Destination?
+    /// A caller-supplied secret-env snapshot. Destructive preview/confirm
+    /// flows use this to ensure the environment they validate is exactly the
+    /// one passed to restic; ordinary invocations read the current store value.
+    public let destinationSecretEnv: [String: String]?
 
-    public init(destination: Destination, fromDestination: Destination? = nil) {
+    public init(
+        destination: Destination,
+        fromDestination: Destination? = nil,
+        destinationSecretEnv: [String: String]? = nil
+    ) {
         self.destination = destination
         self.fromDestination = fromDestination
+        self.destinationSecretEnv = destinationSecretEnv
     }
 }
 
@@ -195,7 +204,13 @@ public final class ResticRunner: Sendable {
             env.merge(try await secretEnv(for: fromDestination)) { _, new in new }
         }
         env.merge(inv.destination.nonSecretEnv) { _, new in new }
-        env.merge(try await secretEnv(for: inv.destination)) { _, new in new }
+        let destinationSecretEnv: [String: String]
+        if let supplied = inv.destinationSecretEnv {
+            destinationSecretEnv = supplied
+        } else {
+            destinationSecretEnv = try await secretEnv(for: inv.destination)
+        }
+        env.merge(destinationSecretEnv) { _, new in new }
 
         // Written last: these must not be overridable by configured env.
         env["RESTIC_CACHE_DIR"] = paths.resticCacheDir.path

--- a/Core/Sources/ResticStationCore/Runs/RunStore.swift
+++ b/Core/Sources/ResticStationCore/Runs/RunStore.swift
@@ -70,6 +70,9 @@ public enum CurrentRunLiveness: String, Equatable, Sendable {
 public enum RunStoreError: Error, Equatable, Sendable, CustomStringConvertible {
     case renameFailed(errno: Int32, from: String, to: String)
     case indexAppendFailed(errno: Int32, path: String)
+    /// A caller tried to discard something other than its own fresh,
+    /// still-running run directory.
+    case discardUnsafe(path: String)
     /// The `index.jsonl` companion lock could not be acquired within the
     /// bounded retry window — see `RunStore.indexLockTimeout`.
     case indexLockTimeout(path: String)
@@ -80,6 +83,8 @@ public enum RunStoreError: Error, Equatable, Sendable, CustomStringConvertible {
             return "rename(\(from), \(to)) failed: errno \(errno)"
         case .indexAppendFailed(let errno, let path):
             return "append to \(path) failed: errno \(errno)"
+        case .discardUnsafe(let path):
+            return "refusing to discard non-fresh run metadata at \(path)"
         case .indexLockTimeout(let path):
             return "timed out waiting for index lock \(path)"
         }
@@ -227,6 +232,23 @@ public struct RunStore: Sendable {
         )
         try writeMetadataAtomic(metadata)
         try appendIndexEntry(metadata.indexEntry)
+    }
+
+    /// Removes a just-created run before it reaches the index. This is only
+    /// for a preflight that was retryably unavailable before restic started;
+    /// presenting such contention as a failed maintenance run would replace
+    /// the last real cleanup despite modifying no repository data.
+    public func discardUnstarted(_ run: ActiveRun) throws {
+        let directory = paths.runDir(runId: run.runId)
+        let metadataURL = directory.appendingPathComponent("metadata.json", isDirectory: false)
+        let data = try Data(contentsOf: metadataURL)
+        let metadata = try ConfigStore.makeDecoder().decode(RunMetadata.self, from: data)
+        guard metadata.runId == run.runId,
+              metadata.status == .running,
+              metadata.pid == run.pid else {
+            throw RunStoreError.discardUnsafe(path: metadataURL.path)
+        }
+        try FileManager.default.removeItem(at: directory)
     }
 
     // MARK: - Crash recovery

--- a/Core/Sources/ResticStationCore/Support/HelperCommand.swift
+++ b/Core/Sources/ResticStationCore/Support/HelperCommand.swift
@@ -26,9 +26,9 @@ public enum HelperCommand: Equatable, Sendable {
     case prune(setId: UUID)
     /// `run-set --set <uuid> --kind check`.
     case check(setId: UUID)
-    /// `maintenance prune --set <uuid> [--dest <uuid>] [--expected-destination <fingerprint>] [--dry-run]`.
+    /// `maintenance prune --set <uuid> [--dest <uuid>] [--expected-destination <preview-token>] [--dry-run]`.
     /// This reclaims unused packs without applying a retention policy.
-    /// `expectedDestination` binds a destructive confirmation to the full
+    /// `expectedDestination` is an opaque helper-issued binding for the full
     /// effective destination the preceding preview described; direct CLI
     /// callers may omit it.
     case maintenancePrune(setId: UUID, destId: UUID?, expectedDestination: String?, dryRun: Bool, json: Bool = false)

--- a/Core/Sources/ResticStationCore/Support/HelperCommand.swift
+++ b/Core/Sources/ResticStationCore/Support/HelperCommand.swift
@@ -31,7 +31,7 @@ public enum HelperCommand: Equatable, Sendable {
     /// `expectedDestination` binds a destructive confirmation to the full
     /// effective destination the preceding preview described; direct CLI
     /// callers may omit it.
-    case maintenancePrune(setId: UUID, destId: UUID?, expectedDestination: String?, dryRun: Bool)
+    case maintenancePrune(setId: UUID, destId: UUID?, expectedDestination: String?, dryRun: Bool, json: Bool = false)
     /// `init-secondary --set <uuid> --dest <uuid>`.
     case initSecondary(setId: UUID, destId: UUID)
     /// `probe-repo --set <uuid> --dest <uuid>` (exit 3 = offline).
@@ -71,11 +71,12 @@ public enum HelperCommand: Equatable, Sendable {
             return Self.runSet(setId: setId, kind: "prune")
         case .check(let setId):
             return Self.runSet(setId: setId, kind: "check")
-        case .maintenancePrune(let setId, let destId, let expectedDestination, let dryRun):
+        case .maintenancePrune(let setId, let destId, let expectedDestination, let dryRun, let json):
             var argv = ["maintenance", "prune", "--set", Self.render(setId)]
             if let destId { argv.append(contentsOf: ["--dest", Self.render(destId)]) }
             if let expectedDestination { argv.append(contentsOf: ["--expected-destination", expectedDestination]) }
             if dryRun { argv.append("--dry-run") }
+            if json { argv.append("--json") }
             return argv
         case .initSecondary(let setId, let destId):
             return ["init-secondary", "--set", Self.render(setId), "--dest", Self.render(destId)]

--- a/Core/Sources/ResticStationCore/Support/HelperCommand.swift
+++ b/Core/Sources/ResticStationCore/Support/HelperCommand.swift
@@ -74,7 +74,9 @@ public enum HelperCommand: Equatable, Sendable {
         case .maintenancePrune(let setId, let destId, let expectedDestination, let dryRun, let json):
             var argv = ["maintenance", "prune", "--set", Self.render(setId)]
             if let destId { argv.append(contentsOf: ["--dest", Self.render(destId)]) }
-            if let expectedDestination { argv.append(contentsOf: ["--expected-destination", expectedDestination]) }
+            // Attach the opaque value so a valid base64url token beginning
+            // with `-` can never be reparsed as another option.
+            if let expectedDestination { argv.append("--expected-destination=\(expectedDestination)") }
             if dryRun { argv.append("--dry-run") }
             if json { argv.append("--json") }
             return argv

--- a/Core/Sources/ResticStationCore/Support/HelperCommand.swift
+++ b/Core/Sources/ResticStationCore/Support/HelperCommand.swift
@@ -26,11 +26,12 @@ public enum HelperCommand: Equatable, Sendable {
     case prune(setId: UUID)
     /// `run-set --set <uuid> --kind check`.
     case check(setId: UUID)
-    /// `maintenance prune --set <uuid> [--dest <uuid>] [--expected-repo <url>] [--dry-run]`.
+    /// `maintenance prune --set <uuid> [--dest <uuid>] [--expected-destination <fingerprint>] [--dry-run]`.
     /// This reclaims unused packs without applying a retention policy.
-    /// `expectedRepository` binds a destructive confirmation to the repo the
-    /// preceding preview described; direct CLI callers may omit it.
-    case maintenancePrune(setId: UUID, destId: UUID?, expectedRepository: String?, dryRun: Bool)
+    /// `expectedDestination` binds a destructive confirmation to the full
+    /// effective destination the preceding preview described; direct CLI
+    /// callers may omit it.
+    case maintenancePrune(setId: UUID, destId: UUID?, expectedDestination: String?, dryRun: Bool)
     /// `init-secondary --set <uuid> --dest <uuid>`.
     case initSecondary(setId: UUID, destId: UUID)
     /// `probe-repo --set <uuid> --dest <uuid>` (exit 3 = offline).
@@ -70,10 +71,10 @@ public enum HelperCommand: Equatable, Sendable {
             return Self.runSet(setId: setId, kind: "prune")
         case .check(let setId):
             return Self.runSet(setId: setId, kind: "check")
-        case .maintenancePrune(let setId, let destId, let expectedRepository, let dryRun):
+        case .maintenancePrune(let setId, let destId, let expectedDestination, let dryRun):
             var argv = ["maintenance", "prune", "--set", Self.render(setId)]
             if let destId { argv.append(contentsOf: ["--dest", Self.render(destId)]) }
-            if let expectedRepository { argv.append(contentsOf: ["--expected-repo", expectedRepository]) }
+            if let expectedDestination { argv.append(contentsOf: ["--expected-destination", expectedDestination]) }
             if dryRun { argv.append("--dry-run") }
             return argv
         case .initSecondary(let setId, let destId):

--- a/Core/Sources/ResticStationCore/Support/HelperCommand.swift
+++ b/Core/Sources/ResticStationCore/Support/HelperCommand.swift
@@ -26,9 +26,11 @@ public enum HelperCommand: Equatable, Sendable {
     case prune(setId: UUID)
     /// `run-set --set <uuid> --kind check`.
     case check(setId: UUID)
-    /// `maintenance prune --set <uuid> [--dest <uuid>] [--dry-run]`.
+    /// `maintenance prune --set <uuid> [--dest <uuid>] [--expected-repo <url>] [--dry-run]`.
     /// This reclaims unused packs without applying a retention policy.
-    case maintenancePrune(setId: UUID, destId: UUID?, dryRun: Bool)
+    /// `expectedRepository` binds a destructive confirmation to the repo the
+    /// preceding preview described; direct CLI callers may omit it.
+    case maintenancePrune(setId: UUID, destId: UUID?, expectedRepository: String?, dryRun: Bool)
     /// `init-secondary --set <uuid> --dest <uuid>`.
     case initSecondary(setId: UUID, destId: UUID)
     /// `probe-repo --set <uuid> --dest <uuid>` (exit 3 = offline).
@@ -68,9 +70,10 @@ public enum HelperCommand: Equatable, Sendable {
             return Self.runSet(setId: setId, kind: "prune")
         case .check(let setId):
             return Self.runSet(setId: setId, kind: "check")
-        case .maintenancePrune(let setId, let destId, let dryRun):
+        case .maintenancePrune(let setId, let destId, let expectedRepository, let dryRun):
             var argv = ["maintenance", "prune", "--set", Self.render(setId)]
             if let destId { argv.append(contentsOf: ["--dest", Self.render(destId)]) }
+            if let expectedRepository { argv.append(contentsOf: ["--expected-repo", expectedRepository]) }
             if dryRun { argv.append("--dry-run") }
             return argv
         case .initSecondary(let setId, let destId):

--- a/Core/Sources/ResticStationCore/Support/PreviewToken.swift
+++ b/Core/Sources/ResticStationCore/Support/PreviewToken.swift
@@ -19,7 +19,8 @@ public struct PreviewTokenDestination: Codable, Equatable, Sendable {
     }
 }
 
-/// The persisted capability behind a destructive purge/retention action.
+/// The persisted capability behind a destructive purge, retention, or
+/// standalone-prune action.
 ///
 /// The opaque `value` is intentionally only ever written to the owner-only
 /// ``PreviewTokenStore`` index and returned by a successful preview.  It
@@ -110,6 +111,68 @@ public struct PreviewTokenStore: Sendable {
             index.tokens[token.value] = token
             try writeIndex(index)
             return token
+        }
+    }
+
+    /// Issues the opaque capability for a standalone prune dry run. Unlike a
+    /// purge token, the fingerprint is supplied by the helper after it has
+    /// included the destination's secret environment; only the owner-only
+    /// token index ever contains that fingerprint.
+    public func issueMaintenancePrune(
+        machineId: String,
+        setId: UUID,
+        destinationId: UUID,
+        effectiveDestinationFingerprint: String,
+        lifetime: TimeInterval = defaultLifetime
+    ) throws -> String {
+        try withStoreLock {
+            let createdAt = now()
+            var index = try readIndex()
+            discardExpiredEntries(from: &index, at: createdAt)
+            let token = PreviewToken(
+                value: Self.randomValue(),
+                machineId: machineId,
+                setId: setId,
+                destinations: [PreviewTokenDestination(destinationId: destinationId, snapshotIDs: [])],
+                configFingerprint: effectiveDestinationFingerprint,
+                patterns: ["maintenance-prune"],
+                createdAt: createdAt,
+                expiresAt: createdAt.addingTimeInterval(lifetime)
+            )
+            index.tokens[token.value] = token
+            try writeIndex(index)
+            return token.value
+        }
+    }
+
+    /// Consumes a standalone-prune capability only when this helper's freshly
+    /// loaded effective destination is identical to the one its dry run used.
+    /// A mismatch is deliberately `unknown`: callers get one fail-closed
+    /// message without learning whether a token is valid or how it differed.
+    public func consumeMaintenancePrune(
+        _ value: String,
+        machineId: String,
+        setId: UUID,
+        destinationId: UUID,
+        effectiveDestinationFingerprint: String
+    ) throws {
+        try withStoreLock {
+            var index = try readIndex()
+            guard var token = index.tokens[value] else { throw PreviewTokenError.unknown }
+            let consumedAt = now()
+            if token.expiresAt <= consumedAt { throw PreviewTokenError.expired }
+            if token.usedAt != nil { throw PreviewTokenError.alreadyUsed }
+            guard token.machineId == machineId,
+                  token.setId == setId,
+                  token.destinations == [PreviewTokenDestination(destinationId: destinationId, snapshotIDs: [])],
+                  token.configFingerprint == effectiveDestinationFingerprint,
+                  token.patterns == ["maintenance-prune"] else {
+                throw PreviewTokenError.unknown
+            }
+            token.usedAt = consumedAt
+            index.tokens[value] = token
+            discardExpiredEntries(from: &index, at: consumedAt)
+            try writeIndex(index)
         }
     }
 

--- a/Core/Sources/ResticStationCore/Support/PreviewToken.swift
+++ b/Core/Sources/ResticStationCore/Support/PreviewToken.swift
@@ -26,11 +26,20 @@ public struct MaintenancePruneAuthorization: Sendable {
     public let token: String
     public let machineId: String
     public let effectiveDestinationFingerprint: String
+    /// Canonical executable selected and hashed for this helper invocation.
+    /// It stays helper-private and is never emitted in CLI JSON or logs.
+    public let resticExecutablePath: String?
 
-    public init(token: String, machineId: String, effectiveDestinationFingerprint: String) {
+    public init(
+        token: String,
+        machineId: String,
+        effectiveDestinationFingerprint: String,
+        resticExecutablePath: String? = nil
+    ) {
         self.token = token
         self.machineId = machineId
         self.effectiveDestinationFingerprint = effectiveDestinationFingerprint
+        self.resticExecutablePath = resticExecutablePath
     }
 }
 

--- a/Core/Sources/ResticStationCore/Support/PreviewToken.swift
+++ b/Core/Sources/ResticStationCore/Support/PreviewToken.swift
@@ -19,6 +19,21 @@ public struct PreviewTokenDestination: Codable, Equatable, Sendable {
     }
 }
 
+/// Helper-private evidence required to consume a standalone-prune preview.
+/// The secret-sensitive fingerprint stays in helper/engine memory and is
+/// never serialized into the app's command line or JSON response.
+public struct MaintenancePruneAuthorization: Sendable {
+    public let token: String
+    public let machineId: String
+    public let effectiveDestinationFingerprint: String
+
+    public init(token: String, machineId: String, effectiveDestinationFingerprint: String) {
+        self.token = token
+        self.machineId = machineId
+        self.effectiveDestinationFingerprint = effectiveDestinationFingerprint
+    }
+}
+
 /// The persisted capability behind a destructive purge, retention, or
 /// standalone-prune action.
 ///

--- a/Core/Sources/ResticStationCore/Support/PreviewToken.swift
+++ b/Core/Sources/ResticStationCore/Support/PreviewToken.swift
@@ -29,17 +29,20 @@ public struct MaintenancePruneAuthorization: Sendable {
     /// Canonical executable selected and hashed for this helper invocation.
     /// It stays helper-private and is never emitted in CLI JSON or logs.
     public let resticExecutablePath: String?
+    public let resticExecutableIdentity: String?
 
     public init(
         token: String,
         machineId: String,
         effectiveDestinationFingerprint: String,
-        resticExecutablePath: String? = nil
+        resticExecutablePath: String? = nil,
+        resticExecutableIdentity: String? = nil
     ) {
         self.token = token
         self.machineId = machineId
         self.effectiveDestinationFingerprint = effectiveDestinationFingerprint
         self.resticExecutablePath = resticExecutablePath
+        self.resticExecutableIdentity = resticExecutableIdentity
     }
 }
 

--- a/Core/Tests/ResticStationCoreTests/Config/ModelsTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Config/ModelsTests.swift
@@ -482,6 +482,31 @@ let dataModelMachinesExampleJSON = """
         let destination = Destination(id: UUID(), label: "x", repoURL: repoURL, isPrimary: true)
         #expect(destination.kind == expectedKind)
     }
+
+    @Test("maintenance bindings resolve a local repository symlink")
+    func maintenanceBindingUsesResolvedLocalRepository() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("restic-station-destination-link-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let first = root.appendingPathComponent("first.restic", isDirectory: true)
+        let second = root.appendingPathComponent("second.restic", isDirectory: true)
+        try FileManager.default.createDirectory(at: first, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: second, withIntermediateDirectories: true)
+        let link = root.appendingPathComponent("current.restic", isDirectory: true)
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: first)
+
+        let destination = Destination(id: UUID(), label: "Primary", repoURL: link.path, isPrimary: true)
+        let firstFingerprint = destination.pruneConfirmationFingerprint(secretEnv: [:])
+        #expect(destination.pruneInvocationDestination().repoURL == first.path)
+
+        try FileManager.default.removeItem(at: link)
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: second)
+
+        #expect(destination.pruneInvocationDestination().repoURL == second.path)
+        #expect(firstFingerprint != destination.pruneConfirmationFingerprint(secretEnv: [:]))
+    }
 }
 
 @Suite struct RetentionPolicyTests {

--- a/Core/Tests/ResticStationCoreTests/Config/ModelsTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Config/ModelsTests.swift
@@ -507,6 +507,13 @@ let dataModelMachinesExampleJSON = """
         #expect(destination.pruneInvocationDestination().repoURL == second.path)
         #expect(firstFingerprint != destination.pruneConfirmationFingerprint(secretEnv: [:]))
     }
+
+    @Test("maintenance binding includes the previewed executable identity")
+    func maintenanceBindingUsesExecutableIdentity() {
+        let destination = Destination(id: UUID(), label: "Primary", repoURL: "/tmp/repo", isPrimary: true)
+        #expect(destination.pruneConfirmationFingerprint(secretEnv: [:], executableIdentity: "restic-a")
+            != destination.pruneConfirmationFingerprint(secretEnv: [:], executableIdentity: "restic-b"))
+    }
 }
 
 @Suite struct RetentionPolicyTests {

--- a/Core/Tests/ResticStationCoreTests/Engine/BackupEngineTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Engine/BackupEngineTests.swift
@@ -1456,6 +1456,33 @@ struct BackupEngineTests {
         #expect(env.entries(kind: .prune).isEmpty)
     }
 
+    @Test("standalone prune: a launch-time secret failure retains its preview token")
+    func standalonePruneSecretFailureRetainsItsPreviewToken() async throws {
+        let env = Self.makeEnv(secretsUnavailableFor: [Self.primaryId], script: [], retention: nil)
+        defer { env.cleanUp() }
+        let fingerprint = env.primary.pruneConfirmationFingerprint(secretEnv: [:])
+        let token = try PreviewTokenStore(paths: env.paths).issueMaintenancePrune(
+            machineId: env.machineId,
+            setId: env.set.id,
+            destinationId: env.primary.id,
+            effectiveDestinationFingerprint: fingerprint
+        )
+
+        let result = await env.engine.runPruneRepository(
+            set: env.set,
+            destination: env.primary,
+            authorization: MaintenancePruneAuthorization(
+                token: token,
+                machineId: env.machineId,
+                effectiveDestinationFingerprint: fingerprint
+            )
+        )
+
+        #expect(result == .skipped(.secretUnavailable))
+        #expect(try PreviewTokenStore(paths: env.paths).token(token).value == token)
+        #expect(env.fake.invocations.isEmpty)
+    }
+
     @Test("standalone prune: an unavailable secret is distinguished from success")
     func standalonePruneReportsSecretUnavailable() async throws {
         let env = Self.makeEnv(secretsUnavailableFor: [Self.primaryId], script: [], retention: nil)

--- a/Core/Tests/ResticStationCoreTests/Engine/BackupEngineTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Engine/BackupEngineTests.swift
@@ -1453,6 +1453,7 @@ struct BackupEngineTests {
         #expect(result == .skipped(.previewUnavailable))
         #expect(try PreviewTokenStore(paths: env.paths).token(token).value == token)
         #expect(env.fake.invocations.isEmpty)
+        #expect(env.entries(kind: .prune).isEmpty)
     }
 
     @Test("standalone prune: an unavailable secret is distinguished from success")

--- a/Core/Tests/ResticStationCoreTests/Engine/BackupEngineTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Engine/BackupEngineTests.swift
@@ -1271,21 +1271,38 @@ struct BackupEngineTests {
         #expect(env.entries(kind: .prune).count == 1)
     }
 
-    @Test("standalone prune: a stale mirror is never touched")
+    @Test("standalone prune: a stale mirror is never touched or consumes its preview token")
     func standalonePruneRefusesStaleMirror() async throws {
         let env = Self.makeEnv(script: [], retention: nil)
         defer { env.cleanUp() }
         let mirror = env.secondaries[0]
+        let fingerprint = mirror.pruneConfirmationFingerprint(secretEnv: [:])
+        let token = try PreviewTokenStore(paths: env.paths).issueMaintenancePrune(
+            machineId: env.machineId,
+            setId: env.set.id,
+            destinationId: mirror.id,
+            effectiveDestinationFingerprint: fingerprint
+        )
+        let authorization = MaintenancePruneAuthorization(
+            token: token,
+            machineId: env.machineId,
+            effectiveDestinationFingerprint: fingerprint
+        )
         try env.stateStore.updateRepoStatus(destId: env.primary.id) { $0.lastSyncedAt = Self.t0 }
         try env.stateStore.updateRepoStatus(destId: mirror.id) {
             $0.lastSyncedAt = Self.t0.addingTimeInterval(-1)
         }
 
-        let status = await env.engine.runPruneRepository(set: env.set, destination: mirror)
+        let status = await env.engine.runPruneRepository(
+            set: env.set,
+            destination: mirror,
+            authorization: authorization
+        )
 
         #expect(status == .skipped(.staleMirror))
         #expect(env.fake.invocations.isEmpty)
         #expect(env.entries(kind: .prune).isEmpty)
+        #expect(try PreviewTokenStore(paths: env.paths).token(token).value == token)
     }
 
     @Test("standalone prune: dry run never spawns a modifying restic command")

--- a/Core/Tests/ResticStationCoreTests/Engine/BackupEngineTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Engine/BackupEngineTests.swift
@@ -1382,6 +1382,24 @@ struct BackupEngineTests {
         #expect(completed == .completed(.success))
     }
 
+    @Test("standalone prune: an invalid confirmation remains previewChanged")
+    func standalonePruneInvalidConfirmationIsPreviewChanged() async throws {
+        let env = Self.makeEnv(script: [], retention: nil)
+        defer { env.cleanUp() }
+        let result = await env.engine.runPruneRepository(
+            set: env.set,
+            destination: env.primary,
+            authorization: MaintenancePruneAuthorization(
+                token: "not-a-preview-token",
+                machineId: env.machineId,
+                effectiveDestinationFingerprint: env.primary.pruneConfirmationFingerprint(secretEnv: [:])
+            )
+        )
+
+        #expect(result == .skipped(.previewChanged))
+        #expect(env.fake.invocations.isEmpty)
+    }
+
     @Test("standalone prune: an unavailable secret is distinguished from success")
     func standalonePruneReportsSecretUnavailable() async throws {
         let env = Self.makeEnv(secretsUnavailableFor: [Self.primaryId], script: [], retention: nil)

--- a/Core/Tests/ResticStationCoreTests/Engine/BackupEngineTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Engine/BackupEngineTests.swift
@@ -1271,6 +1271,30 @@ struct BackupEngineTests {
         #expect(env.entries(kind: .prune).count == 1)
     }
 
+    @Test("standalone prune: automatic unlock reuses its confirmed secret snapshot")
+    func standalonePruneUnlockUsesConfirmedSecretSnapshot() async throws {
+        let env = Self.makeEnv(script: [], retention: nil)
+        defer { env.cleanUp() }
+        let snapshot = ["RESTIC_PASSWORD": "previewed-password", "RCLONE_CONFIG_REMOTE": "previewed-remote"]
+        var script: [FakeProcessRunner.Expectation] = []
+        script += Self.resticCall(["-r", env.primary.repoURL, "prune"], dest: Self.primaryId, exitCode: 11)
+        script += Self.resticCall(["-r", env.primary.repoURL, "unlock"], dest: Self.primaryId)
+        script += Self.resticCall(["-r", env.primary.repoURL, "prune"], dest: Self.primaryId)
+        env.fake.script = script
+
+        let status = await env.engine.runPruneRepository(
+            set: env.set,
+            destination: env.primary,
+            destinationSecretEnv: snapshot
+        )
+
+        #expect(status == .completed(.success))
+        let resticInvocations = env.fake.invocations.filter { $0.argv.first == Self.resticPath }
+        #expect(resticInvocations.count == 3)
+        #expect(resticInvocations[1].env == resticInvocations[0].env)
+        #expect(resticInvocations[1].env == resticInvocations[2].env)
+    }
+
     @Test("standalone prune: a stale mirror is never touched or consumes its preview token")
     func standalonePruneRefusesStaleMirror() async throws {
         let env = Self.makeEnv(script: [], retention: nil)

--- a/Core/Tests/ResticStationCoreTests/Engine/BackupEngineTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Engine/BackupEngineTests.swift
@@ -1326,6 +1326,45 @@ struct BackupEngineTests {
         #expect(env.entries(kind: .prune).isEmpty)
     }
 
+    @Test("standalone prune: a busy confirmation does not consume its preview token")
+    func standalonePruneBusyConfirmationRetainsItsPreviewToken() async throws {
+        let env = Self.makeEnv(script: [], retention: nil)
+        defer { env.cleanUp() }
+        let fingerprint = env.primary.pruneConfirmationFingerprint(secretEnv: [:])
+        let token = try PreviewTokenStore(paths: env.paths).issueMaintenancePrune(
+            machineId: env.machineId,
+            setId: env.set.id,
+            destinationId: env.primary.id,
+            effectiveDestinationFingerprint: fingerprint
+        )
+        let authorization = MaintenancePruneAuthorization(
+            token: token,
+            machineId: env.machineId,
+            effectiveDestinationFingerprint: fingerprint
+        )
+        try env.paths.ensureDirectories()
+        let heldLock = FileLock(path: env.paths.setLockFile(setId: env.set.id))
+        #expect(heldLock.tryAcquire())
+
+        let busy = await env.engine.runPruneRepository(
+            set: env.set,
+            destination: env.primary,
+            authorization: authorization
+        )
+        heldLock.release()
+
+        #expect(busy == .skipped(.busy))
+        #expect(try PreviewTokenStore(paths: env.paths).token(token).value == token)
+
+        env.fake.script = Self.resticCall(["-r", env.primary.repoURL, "prune"], dest: Self.primaryId)
+        let completed = await env.engine.runPruneRepository(
+            set: env.set,
+            destination: env.primary,
+            authorization: authorization
+        )
+        #expect(completed == .completed(.success))
+    }
+
     @Test("standalone prune: an unavailable secret is distinguished from success")
     func standalonePruneReportsSecretUnavailable() async throws {
         let env = Self.makeEnv(secretsUnavailableFor: [Self.primaryId], script: [], retention: nil)

--- a/Core/Tests/ResticStationCoreTests/Engine/BackupEngineTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Engine/BackupEngineTests.swift
@@ -1306,6 +1306,26 @@ struct BackupEngineTests {
         #expect(env.entries(kind: .prune).isEmpty, "a preview must not replace the last real prune run")
     }
 
+    @Test("standalone prune: a busy dry run is also absent from history")
+    func standalonePruneBusyDryRunIsUnrecorded() async throws {
+        let env = Self.makeEnv(script: [], retention: nil)
+        defer { env.cleanUp() }
+        try env.paths.ensureDirectories()
+        let heldLock = FileLock(path: env.paths.setLockFile(setId: env.set.id))
+        #expect(heldLock.tryAcquire())
+        defer { heldLock.release() }
+
+        let result = await env.engine.runPruneRepository(
+            set: env.set,
+            destination: env.primary,
+            dryRun: true
+        )
+
+        #expect(result == .skipped(.busy))
+        #expect(env.fake.invocations.isEmpty)
+        #expect(env.entries(kind: .prune).isEmpty)
+    }
+
     @Test("standalone prune: an unavailable secret is distinguished from success")
     func standalonePruneReportsSecretUnavailable() async throws {
         let env = Self.makeEnv(secretsUnavailableFor: [Self.primaryId], script: [], retention: nil)

--- a/Core/Tests/ResticStationCoreTests/Engine/BackupEngineTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Engine/BackupEngineTests.swift
@@ -1424,6 +1424,37 @@ struct BackupEngineTests {
         #expect(env.fake.invocations.isEmpty)
     }
 
+    @Test("standalone prune: token-store contention preserves the preview for retry")
+    func standalonePruneUnavailableConfirmationRetainsItsPreviewToken() async throws {
+        let env = Self.makeEnv(script: [], retention: nil)
+        defer { env.cleanUp() }
+        let fingerprint = env.primary.pruneConfirmationFingerprint(secretEnv: [:])
+        let token = try PreviewTokenStore(paths: env.paths).issueMaintenancePrune(
+            machineId: env.machineId,
+            setId: env.set.id,
+            destinationId: env.primary.id,
+            effectiveDestinationFingerprint: fingerprint
+        )
+        try env.paths.ensureDirectories()
+        let heldTokenStoreLock = FileLock(path: env.paths.previewTokensLockFile)
+        #expect(heldTokenStoreLock.tryAcquire())
+
+        let result = await env.engine.runPruneRepository(
+            set: env.set,
+            destination: env.primary,
+            authorization: MaintenancePruneAuthorization(
+                token: token,
+                machineId: env.machineId,
+                effectiveDestinationFingerprint: fingerprint
+            )
+        )
+        heldTokenStoreLock.release()
+
+        #expect(result == .skipped(.previewUnavailable))
+        #expect(try PreviewTokenStore(paths: env.paths).token(token).value == token)
+        #expect(env.fake.invocations.isEmpty)
+    }
+
     @Test("standalone prune: an unavailable secret is distinguished from success")
     func standalonePruneReportsSecretUnavailable() async throws {
         let env = Self.makeEnv(secretsUnavailableFor: [Self.primaryId], script: [], retention: nil)

--- a/Core/Tests/ResticStationCoreTests/Engine/ReachabilityTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Engine/ReachabilityTests.swift
@@ -99,6 +99,26 @@ struct ReachabilityTests {
         #expect(resticCall?.argv == ["/usr/local/bin/restic", "-r", dest.repoURL, "cat", "config"])
     }
 
+    @Test("remote destination: an explicit secret snapshot is used for the probe")
+    func remoteProbeUsesProvidedSecretSnapshot() async throws {
+        let dest = Destination(id: Self.destId, label: "R2", repoURL: "s3:https://x/bucket", isPrimary: false)
+        let fake = FakeProcessRunner(script: [
+            .init(argvPrefix: ["/usr/local/bin/restic", "-r", dest.repoURL, "cat", "config"]),
+        ])
+        let secrets = FakeSecretStore(defaultPassword: Self.password)
+        secrets.store(secretEnv: ["AWS_SECRET_ACCESS_KEY": "changed-after-preview"], for: dest.id)
+        let reachability = Self.makeReachability(fake, secrets: secrets)
+
+        let result = await reachability.probe(
+            dest,
+            destinationSecretEnv: ["AWS_SECRET_ACCESS_KEY": "previewed-value"]
+        )
+
+        #expect(result == .reachable)
+        let env = try #require(fake.invocations.last?.env)
+        #expect(env["AWS_SECRET_ACCESS_KEY"] == "previewed-value")
+    }
+
     @Test("remote destination: a ProcessRunning timeout is offline, not error")
     func remoteTimeoutIsOffline() async throws {
         let dest = Destination(id: Self.destId, label: "R2", repoURL: "s3:https://x/bucket", isPrimary: false)

--- a/Core/Tests/ResticStationCoreTests/Restic/ResticRunnerTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Restic/ResticRunnerTests.swift
@@ -110,6 +110,37 @@ struct ResticRunnerTests {
         #expect(fake.invocations.first?.argv.first == previewed.path)
     }
 
+    @Test("maintenance executable replacement is refused before spawning restic")
+    func maintenanceExecutableReplacementIsRejectedAtLaunch() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("restic-station-executable-recheck-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let executable = root.appendingPathComponent("restic", isDirectory: false)
+        try Data("previewed binary".utf8).write(to: executable)
+        let fake = FakeProcessRunner()
+        let runner = ResticRunner(
+            resticPath: executable.path,
+            paths: Self.paths(),
+            secrets: FakeSecretStore(defaultPassword: Self.password),
+            runner: fake
+        )
+        let previewed = try #require(runner.maintenanceExecutable())
+        try Data("replacement binary".utf8).write(to: executable)
+
+        await #expect(throws: ResticRunnerError.launchFailed("the restic executable changed after the maintenance preview")) {
+            try await runner.run(
+                .backup(repo: Self.primary.repoURL, sources: ["/tmp/source"]),
+                for: ResticInvocation(
+                    destination: Self.primary,
+                    resticPathOverride: previewed.path,
+                    expectedExecutableIdentity: previewed.identity
+                )
+            )
+        }
+        #expect(fake.invocations.isEmpty)
+    }
+
     // MARK: - Environment assembly
 
     @Test("single destination: exact password command, cache dir, secret env injected, nothing inherited")

--- a/Core/Tests/ResticStationCoreTests/Restic/ResticRunnerTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Restic/ResticRunnerTests.swift
@@ -58,6 +58,27 @@ struct ResticRunnerTests {
         return store
     }
 
+    @Test("maintenance executable identity changes when the binary is replaced")
+    func maintenanceExecutableIdentityBindsBinaryContents() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("restic-station-executable-identity-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let executable = root.appendingPathComponent("restic", isDirectory: false)
+        try Data("previewed binary".utf8).write(to: executable)
+
+        let runner = ResticRunner(
+            resticPath: executable.path,
+            paths: Self.paths(),
+            secrets: FakeSecretStore(defaultPassword: Self.password),
+            runner: FakeProcessRunner()
+        )
+        let previewIdentity = try #require(runner.maintenanceExecutableIdentity())
+        try Data("replacement binary".utf8).write(to: executable)
+
+        #expect(previewIdentity != runner.maintenanceExecutableIdentity())
+    }
+
     // MARK: - Environment assembly
 
     @Test("single destination: exact password command, cache dir, secret env injected, nothing inherited")

--- a/Core/Tests/ResticStationCoreTests/Restic/ResticRunnerTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Restic/ResticRunnerTests.swift
@@ -230,6 +230,28 @@ struct ResticRunnerTests {
         #expect(env["AWS_SECRET_ACCESS_KEY"] == "from-the-store")
     }
 
+    @Test("a supplied destination secret snapshot is used without rereading the store")
+    func suppliedDestinationSecretEnvIsUsedVerbatim() async throws {
+        let fake = FakeProcessRunner(script: [
+            .init(argvPrefix: [Self.resticPath, "-r", "/repo", "snapshots", "--json"]),
+        ])
+        let runner = Self.makeRunner(fake, secrets: Self.secretStore(
+            for: Self.primaryId,
+            secretEnv: ["AWS_SECRET_ACCESS_KEY": "changed-after-preview"]
+        ))
+
+        _ = try await runner.run(
+            .snapshots(repo: "/repo"),
+            for: ResticInvocation(
+                destination: Self.primary,
+                destinationSecretEnv: ["AWS_SECRET_ACCESS_KEY": "previewed-value"]
+            )
+        )
+
+        let env = try #require(fake.invocations[0].env)
+        #expect(env["AWS_SECRET_ACCESS_KEY"] == "previewed-value")
+    }
+
     /// End-to-end env assembly with the *real* file backend, on every
     /// platform: the assembled environment must carry both the password
     /// command and the two variables its child needs to find the same

--- a/Core/Tests/ResticStationCoreTests/Restic/ResticRunnerTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Restic/ResticRunnerTests.swift
@@ -73,10 +73,41 @@ struct ResticRunnerTests {
             secrets: FakeSecretStore(defaultPassword: Self.password),
             runner: FakeProcessRunner()
         )
-        let previewIdentity = try #require(runner.maintenanceExecutableIdentity())
+        let previewIdentity = try #require(runner.maintenanceExecutable()?.identity)
         try Data("replacement binary".utf8).write(to: executable)
 
-        #expect(previewIdentity != runner.maintenanceExecutableIdentity())
+        #expect(previewIdentity != runner.maintenanceExecutable()?.identity)
+    }
+
+    @Test("maintenance runner keeps the previewed executable when its symlink retargets")
+    func maintenanceExecutableIdentityUsesCanonicalExecutablePath() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("restic-station-executable-link-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let previewed = root.appendingPathComponent("restic-previewed", isDirectory: false)
+        let replacement = root.appendingPathComponent("restic-replacement", isDirectory: false)
+        try Data("previewed binary".utf8).write(to: previewed)
+        try Data("replacement binary".utf8).write(to: replacement)
+        let link = root.appendingPathComponent("restic", isDirectory: false)
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: previewed)
+        let fake = FakeProcessRunner(script: [.init(argvPrefix: [previewed.path, "-r", Self.primary.repoURL, "backup", "--json"])])
+        let runner = ResticRunner(
+            resticPath: link.path,
+            paths: Self.paths(),
+            secrets: FakeSecretStore(defaultPassword: Self.password),
+            runner: fake
+        )
+        let previewedExecutable = try #require(runner.maintenanceExecutable())
+        try FileManager.default.removeItem(at: link)
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: replacement)
+
+        #expect(previewedExecutable != runner.maintenanceExecutable())
+        _ = try await runner.run(
+            .backup(repo: Self.primary.repoURL, sources: ["/tmp/source"]),
+            for: ResticInvocation(destination: Self.primary, resticPathOverride: previewedExecutable.path)
+        )
+        #expect(fake.invocations.first?.argv.first == previewed.path)
     }
 
     // MARK: - Environment assembly

--- a/Core/Tests/ResticStationCoreTests/Support/HelperCommandTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Support/HelperCommandTests.swift
@@ -74,11 +74,16 @@ private let destId = UUID(uuidString: "0B7A50D4-9C3E-4F5B-9A0E-8E1F2C3D4A5B")!
 
     @Test func maintenancePrune() {
         #expect(
-            HelperCommand.maintenancePrune(setId: setId, destId: destId, dryRun: true).argv
-                == ["maintenance", "prune", "--set", "6B29FC40-CA47-1067-B31D-00DD010662DA", "--dest", "0B7A50D4-9C3E-4F5B-9A0E-8E1F2C3D4A5B", "--dry-run"]
+            HelperCommand.maintenancePrune(
+                setId: setId,
+                destId: destId,
+                expectedRepository: "/Volumes/Backups/projects.restic",
+                dryRun: true
+            ).argv
+                == ["maintenance", "prune", "--set", "6B29FC40-CA47-1067-B31D-00DD010662DA", "--dest", "0B7A50D4-9C3E-4F5B-9A0E-8E1F2C3D4A5B", "--expected-repo", "/Volumes/Backups/projects.restic", "--dry-run"]
         )
         #expect(
-            HelperCommand.maintenancePrune(setId: setId, destId: nil, dryRun: false).argv
+            HelperCommand.maintenancePrune(setId: setId, destId: nil, expectedRepository: nil, dryRun: false).argv
                 == ["maintenance", "prune", "--set", "6B29FC40-CA47-1067-B31D-00DD010662DA"]
         )
     }
@@ -145,7 +150,7 @@ private let destId = UUID(uuidString: "0B7A50D4-9C3E-4F5B-9A0E-8E1F2C3D4A5B")!
             .backUpNow(setId: setId),
             .prune(setId: setId),
             .check(setId: setId),
-            .maintenancePrune(setId: setId, destId: destId, dryRun: true),
+            .maintenancePrune(setId: setId, destId: destId, expectedRepository: nil, dryRun: true),
             .initSecondary(setId: setId, destId: destId),
             .probeRepo(setId: setId, destId: destId),
             .unlock(setId: setId, destId: destId),

--- a/Core/Tests/ResticStationCoreTests/Support/HelperCommandTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Support/HelperCommandTests.swift
@@ -81,7 +81,7 @@ private let destId = UUID(uuidString: "0B7A50D4-9C3E-4F5B-9A0E-8E1F2C3D4A5B")!
                 dryRun: true,
                 json: true
             ).argv
-                == ["maintenance", "prune", "--set", "6B29FC40-CA47-1067-B31D-00DD010662DA", "--dest", "0B7A50D4-9C3E-4F5B-9A0E-8E1F2C3D4A5B", "--expected-destination", "preview-fingerprint", "--dry-run", "--json"]
+                == ["maintenance", "prune", "--set", "6B29FC40-CA47-1067-B31D-00DD010662DA", "--dest", "0B7A50D4-9C3E-4F5B-9A0E-8E1F2C3D4A5B", "--expected-destination=preview-fingerprint", "--dry-run", "--json"]
         )
         #expect(
             HelperCommand.maintenancePrune(setId: setId, destId: nil, expectedDestination: nil, dryRun: false).argv

--- a/Core/Tests/ResticStationCoreTests/Support/HelperCommandTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Support/HelperCommandTests.swift
@@ -77,13 +77,13 @@ private let destId = UUID(uuidString: "0B7A50D4-9C3E-4F5B-9A0E-8E1F2C3D4A5B")!
             HelperCommand.maintenancePrune(
                 setId: setId,
                 destId: destId,
-                expectedRepository: "/Volumes/Backups/projects.restic",
+                expectedDestination: "preview-fingerprint",
                 dryRun: true
             ).argv
-                == ["maintenance", "prune", "--set", "6B29FC40-CA47-1067-B31D-00DD010662DA", "--dest", "0B7A50D4-9C3E-4F5B-9A0E-8E1F2C3D4A5B", "--expected-repo", "/Volumes/Backups/projects.restic", "--dry-run"]
+                == ["maintenance", "prune", "--set", "6B29FC40-CA47-1067-B31D-00DD010662DA", "--dest", "0B7A50D4-9C3E-4F5B-9A0E-8E1F2C3D4A5B", "--expected-destination", "preview-fingerprint", "--dry-run"]
         )
         #expect(
-            HelperCommand.maintenancePrune(setId: setId, destId: nil, expectedRepository: nil, dryRun: false).argv
+            HelperCommand.maintenancePrune(setId: setId, destId: nil, expectedDestination: nil, dryRun: false).argv
                 == ["maintenance", "prune", "--set", "6B29FC40-CA47-1067-B31D-00DD010662DA"]
         )
     }
@@ -150,7 +150,7 @@ private let destId = UUID(uuidString: "0B7A50D4-9C3E-4F5B-9A0E-8E1F2C3D4A5B")!
             .backUpNow(setId: setId),
             .prune(setId: setId),
             .check(setId: setId),
-            .maintenancePrune(setId: setId, destId: destId, expectedRepository: nil, dryRun: true),
+            .maintenancePrune(setId: setId, destId: destId, expectedDestination: nil, dryRun: true),
             .initSecondary(setId: setId, destId: destId),
             .probeRepo(setId: setId, destId: destId),
             .unlock(setId: setId, destId: destId),

--- a/Core/Tests/ResticStationCoreTests/Support/HelperCommandTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Support/HelperCommandTests.swift
@@ -78,9 +78,10 @@ private let destId = UUID(uuidString: "0B7A50D4-9C3E-4F5B-9A0E-8E1F2C3D4A5B")!
                 setId: setId,
                 destId: destId,
                 expectedDestination: "preview-fingerprint",
-                dryRun: true
+                dryRun: true,
+                json: true
             ).argv
-                == ["maintenance", "prune", "--set", "6B29FC40-CA47-1067-B31D-00DD010662DA", "--dest", "0B7A50D4-9C3E-4F5B-9A0E-8E1F2C3D4A5B", "--expected-destination", "preview-fingerprint", "--dry-run"]
+                == ["maintenance", "prune", "--set", "6B29FC40-CA47-1067-B31D-00DD010662DA", "--dest", "0B7A50D4-9C3E-4F5B-9A0E-8E1F2C3D4A5B", "--expected-destination", "preview-fingerprint", "--dry-run", "--json"]
         )
         #expect(
             HelperCommand.maintenancePrune(setId: setId, destId: nil, expectedDestination: nil, dryRun: false).argv

--- a/Core/Tests/ResticStationCoreTests/Support/PreviewTokenTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Support/PreviewTokenTests.swift
@@ -64,6 +64,47 @@ struct PreviewTokenStoreTests {
         _ = try store.consume(token.value)
         #expect(throws: PreviewTokenError.alreadyUsed) { try store.token(token.value) }
 
+        let maintenance = try store.issueMaintenancePrune(
+            machineId: "example-machine",
+            setId: setId,
+            destinationId: destinationId,
+            effectiveDestinationFingerprint: "secret-inclusive-preview"
+        )
+        #expect(maintenance.count >= 43)
+        #expect(maintenance != "secret-inclusive-preview")
+        try store.consumeMaintenancePrune(
+            maintenance,
+            machineId: "example-machine",
+            setId: setId,
+            destinationId: destinationId,
+            effectiveDestinationFingerprint: "secret-inclusive-preview"
+        )
+        #expect(throws: PreviewTokenError.alreadyUsed) {
+            try store.consumeMaintenancePrune(
+                maintenance,
+                machineId: "example-machine",
+                setId: setId,
+                destinationId: destinationId,
+                effectiveDestinationFingerprint: "secret-inclusive-preview"
+            )
+        }
+
+        let changed = try store.issueMaintenancePrune(
+            machineId: "example-machine",
+            setId: setId,
+            destinationId: destinationId,
+            effectiveDestinationFingerprint: "preview-secret-environment"
+        )
+        #expect(throws: PreviewTokenError.unknown) {
+            try store.consumeMaintenancePrune(
+                changed,
+                machineId: "example-machine",
+                setId: setId,
+                destinationId: destinationId,
+                effectiveDestinationFingerprint: "changed-secret-environment"
+            )
+        }
+
         let expiring = try store.issue(
             machineId: "example-machine",
             setId: setId,

--- a/Helper/Sources/Commands/Maintenance.swift
+++ b/Helper/Sources/Commands/Maintenance.swift
@@ -26,6 +26,12 @@ struct MaintenancePrune: AsyncParsableCommand, JSONRenderable {
     @Option(name: .long, help: "Destination UUID. Defaults to the primary destination.")
     var dest: UUID?
 
+    /// App confirmations carry the repository address that their dry run
+    /// inspected. The helper owns the final check, because it reloads config
+    /// after the app may have compared an earlier in-memory snapshot.
+    @Option(name: .long, help: "Require the resolved destination to use this repository address.")
+    var expectedRepo: String?
+
     @Flag(name: .long, help: "Ask restic what prune would reclaim without modifying the repository.")
     var dryRun = false
 
@@ -61,6 +67,12 @@ struct MaintenancePrune: AsyncParsableCommand, JSONRenderable {
             )
         }
 
+        try Self.validateExpectedRepository(
+            expectedRepo,
+            destination: destination,
+            setId: set
+        )
+
         let result = await context.engine.runPruneRepository(
             set: backupSet,
             destination: destination,
@@ -86,6 +98,23 @@ struct MaintenancePrune: AsyncParsableCommand, JSONRenderable {
             let qualifier = dryRun ? "dry run " : ""
             print("\"\(destination.label)\": prune \(qualifier)\(status.rawValue)")
         }
+    }
+
+    /// The destructive command must validate against the helper's freshly
+    /// loaded config, not only against the app's earlier in-memory view. Kept
+    /// separate for a focused regression that proves the check happens before
+    /// an engine/restic invocation can be reached.
+    static func validateExpectedRepository(
+        _ expectedRepo: String?,
+        destination: Destination,
+        setId: UUID
+    ) throws {
+        guard let expectedRepo, destination.repoURL != expectedRepo else { return }
+        throw CLIFailure(
+            code: .operationNotAllowed,
+            message: "Destination configuration changed after the reclaim preview. Run a new dry run before pruning.",
+            details: CLIErrorDetails(setId: setId, destinationId: destination.id)
+        )
     }
 
     private static func status(

--- a/Helper/Sources/Commands/Maintenance.swift
+++ b/Helper/Sources/Commands/Maintenance.swift
@@ -97,7 +97,8 @@ struct MaintenancePrune: AsyncParsableCommand, JSONRenderable {
                 token: $0,
                 machineId: context.addressable.machineId,
                 effectiveDestinationFingerprint: effectiveFingerprint,
-                resticExecutablePath: executable.path
+                resticExecutablePath: executable.path,
+                resticExecutableIdentity: executable.identity
             )
         }
 
@@ -107,6 +108,7 @@ struct MaintenancePrune: AsyncParsableCommand, JSONRenderable {
             destinationSecretEnv: destinationSecretEnv,
             authorization: authorization,
             resticExecutablePath: executable.path,
+            resticExecutableIdentity: executable.identity,
             dryRun: dryRun
         )
         let status = try Self.status(

--- a/Helper/Sources/Commands/Maintenance.swift
+++ b/Helper/Sources/Commands/Maintenance.swift
@@ -45,6 +45,10 @@ struct MaintenancePrune: AsyncParsableCommand, JSONRenderable {
         let label: String
         let dryRun: Bool
         let status: RunStatus
+        /// Opaque and emitted only by a successful dry run. The app sends it
+        /// back on confirmation; the helper recomputes it from freshly loaded
+        /// config plus secret storage before it allows a destructive prune.
+        let confirmationBinding: String?
     }
 
     func run() async throws {
@@ -68,11 +72,14 @@ struct MaintenancePrune: AsyncParsableCommand, JSONRenderable {
             )
         }
 
-        try Self.validateExpectedDestination(
-            expectedDestination,
-            destination: destination,
-            setId: set
-        )
+        if let expectedDestination {
+            try Self.validateExpectedDestination(
+                expectedDestination,
+                destination: destination,
+                setId: set,
+                secretEnv: try await context.secrets.secretEnv(destId: destination.id)
+            )
+        }
 
         let result = await context.engine.runPruneRepository(
             set: backupSet,
@@ -85,13 +92,23 @@ struct MaintenancePrune: AsyncParsableCommand, JSONRenderable {
             destination: destination,
             context: context
         )
+        let confirmationBinding: String?
+        if dryRun {
+            confirmationBinding = try await Self.confirmationBinding(
+                destination: destination,
+                secrets: context.secrets
+            )
+        } else {
+            confirmationBinding = nil
+        }
 
         let report = Report(
             setId: set,
             destinationId: destination.id,
             label: destination.label,
             dryRun: dryRun,
-            status: status
+            status: status,
+            confirmationBinding: confirmationBinding
         )
         if json {
             CLIJSON.print(report)
@@ -108,15 +125,29 @@ struct MaintenancePrune: AsyncParsableCommand, JSONRenderable {
     static func validateExpectedDestination(
         _ expectedDestination: String?,
         destination: Destination,
-        setId: UUID
+        setId: UUID,
+        secretEnv: [String: String]
     ) throws {
         guard let expectedDestination,
-              destination.pruneConfirmationFingerprint() != expectedDestination else { return }
+              destination.pruneConfirmationFingerprint(secretEnv: secretEnv) != expectedDestination else { return }
         throw CLIFailure(
             code: .operationNotAllowed,
             message: "Destination configuration changed after the reclaim preview. Run a new dry run before pruning.",
             details: CLIErrorDetails(setId: setId, destinationId: destination.id)
         )
+    }
+
+    private static func confirmationBinding(
+        destination: Destination,
+        secrets: any SecretStore
+    ) async throws -> String {
+        do {
+            return destination.pruneConfirmationFingerprint(
+                secretEnv: try await secrets.secretEnv(destId: destination.id)
+            )
+        } catch {
+            throw CLIFailure.classify(error)
+        }
     }
 
     private static func status(

--- a/Helper/Sources/Commands/Maintenance.swift
+++ b/Helper/Sources/Commands/Maintenance.swift
@@ -75,11 +75,12 @@ struct MaintenancePrune: AsyncParsableCommand, JSONRenderable {
             )
         }
 
+        let invocationDestination = destination.pruneInvocationDestination()
         let destinationSecretEnv = try await Self.destinationSecretEnv(
             destination: destination,
             secrets: context.secrets
         )
-        let effectiveFingerprint = destination.pruneConfirmationFingerprint(secretEnv: destinationSecretEnv)
+        let effectiveFingerprint = invocationDestination.pruneConfirmationFingerprint(secretEnv: destinationSecretEnv)
 
         let authorization = expectedDestination.map {
             MaintenancePruneAuthorization(
@@ -91,7 +92,7 @@ struct MaintenancePrune: AsyncParsableCommand, JSONRenderable {
 
         let result = await context.engine.runPruneRepository(
             set: backupSet,
-            destination: destination,
+            destination: invocationDestination,
             destinationSecretEnv: destinationSecretEnv,
             authorization: authorization,
             dryRun: dryRun
@@ -121,7 +122,7 @@ struct MaintenancePrune: AsyncParsableCommand, JSONRenderable {
             dryRun: dryRun,
             status: status,
             confirmationBinding: confirmationBinding,
-            destinationFingerprint: destination.pruneConfirmationFingerprint(secretEnv: [:])
+            destinationFingerprint: invocationDestination.pruneConfirmationFingerprint(secretEnv: [:])
         )
         if json {
             CLIJSON.print(report)

--- a/Helper/Sources/Commands/Maintenance.swift
+++ b/Helper/Sources/Commands/Maintenance.swift
@@ -29,7 +29,7 @@ struct MaintenancePrune: AsyncParsableCommand, JSONRenderable {
     /// App confirmations carry an opaque, helper-issued preview binding. The
     /// helper owns the final check, because it reloads config after the app
     /// may have compared an earlier in-memory snapshot.
-    @Option(name: .long, help: "Require this helper-issued preview binding before pruning.")
+    @Option(name: .long, parsing: .unconditional, help: "Require this helper-issued preview binding before pruning.")
     var expectedDestination: String?
 
     @Flag(name: .long, help: "Ask restic what prune would reclaim without modifying the repository.")
@@ -80,7 +80,17 @@ struct MaintenancePrune: AsyncParsableCommand, JSONRenderable {
             destination: destination,
             secrets: context.secrets
         )
-        let effectiveFingerprint = invocationDestination.pruneConfirmationFingerprint(secretEnv: destinationSecretEnv)
+        guard let executableIdentity = context.restic.maintenanceExecutableIdentity() else {
+            throw CLIFailure(
+                code: .resticNotFound,
+                message: "The configured restic executable could not be read. Recheck restic, then run a new reclaim preview.",
+                details: CLIErrorDetails(setId: set, destinationId: destination.id)
+            )
+        }
+        let effectiveFingerprint = invocationDestination.pruneConfirmationFingerprint(
+            secretEnv: destinationSecretEnv,
+            executableIdentity: executableIdentity
+        )
 
         let authorization = expectedDestination.map {
             MaintenancePruneAuthorization(
@@ -176,6 +186,12 @@ struct MaintenancePrune: AsyncParsableCommand, JSONRenderable {
             )
         case .skipped(.previewChanged):
             throw previewChangedFailure(setId: setId, destinationId: destination.id)
+        case .skipped(.previewUnavailable):
+            throw CLIFailure(
+                code: .setBusy,
+                message: "The reclaim confirmation is temporarily unavailable. Try confirming again.",
+                details: CLIErrorDetails(setId: setId, destinationId: destination.id)
+            )
         case .failed(.offline(let reason)):
             throw CLIFailure(
                 code: .repositoryOffline,

--- a/Helper/Sources/Commands/Maintenance.swift
+++ b/Helper/Sources/Commands/Maintenance.swift
@@ -26,11 +26,10 @@ struct MaintenancePrune: AsyncParsableCommand, JSONRenderable {
     @Option(name: .long, help: "Destination UUID. Defaults to the primary destination.")
     var dest: UUID?
 
-    /// App confirmations carry a fingerprint of the complete effective
-    /// destination their dry run inspected. The helper owns the final check,
-    /// because it reloads config after the app may have compared an earlier
-    /// in-memory snapshot.
-    @Option(name: .long, help: "Require the resolved destination to match this preview fingerprint.")
+    /// App confirmations carry an opaque, helper-issued preview binding. The
+    /// helper owns the final check, because it reloads config after the app
+    /// may have compared an earlier in-memory snapshot.
+    @Option(name: .long, help: "Require this helper-issued preview binding before pruning.")
     var expectedDestination: String?
 
     @Flag(name: .long, help: "Ask restic what prune would reclaim without modifying the repository.")
@@ -73,12 +72,21 @@ struct MaintenancePrune: AsyncParsableCommand, JSONRenderable {
         }
 
         if let expectedDestination {
-            try Self.validateExpectedDestination(
-                expectedDestination,
+            let effectiveFingerprint = try await Self.effectiveDestinationFingerprint(
                 destination: destination,
-                setId: set,
-                secretEnv: try await context.secrets.secretEnv(destId: destination.id)
+                secrets: context.secrets
             )
+            do {
+                try PreviewTokenStore(paths: context.paths).consumeMaintenancePrune(
+                    expectedDestination,
+                    machineId: context.addressable.machineId,
+                    setId: set,
+                    destinationId: destination.id,
+                    effectiveDestinationFingerprint: effectiveFingerprint
+                )
+            } catch {
+                throw Self.previewChangedFailure(setId: set, destinationId: destination.id)
+            }
         }
 
         let result = await context.engine.runPruneRepository(
@@ -94,9 +102,15 @@ struct MaintenancePrune: AsyncParsableCommand, JSONRenderable {
         )
         let confirmationBinding: String?
         if dryRun {
-            confirmationBinding = try await Self.confirmationBinding(
+            let effectiveFingerprint = try await Self.effectiveDestinationFingerprint(
                 destination: destination,
                 secrets: context.secrets
+            )
+            confirmationBinding = try PreviewTokenStore(paths: context.paths).issueMaintenancePrune(
+                machineId: context.addressable.machineId,
+                setId: set,
+                destinationId: destination.id,
+                effectiveDestinationFingerprint: effectiveFingerprint
             )
         } else {
             confirmationBinding = nil
@@ -118,26 +132,15 @@ struct MaintenancePrune: AsyncParsableCommand, JSONRenderable {
         }
     }
 
-    /// The destructive command must validate against the helper's freshly
-    /// loaded config, not only against the app's earlier in-memory view. Kept
-    /// separate for a focused regression that proves the check happens before
-    /// an engine/restic invocation can be reached.
-    static func validateExpectedDestination(
-        _ expectedDestination: String?,
-        destination: Destination,
-        setId: UUID,
-        secretEnv: [String: String]
-    ) throws {
-        guard let expectedDestination,
-              destination.pruneConfirmationFingerprint(secretEnv: secretEnv) != expectedDestination else { return }
-        throw CLIFailure(
+    private static func previewChangedFailure(setId: UUID, destinationId: UUID) -> CLIFailure {
+        CLIFailure(
             code: .operationNotAllowed,
             message: "Destination configuration changed after the reclaim preview. Run a new dry run before pruning.",
-            details: CLIErrorDetails(setId: setId, destinationId: destination.id)
+            details: CLIErrorDetails(setId: setId, destinationId: destinationId)
         )
     }
 
-    private static func confirmationBinding(
+    private static func effectiveDestinationFingerprint(
         destination: Destination,
         secrets: any SecretStore
     ) async throws -> String {

--- a/Helper/Sources/Commands/Maintenance.swift
+++ b/Helper/Sources/Commands/Maintenance.swift
@@ -48,6 +48,10 @@ struct MaintenancePrune: AsyncParsableCommand, JSONRenderable {
         /// back on confirmation; the helper recomputes it from freshly loaded
         /// config plus secret storage before it allows a destructive prune.
         let confirmationBinding: String?
+        /// Non-secret identity of the destination the helper actually
+        /// previewed. The app compares it with the destination it displays
+        /// before offering a destructive confirmation.
+        let destinationFingerprint: String
     }
 
     func run() async throws {
@@ -77,24 +81,19 @@ struct MaintenancePrune: AsyncParsableCommand, JSONRenderable {
         )
         let effectiveFingerprint = destination.pruneConfirmationFingerprint(secretEnv: destinationSecretEnv)
 
-        if let expectedDestination {
-            do {
-                try PreviewTokenStore(paths: context.paths).consumeMaintenancePrune(
-                    expectedDestination,
-                    machineId: context.addressable.machineId,
-                    setId: set,
-                    destinationId: destination.id,
-                    effectiveDestinationFingerprint: effectiveFingerprint
-                )
-            } catch {
-                throw Self.previewChangedFailure(setId: set, destinationId: destination.id)
-            }
+        let authorization = expectedDestination.map {
+            MaintenancePruneAuthorization(
+                token: $0,
+                machineId: context.addressable.machineId,
+                effectiveDestinationFingerprint: effectiveFingerprint
+            )
         }
 
         let result = await context.engine.runPruneRepository(
             set: backupSet,
             destination: destination,
             destinationSecretEnv: destinationSecretEnv,
+            authorization: authorization,
             dryRun: dryRun
         )
         let status = try Self.status(
@@ -121,7 +120,8 @@ struct MaintenancePrune: AsyncParsableCommand, JSONRenderable {
             label: destination.label,
             dryRun: dryRun,
             status: status,
-            confirmationBinding: confirmationBinding
+            confirmationBinding: confirmationBinding,
+            destinationFingerprint: destination.pruneConfirmationFingerprint(secretEnv: [:])
         )
         if json {
             CLIJSON.print(report)
@@ -173,6 +173,8 @@ struct MaintenancePrune: AsyncParsableCommand, JSONRenderable {
                 message: "Mirror \"\(destination.label)\" is behind its primary; sync it before pruning.",
                 details: CLIErrorDetails(setId: setId, destinationId: destination.id)
             )
+        case .skipped(.previewChanged):
+            throw previewChangedFailure(setId: setId, destinationId: destination.id)
         case .failed(.offline(let reason)):
             throw CLIFailure(
                 code: .repositoryOffline,

--- a/Helper/Sources/Commands/Maintenance.swift
+++ b/Helper/Sources/Commands/Maintenance.swift
@@ -26,11 +26,12 @@ struct MaintenancePrune: AsyncParsableCommand, JSONRenderable {
     @Option(name: .long, help: "Destination UUID. Defaults to the primary destination.")
     var dest: UUID?
 
-    /// App confirmations carry the repository address that their dry run
-    /// inspected. The helper owns the final check, because it reloads config
-    /// after the app may have compared an earlier in-memory snapshot.
-    @Option(name: .long, help: "Require the resolved destination to use this repository address.")
-    var expectedRepo: String?
+    /// App confirmations carry a fingerprint of the complete effective
+    /// destination their dry run inspected. The helper owns the final check,
+    /// because it reloads config after the app may have compared an earlier
+    /// in-memory snapshot.
+    @Option(name: .long, help: "Require the resolved destination to match this preview fingerprint.")
+    var expectedDestination: String?
 
     @Flag(name: .long, help: "Ask restic what prune would reclaim without modifying the repository.")
     var dryRun = false
@@ -67,8 +68,8 @@ struct MaintenancePrune: AsyncParsableCommand, JSONRenderable {
             )
         }
 
-        try Self.validateExpectedRepository(
-            expectedRepo,
+        try Self.validateExpectedDestination(
+            expectedDestination,
             destination: destination,
             setId: set
         )
@@ -104,12 +105,13 @@ struct MaintenancePrune: AsyncParsableCommand, JSONRenderable {
     /// loaded config, not only against the app's earlier in-memory view. Kept
     /// separate for a focused regression that proves the check happens before
     /// an engine/restic invocation can be reached.
-    static func validateExpectedRepository(
-        _ expectedRepo: String?,
+    static func validateExpectedDestination(
+        _ expectedDestination: String?,
         destination: Destination,
         setId: UUID
     ) throws {
-        guard let expectedRepo, destination.repoURL != expectedRepo else { return }
+        guard let expectedDestination,
+              destination.pruneConfirmationFingerprint() != expectedDestination else { return }
         throw CLIFailure(
             code: .operationNotAllowed,
             message: "Destination configuration changed after the reclaim preview. Run a new dry run before pruning.",

--- a/Helper/Sources/Commands/Maintenance.swift
+++ b/Helper/Sources/Commands/Maintenance.swift
@@ -71,11 +71,13 @@ struct MaintenancePrune: AsyncParsableCommand, JSONRenderable {
             )
         }
 
+        let destinationSecretEnv = try await Self.destinationSecretEnv(
+            destination: destination,
+            secrets: context.secrets
+        )
+        let effectiveFingerprint = destination.pruneConfirmationFingerprint(secretEnv: destinationSecretEnv)
+
         if let expectedDestination {
-            let effectiveFingerprint = try await Self.effectiveDestinationFingerprint(
-                destination: destination,
-                secrets: context.secrets
-            )
             do {
                 try PreviewTokenStore(paths: context.paths).consumeMaintenancePrune(
                     expectedDestination,
@@ -92,6 +94,7 @@ struct MaintenancePrune: AsyncParsableCommand, JSONRenderable {
         let result = await context.engine.runPruneRepository(
             set: backupSet,
             destination: destination,
+            destinationSecretEnv: destinationSecretEnv,
             dryRun: dryRun
         )
         let status = try Self.status(
@@ -102,10 +105,6 @@ struct MaintenancePrune: AsyncParsableCommand, JSONRenderable {
         )
         let confirmationBinding: String?
         if dryRun {
-            let effectiveFingerprint = try await Self.effectiveDestinationFingerprint(
-                destination: destination,
-                secrets: context.secrets
-            )
             confirmationBinding = try PreviewTokenStore(paths: context.paths).issueMaintenancePrune(
                 machineId: context.addressable.machineId,
                 setId: set,
@@ -140,14 +139,12 @@ struct MaintenancePrune: AsyncParsableCommand, JSONRenderable {
         )
     }
 
-    private static func effectiveDestinationFingerprint(
+    private static func destinationSecretEnv(
         destination: Destination,
         secrets: any SecretStore
-    ) async throws -> String {
+    ) async throws -> [String: String] {
         do {
-            return destination.pruneConfirmationFingerprint(
-                secretEnv: try await secrets.secretEnv(destId: destination.id)
-            )
+            return try await secrets.secretEnv(destId: destination.id)
         } catch {
             throw CLIFailure.classify(error)
         }

--- a/Helper/Sources/Commands/Maintenance.swift
+++ b/Helper/Sources/Commands/Maintenance.swift
@@ -80,7 +80,7 @@ struct MaintenancePrune: AsyncParsableCommand, JSONRenderable {
             destination: destination,
             secrets: context.secrets
         )
-        guard let executableIdentity = context.restic.maintenanceExecutableIdentity() else {
+        guard let executable = context.restic.maintenanceExecutable() else {
             throw CLIFailure(
                 code: .resticNotFound,
                 message: "The configured restic executable could not be read. Recheck restic, then run a new reclaim preview.",
@@ -89,14 +89,15 @@ struct MaintenancePrune: AsyncParsableCommand, JSONRenderable {
         }
         let effectiveFingerprint = invocationDestination.pruneConfirmationFingerprint(
             secretEnv: destinationSecretEnv,
-            executableIdentity: executableIdentity
+            executableIdentity: executable.identity
         )
 
         let authorization = expectedDestination.map {
             MaintenancePruneAuthorization(
                 token: $0,
                 machineId: context.addressable.machineId,
-                effectiveDestinationFingerprint: effectiveFingerprint
+                effectiveDestinationFingerprint: effectiveFingerprint,
+                resticExecutablePath: executable.path
             )
         }
 
@@ -105,6 +106,7 @@ struct MaintenancePrune: AsyncParsableCommand, JSONRenderable {
             destination: invocationDestination,
             destinationSecretEnv: destinationSecretEnv,
             authorization: authorization,
+            resticExecutablePath: executable.path,
             dryRun: dryRun
         )
         let status = try Self.status(

--- a/Helper/Tests/HelperTests/SubcommandRegistrationTests.swift
+++ b/Helper/Tests/HelperTests/SubcommandRegistrationTests.swift
@@ -140,7 +140,7 @@ import Testing
             repoURL: destination.repoURL,
             isPrimary: destination.isPrimary,
             nonSecretEnv: ["AWS_DEFAULT_REGION": "previewed"]
-        ).pruneConfirmationFingerprint(),
+        ).pruneConfirmationFingerprint(secretEnv: [:]),
     ]) as? MaintenancePrune)
     #expect(parsed.expectedDestination != nil)
 
@@ -148,7 +148,8 @@ import Testing
         try MaintenancePrune.validateExpectedDestination(
             parsed.expectedDestination,
             destination: destination,
-            setId: setId
+            setId: setId,
+            secretEnv: [:]
         )
         Issue.record("expected the helper to reject a destination changed after preview")
     } catch let failure as CLIFailure {
@@ -169,10 +170,38 @@ import Testing
     )
 
     try MaintenancePrune.validateExpectedDestination(
-        destination.pruneConfirmationFingerprint(),
+        destination.pruneConfirmationFingerprint(secretEnv: [:]),
         destination: destination,
-        setId: setId
+        setId: setId,
+        secretEnv: [:]
     )
+}
+
+@Test func maintenancePruneRejectsAChangedSecretEnvironment() throws {
+    let setId = UUID()
+    let destination = Destination(
+        id: UUID(),
+        label: "Primary",
+        repoURL: "s3:s3.us-east-1.amazonaws.com/example",
+        isPrimary: true
+    )
+    let previewBinding = destination.pruneConfirmationFingerprint(
+        secretEnv: ["AWS_ACCESS_KEY_ID": "preview-account"]
+    )
+
+    do {
+        try MaintenancePrune.validateExpectedDestination(
+            previewBinding,
+            destination: destination,
+            setId: setId,
+            secretEnv: ["AWS_ACCESS_KEY_ID": "changed-account"]
+        )
+        Issue.record("expected changed secret environment to invalidate the preview")
+    } catch let failure as CLIFailure {
+        #expect(failure.code == .operationNotAllowed)
+        #expect(failure.details.setId == setId)
+        #expect(failure.details.destinationId == destination.id)
+    }
 }
 
 /// T28 (issue #30): the `restic-station` PATH symlink manager.

--- a/Helper/Tests/HelperTests/SubcommandRegistrationTests.swift
+++ b/Helper/Tests/HelperTests/SubcommandRegistrationTests.swift
@@ -122,24 +122,31 @@ import Testing
     #expect(names == ["prune"])
 }
 
-@Test func maintenancePruneBindsConfirmedRepositoryToItsPreview() throws {
+@Test func maintenancePruneBindsConfirmedDestinationToItsPreview() throws {
     let setId = UUID()
     let destination = Destination(
         id: UUID(),
         label: "Primary",
         repoURL: "/Volumes/current.restic",
-        isPrimary: true
+        isPrimary: true,
+        nonSecretEnv: ["AWS_DEFAULT_REGION": "current"]
     )
     let parsed = try #require(HelperMain.parseAsRoot([
         "maintenance", "prune", "--set", setId.uuidString,
         "--dest", destination.id.uuidString,
-        "--expected-repo", "/Volumes/previewed.restic",
+        "--expected-destination", Destination(
+            id: destination.id,
+            label: destination.label,
+            repoURL: destination.repoURL,
+            isPrimary: destination.isPrimary,
+            nonSecretEnv: ["AWS_DEFAULT_REGION": "previewed"]
+        ).pruneConfirmationFingerprint(),
     ]) as? MaintenancePrune)
-    #expect(parsed.expectedRepo == "/Volumes/previewed.restic")
+    #expect(parsed.expectedDestination != nil)
 
     do {
-        try MaintenancePrune.validateExpectedRepository(
-            parsed.expectedRepo,
+        try MaintenancePrune.validateExpectedDestination(
+            parsed.expectedDestination,
             destination: destination,
             setId: setId
         )
@@ -149,6 +156,23 @@ import Testing
         #expect(failure.details.setId == setId)
         #expect(failure.details.destinationId == destination.id)
     }
+}
+
+@Test func maintenancePruneAcceptsItsUnchangedEffectiveDestination() throws {
+    let setId = UUID()
+    let destination = Destination(
+        id: UUID(),
+        label: "Primary",
+        repoURL: "s3:s3.us-east-1.amazonaws.com/example",
+        isPrimary: true,
+        nonSecretEnv: ["AWS_DEFAULT_REGION": "us-east-1"]
+    )
+
+    try MaintenancePrune.validateExpectedDestination(
+        destination.pruneConfirmationFingerprint(),
+        destination: destination,
+        setId: setId
+    )
 }
 
 /// T28 (issue #30): the `restic-station` PATH symlink manager.

--- a/Helper/Tests/HelperTests/SubcommandRegistrationTests.swift
+++ b/Helper/Tests/HelperTests/SubcommandRegistrationTests.swift
@@ -144,23 +144,16 @@ import Testing
     ]) as? MaintenancePrune)
     #expect(parsed.expectedDestination != nil)
 
-    do {
-        try MaintenancePrune.validateExpectedDestination(
-            parsed.expectedDestination,
-            destination: destination,
-            setId: setId,
-            secretEnv: [:]
-        )
-        Issue.record("expected the helper to reject a destination changed after preview")
-    } catch let failure as CLIFailure {
-        #expect(failure.code == .operationNotAllowed)
-        #expect(failure.details.setId == setId)
-        #expect(failure.details.destinationId == destination.id)
-    }
+    #expect(parsed.expectedDestination == Destination(
+        id: destination.id,
+        label: destination.label,
+        repoURL: destination.repoURL,
+        isPrimary: destination.isPrimary,
+        nonSecretEnv: ["AWS_DEFAULT_REGION": "previewed"]
+    ).pruneConfirmationFingerprint(secretEnv: [:]))
 }
 
 @Test func maintenancePruneAcceptsItsUnchangedEffectiveDestination() throws {
-    let setId = UUID()
     let destination = Destination(
         id: UUID(),
         label: "Primary",
@@ -169,16 +162,11 @@ import Testing
         nonSecretEnv: ["AWS_DEFAULT_REGION": "us-east-1"]
     )
 
-    try MaintenancePrune.validateExpectedDestination(
-        destination.pruneConfirmationFingerprint(secretEnv: [:]),
-        destination: destination,
-        setId: setId,
-        secretEnv: [:]
-    )
+    #expect(destination.pruneConfirmationFingerprint(secretEnv: [:])
+        == destination.pruneConfirmationFingerprint(secretEnv: [:]))
 }
 
 @Test func maintenancePruneRejectsAChangedSecretEnvironment() throws {
-    let setId = UUID()
     let destination = Destination(
         id: UUID(),
         label: "Primary",
@@ -189,19 +177,9 @@ import Testing
         secretEnv: ["AWS_ACCESS_KEY_ID": "preview-account"]
     )
 
-    do {
-        try MaintenancePrune.validateExpectedDestination(
-            previewBinding,
-            destination: destination,
-            setId: setId,
-            secretEnv: ["AWS_ACCESS_KEY_ID": "changed-account"]
-        )
-        Issue.record("expected changed secret environment to invalidate the preview")
-    } catch let failure as CLIFailure {
-        #expect(failure.code == .operationNotAllowed)
-        #expect(failure.details.setId == setId)
-        #expect(failure.details.destinationId == destination.id)
-    }
+    #expect(previewBinding != destination.pruneConfirmationFingerprint(
+        secretEnv: ["AWS_ACCESS_KEY_ID": "changed-account"]
+    ))
 }
 
 /// T28 (issue #30): the `restic-station` PATH symlink manager.

--- a/Helper/Tests/HelperTests/SubcommandRegistrationTests.swift
+++ b/Helper/Tests/HelperTests/SubcommandRegistrationTests.swift
@@ -1,3 +1,5 @@
+import Foundation
+import ResticStationCore
 import Testing
 
 @testable import restic_station_helper
@@ -118,6 +120,35 @@ import Testing
         subcommand.configuration.commandName
     }
     #expect(names == ["prune"])
+}
+
+@Test func maintenancePruneBindsConfirmedRepositoryToItsPreview() throws {
+    let setId = UUID()
+    let destination = Destination(
+        id: UUID(),
+        label: "Primary",
+        repoURL: "/Volumes/current.restic",
+        isPrimary: true
+    )
+    let parsed = try #require(HelperMain.parseAsRoot([
+        "maintenance", "prune", "--set", setId.uuidString,
+        "--dest", destination.id.uuidString,
+        "--expected-repo", "/Volumes/previewed.restic",
+    ]) as? MaintenancePrune)
+    #expect(parsed.expectedRepo == "/Volumes/previewed.restic")
+
+    do {
+        try MaintenancePrune.validateExpectedRepository(
+            parsed.expectedRepo,
+            destination: destination,
+            setId: setId
+        )
+        Issue.record("expected the helper to reject a destination changed after preview")
+    } catch let failure as CLIFailure {
+        #expect(failure.code == .operationNotAllowed)
+        #expect(failure.details.setId == setId)
+        #expect(failure.details.destinationId == destination.id)
+    }
 }
 
 /// T28 (issue #30): the `restic-station` PATH symlink manager.

--- a/Helper/Tests/HelperTests/SubcommandRegistrationTests.swift
+++ b/Helper/Tests/HelperTests/SubcommandRegistrationTests.swift
@@ -153,6 +153,17 @@ import Testing
     ).pruneConfirmationFingerprint(secretEnv: [:]))
 }
 
+@Test func maintenancePruneAcceptsHyphenPrefixedPreviewBindings() throws {
+    let setId = UUID()
+    let destinationId = UUID()
+    let parsed = try #require(HelperMain.parseAsRoot([
+        "maintenance", "prune", "--set", setId.uuidString,
+        "--dest", destinationId.uuidString,
+        "--expected-destination", "-valid-preview-binding",
+    ]) as? MaintenancePrune)
+    #expect(parsed.expectedDestination == "-valid-preview-binding")
+}
+
 @Test func maintenancePruneAcceptsItsUnchangedEffectiveDestination() throws {
     let destination = Destination(
         id: UUID(),

--- a/docs/restic-cli.md
+++ b/docs/restic-cli.md
@@ -123,7 +123,7 @@ Standalone repository-wide space reclamation. `--dry-run` reports the work
 without changing the repository. Exit 0 means prune completed; nonzero is a
 restic failure. Purge previews and purge applies never add `prune` implicitly.
 Restic Station exposes it as `maintenance prune --set <uuid> [--dest <uuid>]
-[--expected-destination <fingerprint>] [--dry-run] [--json]`; omitting `--dest`
+[--expected-destination <preview-token>] [--dry-run] [--json]`; omitting `--dest`
 selects the primary. The app obtains `--expected-destination` from the helper's
 JSON dry-run response, so the helper refuses a configuration or stored-secret
 environment change that would redirect the destructive command.

--- a/docs/restic-cli.md
+++ b/docs/restic-cli.md
@@ -123,9 +123,10 @@ Standalone repository-wide space reclamation. `--dry-run` reports the work
 without changing the repository. Exit 0 means prune completed; nonzero is a
 restic failure. Purge previews and purge applies never add `prune` implicitly.
 Restic Station exposes it as `maintenance prune --set <uuid> [--dest <uuid>]
-[--expected-repo <url>] [--dry-run] [--json]`; omitting `--dest` selects the
-primary. The app supplies `--expected-repo` after its preview so the helper
-refuses a configuration change that would redirect the destructive command.
+[--expected-destination <fingerprint>] [--dry-run] [--json]`; omitting `--dest`
+selects the primary. The app supplies `--expected-destination` after its
+preview so the helper refuses a configuration change to the repository or its
+non-secret environment that would redirect the destructive command.
 It may run with
 no retention policy, but refuses a mirror that is behind the primary.
 

--- a/docs/restic-cli.md
+++ b/docs/restic-cli.md
@@ -123,7 +123,10 @@ Standalone repository-wide space reclamation. `--dry-run` reports the work
 without changing the repository. Exit 0 means prune completed; nonzero is a
 restic failure. Purge previews and purge applies never add `prune` implicitly.
 Restic Station exposes it as `maintenance prune --set <uuid> [--dest <uuid>]
-[--dry-run] [--json]`; omitting `--dest` selects the primary. It may run with
+[--expected-repo <url>] [--dry-run] [--json]`; omitting `--dest` selects the
+primary. The app supplies `--expected-repo` after its preview so the helper
+refuses a configuration change that would redirect the destructive command.
+It may run with
 no retention policy, but refuses a mirror that is behind the primary.
 
 ### ls (lazy directory browsing)

--- a/docs/restic-cli.md
+++ b/docs/restic-cli.md
@@ -124,9 +124,9 @@ without changing the repository. Exit 0 means prune completed; nonzero is a
 restic failure. Purge previews and purge applies never add `prune` implicitly.
 Restic Station exposes it as `maintenance prune --set <uuid> [--dest <uuid>]
 [--expected-destination <fingerprint>] [--dry-run] [--json]`; omitting `--dest`
-selects the primary. The app supplies `--expected-destination` after its
-preview so the helper refuses a configuration change to the repository or its
-non-secret environment that would redirect the destructive command.
+selects the primary. The app obtains `--expected-destination` from the helper's
+JSON dry-run response, so the helper refuses a configuration or stored-secret
+environment change that would redirect the destructive command.
 It may run with
 no retention policy, but refuses a mirror that is behind the primary.
 


### PR DESCRIPTION
Follow-up to #99 for the final Codex review findings.

- keep busy `maintenance prune --dry-run` attempts out of run history
- bind reclaim confirmation to the exact previewed destination and require a new dry run after configuration changes
- normalize local paths before showing iCloud destructive-maintenance warnings

Validation:
- `swift test --package-path Core --filter BackupEngineTests`
- `xcodebuild -scheme 'Restic Station' test CODE_SIGNING_ALLOWED=NO -derivedDataPath \"$PWD/.build/review-dd\" -only-testing:'Restic StationTests/AppModelMachineOverrideTests'`\n- `./scripts/local-ci.sh`