### PR TITLE
Restore reclaim confirmation on launch failure

### DIFF
--- a/Core/Sources/ResticStationCore/Engine/BackupEngine.swift
+++ b/Core/Sources/ResticStationCore/Engine/BackupEngine.swift
@@ -719,6 +719,7 @@ public final class BackupEngine: Sendable {
         }
 
         let consumePreviewToken: (@Sendable () throws -> Void)?
+        let restorePreviewToken: (@Sendable () -> Void)?
         if let authorization {
             let previewTokens = previewTokens
             let token = authorization.token
@@ -735,8 +736,21 @@ public final class BackupEngine: Sendable {
                     effectiveDestinationFingerprint: effectiveDestinationFingerprint
                 )
             }
+            restorePreviewToken = {
+                // A restore failure intentionally leaves the token consumed:
+                // retrying a destructive action is never safer than asking
+                // for a fresh preview when capability storage is unavailable.
+                try? previewTokens.restoreMaintenancePrune(
+                    token,
+                    machineId: machineId,
+                    setId: setId,
+                    destinationId: destinationId,
+                    effectiveDestinationFingerprint: effectiveDestinationFingerprint
+                )
+            }
         } else {
             consumePreviewToken = nil
+            restorePreviewToken = nil
         }
 
         let prune = await performChild(
@@ -755,7 +769,8 @@ public final class BackupEngine: Sendable {
             ),
             streamProgress: false,
             preflightPhase: authorization == nil ? nil : "validating preview",
-            beforeLaunch: consumePreviewToken
+            beforeLaunch: consumePreviewToken,
+            afterLaunchFailure: restorePreviewToken
         )
         guard let prune else { return .failed(.didNotRun) }
         switch prune.preflightFailure {
@@ -1339,6 +1354,7 @@ public final class BackupEngine: Sendable {
         preflightPhase: String? = nil,
         preflight: (@Sendable (LogWriter?) async -> PreflightFailure?)? = nil,
         beforeLaunch: (@Sendable () throws -> Void)? = nil,
+        afterLaunchFailure: (@Sendable () -> Void)? = nil,
         downgradeSuccessToWarning: (@Sendable (ResticOutcome) -> Bool)? = nil,
         purgeSnapshotRewrites: (@Sendable (ResticOutcome) -> [String: String]?)? = nil
     ) async -> ChildRun? {
@@ -1400,7 +1416,8 @@ public final class BackupEngine: Sendable {
             invocation: invocation,
             logWriter: logWriter,
             reporter: streamProgress ? reporter : nil,
-            beforeLaunch: beforeLaunch
+            beforeLaunch: beforeLaunch,
+            afterLaunchFailure: afterLaunchFailure
         )
 
         if case .didNotRun(_, let launchPreflightFailure?) = result {
@@ -1497,14 +1514,16 @@ public final class BackupEngine: Sendable {
         invocation: ResticInvocation,
         logWriter: LogWriter?,
         reporter: ProgressReporter?,
-        beforeLaunch: (@Sendable () throws -> Void)? = nil
+        beforeLaunch: (@Sendable () throws -> Void)? = nil,
+        afterLaunchFailure: (@Sendable () -> Void)? = nil
     ) async -> ExecuteResult {
         let first = await spawn(
             command,
             invocation: invocation,
             logWriter: logWriter,
             reporter: reporter,
-            beforeLaunch: beforeLaunch
+            beforeLaunch: beforeLaunch,
+            afterLaunchFailure: afterLaunchFailure
         )
         guard case .ranToCompletion(let outcome) = first, outcome.status == .repoLocked else {
             return first
@@ -1534,7 +1553,8 @@ public final class BackupEngine: Sendable {
         invocation: ResticInvocation,
         logWriter: LogWriter?,
         reporter: ProgressReporter?,
-        beforeLaunch: (@Sendable () throws -> Void)? = nil
+        beforeLaunch: (@Sendable () throws -> Void)? = nil,
+        afterLaunchFailure: (@Sendable () -> Void)? = nil
     ) async -> ExecuteResult {
         do {
             let outcome = try await restic.run(
@@ -1547,7 +1567,8 @@ public final class BackupEngine: Sendable {
                 onRawLine: { line in
                     logWriter?.appendLine(line)
                 },
-                beforeLaunch: beforeLaunch
+                beforeLaunch: beforeLaunch,
+                afterLaunchFailure: afterLaunchFailure
             )
             return .ranToCompletion(outcome)
         } catch let error as PreviewTokenError {

--- a/Core/Sources/ResticStationCore/Restic/ResticRunner.swift
+++ b/Core/Sources/ResticStationCore/Restic/ResticRunner.swift
@@ -139,7 +139,8 @@ public final class ResticRunner: Sendable {
         onLine: (@Sendable (ResticMessage) -> Void)? = nil,
         onRawLine: (@Sendable (String) -> Void)? = nil,
         timeout: TimeInterval? = nil,
-        beforeLaunch: (@Sendable () throws -> Void)? = nil
+        beforeLaunch: (@Sendable () throws -> Void)? = nil,
+        afterLaunchFailure: (@Sendable () -> Void)? = nil
     ) async throws -> ResticOutcome {
         try Task.checkCancellation()
 
@@ -160,6 +161,7 @@ public final class ResticRunner: Sendable {
             executablePath: inv.resticPathOverride,
             expectedExecutableIdentity: inv.expectedExecutableIdentity,
             beforeLaunch: beforeLaunch,
+            afterLaunchFailure: afterLaunchFailure,
             onLine: onLine,
             onRawLine: onRawLine,
             timeout: timeout
@@ -295,6 +297,7 @@ public final class ResticRunner: Sendable {
         executablePath: String? = nil,
         expectedExecutableIdentity: String? = nil,
         beforeLaunch: (@Sendable () throws -> Void)? = nil,
+        afterLaunchFailure: (@Sendable () -> Void)? = nil,
         onLine: (@Sendable (ResticMessage) -> Void)?,
         onRawLine: (@Sendable (String) -> Void)?,
         timeout: TimeInterval?
@@ -331,6 +334,12 @@ public final class ResticRunner: Sendable {
                 timeout: timeout
             )
         } catch let error as ProcessRunnerError {
+            // `DefaultProcessRunner` emits `.launchFailed` only from
+            // `Process.run()`, before a child exists. Destructive callers
+            // may therefore safely restore their just-consumed capability.
+            if case .launchFailed = error {
+                afterLaunchFailure?()
+            }
             switch error {
             case .timeout:
                 throw ResticRunnerError.timedOut

--- a/Core/Sources/ResticStationCore/Support/PreviewToken.swift
+++ b/Core/Sources/ResticStationCore/Support/PreviewToken.swift
@@ -203,6 +203,34 @@ public struct PreviewTokenStore: Sendable {
         }
     }
 
+    /// Restores a standalone-prune capability after a confirmed process
+    /// launch failure. The caller may invoke this only when the process
+    /// runner guarantees that no child was started; a failed restoration
+    /// leaves the token consumed, which is the safer failure mode.
+    public func restoreMaintenancePrune(
+        _ value: String,
+        machineId: String,
+        setId: UUID,
+        destinationId: UUID,
+        effectiveDestinationFingerprint: String
+    ) throws {
+        try withStoreLock {
+            var index = try readIndex()
+            guard var token = index.tokens[value] else { throw PreviewTokenError.unknown }
+            guard token.usedAt != nil,
+                  token.machineId == machineId,
+                  token.setId == setId,
+                  token.destinations == [PreviewTokenDestination(destinationId: destinationId, snapshotIDs: [])],
+                  token.configFingerprint == effectiveDestinationFingerprint,
+                  token.patterns == ["maintenance-prune"] else {
+                throw PreviewTokenError.unknown
+            }
+            token.usedAt = nil
+            index.tokens[value] = token
+            try writeIndex(index)
+        }
+    }
+
     /// Reads a token without consuming it.  Callers must perform every
     /// repository/config check before invoking ``consume(_:)``.
     public func token(_ value: String) throws -> PreviewToken {

--- a/Core/Tests/ResticStationCoreTests/Engine/BackupEngineTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Engine/BackupEngineTests.swift
@@ -1483,6 +1483,39 @@ struct BackupEngineTests {
         #expect(env.fake.invocations.isEmpty)
     }
 
+    @Test("standalone prune: a process launch failure restores its preview token")
+    func standalonePruneLaunchFailureRestoresItsPreviewToken() async throws {
+        let env = Self.makeEnv(script: [], retention: nil)
+        defer { env.cleanUp() }
+        let fingerprint = env.primary.pruneConfirmationFingerprint(secretEnv: [:])
+        let token = try PreviewTokenStore(paths: env.paths).issueMaintenancePrune(
+            machineId: env.machineId,
+            setId: env.set.id,
+            destinationId: env.primary.id,
+            effectiveDestinationFingerprint: fingerprint
+        )
+        env.fake.script = [
+            .init(
+                argvPrefix: [Self.resticPath, "-r", env.primary.repoURL, "prune"],
+                failure: .launchFailed("restic disappeared")
+            ),
+        ]
+
+        let result = await env.engine.runPruneRepository(
+            set: env.set,
+            destination: env.primary,
+            authorization: MaintenancePruneAuthorization(
+                token: token,
+                machineId: env.machineId,
+                effectiveDestinationFingerprint: fingerprint
+            )
+        )
+
+        #expect(result == .failed(.didNotRun))
+        #expect(try PreviewTokenStore(paths: env.paths).token(token).value == token)
+        #expect(env.resticArgvs == [[Self.resticPath, "-r", env.primary.repoURL, "prune"]])
+    }
+
     @Test("standalone prune: an unavailable secret is distinguished from success")
     func standalonePruneReportsSecretUnavailable() async throws {
         let env = Self.makeEnv(secretsUnavailableFor: [Self.primaryId], script: [], retention: nil)

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -57,7 +57,7 @@ itself, unwrapped, because its output is meant to be fed straight back into
 | `fda-check` | ✅ | `{ applicable, granted, probedPath, checkedAt, context }` |
 | `purge preview` | ✅ | array of per-destination purge plans: matched/changed/unattributed snapshots and patterns |
 | `purge apply` | ✅ | `{ setId, status, children }` for the token-gated destructive purge |
-| `maintenance prune` | ✅ | `{ setId, destinationId, label, dryRun, status }` for standalone pack reclamation |
+| `maintenance prune` | ✅ | `{ setId, destinationId, label, dryRun, status, confirmationBinding, destinationFingerprint }` for standalone pack reclamation; `confirmationBinding` is an opaque, short-lived token present only for a successful dry run, and `destinationFingerprint` binds that preview to the displayed destination |
 | `config export` | — | **Unwrapped by design.** The exported config document itself, so it round-trips into `config import`. |
 | `timer status` (Linux) | — | **Human-only.** Its report is narrative assembled while probing; the machine-readable equivalent is `status --json`'s `.scheduler`, in the same problem vocabulary. |
 | `print-password` | — | Hidden; exists for `RESTIC_PASSWORD_COMMAND` and writes a secret to stdout. |


### PR DESCRIPTION
Follow-up to #100 review: restore a standalone-prune confirmation token only when `Process.run()` definitively fails before creating a child, and document the maintenance-prune JSON confirmation fields. Includes a regression test for the launch-failure path.