### PR TITLE
Fix forward the Fable review findings (#104–#108)

### DIFF
--- a/App/Sources/Support/HelperInvoker.swift
+++ b/App/Sources/Support/HelperInvoker.swift
@@ -50,8 +50,10 @@ public struct HelperInvoker: Sendable {
         await run(.backUpNow(setId: setId))
     }
 
-    public func prune(setId: UUID) async -> HelperResult {
-        await run(.prune(setId: setId))
+    /// `expectedConfig` binds the run to the `config.json` the caller
+    /// reviewed; the helper refuses if the file changed underneath it.
+    public func prune(setId: UUID, expectedConfig: String? = nil) async -> HelperResult {
+        await run(.prune(setId: setId, expectedConfig: expectedConfig))
     }
 
     /// Reclaims unused packs without applying retention. The helper owns the

--- a/App/Sources/ViewModels/AppModel+Maintenance.swift
+++ b/App/Sources/ViewModels/AppModel+Maintenance.swift
@@ -210,7 +210,11 @@ enum RetentionPreviewState: Equatable {
 /// come from a fresh dry-run, never from the stale preview").
 struct PrunePlan: Identifiable, Equatable {
     enum Action: Equatable {
-        case retention
+        /// The `config.json` fingerprint and destination list the keep/remove
+        /// table was computed from. Retention's preview is app-direct, so
+        /// unlike reclaim there is no helper-issued token — the helper is
+        /// given this fingerprint instead and refuses if the file moved.
+        case retention(expectedConfig: String, previewedDestinations: [Destination])
         /// The exact addressable destination that the dry-run described.
         /// Confirm revalidates this value before it asks the helper to make
         /// changes, so a concurrent config edit cannot redirect the prune to
@@ -224,11 +228,17 @@ struct PrunePlan: Identifiable, Equatable {
     let previews: [DestinationForgetPreview]
     let action: Action
 
-    init(setId: UUID, setName: String, previews: [DestinationForgetPreview]) {
+    init(
+        setId: UUID,
+        setName: String,
+        previews: [DestinationForgetPreview],
+        expectedConfig: String,
+        previewedDestinations: [Destination]
+    ) {
         self.setId = setId
         self.setName = setName
         self.previews = previews
-        action = .retention
+        action = .retention(expectedConfig: expectedConfig, previewedDestinations: previewedDestinations)
     }
 
     init(
@@ -370,7 +380,20 @@ enum MaintenanceAction: Equatable {
 final class MaintenanceModel: ObservableObject {
 
     /// `nil` until the first render picks the first configured set.
-    @Published var selectedSetId: UUID?
+    ///
+    /// Changing it discards everything measured against the previous set.
+    /// `prunePlan`, `retentionPreview` and `activity` all describe one
+    /// specific set; left in place they render under the *next* set's
+    /// heading — a keep/remove table attributed to the wrong repository, or
+    /// a destructive confirmation appearing over a screen it does not name.
+    @Published var selectedSetId: UUID? {
+        didSet {
+            guard oldValue != selectedSetId else { return }
+            prunePlan = nil
+            retentionPreview = .idle
+            activity = nil
+        }
+    }
 
     @Published private(set) var sizes: [UUID: SizeState] = [:]
     @Published private(set) var retentionPreview: RetentionPreviewState = .idle
@@ -531,13 +554,24 @@ final class MaintenanceModel: ObservableObject {
             return
         }
         isPreparingPrune = true
+        // Captured before the dry run, so the fingerprint describes the
+        // configuration the counts were measured against — not whatever the
+        // file happens to be by the time the user reads them.
+        let expectedConfig = ConfigStore(paths: model.paths).fileFingerprint()
+        let previewedDestinations = set.destinations
         Task { [weak self] in
             let previews = await Self.dryRun(set: set, policy: policy, runner: runner)
             guard let self else { return }
             self.isPreparingPrune = false
             let now = Date()
             self.retentionPreview = .ready(previews: previews, at: now)
-            self.prunePlan = PrunePlan(setId: set.id, setName: set.name, previews: previews)
+            self.prunePlan = PrunePlan(
+                setId: set.id,
+                setName: set.name,
+                previews: previews,
+                expectedConfig: expectedConfig,
+                previewedDestinations: previewedDestinations
+            )
         }
     }
 
@@ -593,17 +627,43 @@ final class MaintenanceModel: ObservableObject {
     /// which goes through the helper, never through this process
     /// (`docs/architecture.md` §The single-code-path rule).
     func confirmApplyRetention(_ plan: PrunePlan, in model: AppModel) {
-        guard let set = MaintenanceLookup.set(model, id: plan.setId) else { return }
+        guard let set = MaintenanceLookup.set(model, id: plan.setId) else {
+            // Silently closing the dialog leaves the user believing a
+            // destructive action ran.
+            prunePlan = nil
+            activity = Self.activity(
+                title: "Maintenance",
+                subject: plan.setName,
+                result: .failed(output: "That backup set no longer exists. Reload settings and try again."),
+                run: nil
+            )
+            return
+        }
         let destIds: [UUID]
         let title: String
         let resultTask: () async -> HelperResult
-        let retainsPlanWhenBusy: Bool
         switch plan.action {
-        case .retention:
+        case .retention(let expectedConfig, let previewedDestinations):
+            // Fail closed exactly like reclaim. The dialog names a snapshot
+            // count computed against a specific destination list; if that
+            // list moved underneath us, the count is about a different
+            // repository set than the one we are about to change.
+            guard set.destinations == previewedDestinations else {
+                self.prunePlan = nil
+                self.activity = Self.activity(
+                    title: "Apply retention",
+                    subject: plan.setName,
+                    result: .failed(output: "The destinations changed after the cleanup preview. Review the updated settings and preview again before applying retention."),
+                    run: nil
+                )
+                return
+            }
             destIds = set.destinations.map(\.id)
             title = "Apply retention"
-            resultTask = { await model.helper.prune(setId: plan.setId) }
-            retainsPlanWhenBusy = false
+            // The helper independently re-checks this against config.json on
+            // disk: the app's in-memory copy is not evidence about what the
+            // helper will load a moment later.
+            resultTask = { await model.helper.prune(setId: plan.setId, expectedConfig: expectedConfig) }
         case .reclaimSpace(let previewedDestination, _, let confirmationBinding):
             guard let destination = set.destinations.first(where: { $0.id == previewedDestination.id }),
                   destination == previewedDestination else {
@@ -618,7 +678,6 @@ final class MaintenanceModel: ObservableObject {
             }
             destIds = [destination.id]
             title = "Reclaim space"
-            retainsPlanWhenBusy = true
             resultTask = {
                 await model.helper.pruneRepository(
                     setId: plan.setId,
@@ -638,14 +697,12 @@ final class MaintenanceModel: ObservableObject {
             let result = await resultTask()
             guard let self else { return }
             self.busyAction = nil
-            if result == .busy, retainsPlanWhenBusy {
-                // SwiftUI closes the confirmation alert before this Task
-                // returns. Restore the still-valid capability so transient
-                // helper/token-store contention can be retried directly.
-                self.prunePlan = plan
-            } else {
-                self.prunePlan = nil
-            }
+            // Never re-present the destructive alert. SwiftUI has already
+            // closed it, and reopening it with no user gesture puts a
+            // prominent "Reclaim Space" button under an in-flight Return
+            // keypress. The busy banner tells the user to try again; the
+            // capability is still valid and the button is still there.
+            self.prunePlan = nil
             model.refresh()
             let latestPrune = MaintenanceLookup.lastRun(model, setId: set.id, kind: .prune)
             let recordedRun: RunIndexEntry?
@@ -663,7 +720,12 @@ final class MaintenanceModel: ObservableObject {
                 run: recordedRun
             )
             // Sizes and the keep/remove table both describe a repository
-            // that just changed underneath them.
+            // that just changed underneath them — but only if something
+            // actually ran. A busy refusal changed nothing, so throwing away
+            // the preview the user is reading and re-running `stats` against
+            // every destination is pure waste, and remote repositories pay
+            // for it.
+            guard result != .busy else { return }
             MaintenanceStatsCache.shared.invalidate(destIds: destIds)
             self.retentionPreview = .idle
             self.loadSizes(for: set, in: model, force: true)

--- a/App/Sources/ViewModels/AppModel+Maintenance.swift
+++ b/App/Sources/ViewModels/AppModel+Maintenance.swift
@@ -586,7 +586,24 @@ final class MaintenanceModel: ObservableObject {
     /// from the same data, so what the user reads in the dialog and what they
     /// see behind it are the same measurement.
     func prepareApplyRetention(for set: BackupSet, in model: AppModel) {
-        guard let policy = set.retention, !policy.isEmpty else {
+        // **Scheduling scope, not addressable.** The Maintenance screen reads
+        // the addressable view — correct for sizes, inspection and restore,
+        // which must see every repository this machine can reach. But Apply
+        // Retention runs through `run-set --kind prune`, and that resolves
+        // the *scheduling* view, where a destination disabled by a machine
+        // override has been dropped. Previewing and fingerprinting the
+        // addressable set would describe a destination list the helper will
+        // never produce: the fingerprints disagree for a perfectly valid
+        // configuration and every apply fails closed with
+        // `operation_not_allowed`. Worse, the dialog would count snapshots on
+        // a destination that is not going to be touched.
+        guard let scheduledSet = Self.scheduledSet(model, id: set.id) else {
+            retentionPreview = .failed(
+                "This backup set does not run on this machine, so retention cannot be applied here."
+            )
+            return
+        }
+        guard let policy = scheduledSet.retention, !policy.isEmpty else {
             retentionPreview = .failed(MaintenanceError.noRetentionPolicy.localizedDescription)
             return
         }
@@ -600,17 +617,29 @@ final class MaintenanceModel: ObservableObject {
         // The fingerprint must describe a configuration that resolves to the
         // set this preview is about to measure. Fingerprinting the bytes
         // alone is not enough: if `config.json` was replaced by fleet sync or
-        // `config import` while the app has been open, `set`, `policy` and
-        // the runner still come from the app's *old* in-memory config, while
-        // the bytes on disk are the *new* one. The helper would then load the
-        // new config, see the fingerprint match, and apply a retention plan
+        // `config import` while the app has been open, the set, policy and
+        // runner still come from the app's *old* in-memory config, while the
+        // bytes on disk are the *new* one. The helper would then load the new
+        // config, see the fingerprint match, and apply a retention plan
         // nobody reviewed — the exact failure this binding exists to stop.
         let store = ConfigStore(paths: model.paths)
         guard let snapshot = try? store.snapshot(),
-              snapshot.config.addressable(for: model.machine).set(id: set.id) == set else {
+              snapshot.config.resolved(for: model.machine).config.sets
+                  .first(where: { $0.id == set.id }) == scheduledSet else {
             retentionPreview = .failed(
                 "Settings on disk have changed since this window loaded them. "
                     + "Reload settings, then preview cleanup again."
+            )
+            return
+        }
+        // Required, not best-effort: encoding `nil` on both sides would make
+        // the fingerprints match while binding no executable at all, and the
+        // helper refuses an unbound destructive launch anyway.
+        guard let executableIdentity = (try? MaintenanceLookup.resticRunner(model))?
+            .maintenanceExecutable()?.identity else {
+            retentionPreview = .failed(
+                "The configured restic executable could not be read, so this operation "
+                    + "cannot be bound to it. Recheck restic and try again."
             )
             return
         }
@@ -622,28 +651,34 @@ final class MaintenanceModel: ObservableObject {
         // still matched.
         let expectedConfig = MaintenanceBinding.effectiveSetFingerprint(
             machineId: model.machine.machineId,
-            set: set,
+            set: scheduledSet,
             configFingerprint: snapshot.fingerprint,
             machineFingerprint: store.machineFileFingerprint(),
-            resticExecutableIdentity: (try? MaintenanceLookup.resticRunner(model))?
-                .maintenanceExecutable()?.identity
+            resticExecutableIdentity: executableIdentity
         )
-        let previewedDestinations = set.destinations
+        let previewedDestinations = scheduledSet.destinations
         let generation = beginPreparation()
         Task { [weak self] in
-            let previews = await Self.dryRun(set: set, policy: policy, runner: runner)
+            let previews = await Self.dryRun(set: scheduledSet, policy: policy, runner: runner)
             guard let self, self.shouldPublish(generation) else { return }
             self.isPreparingPrune = false
             let now = Date()
             self.retentionPreview = .ready(previews: previews, at: now)
             self.prunePlan = PrunePlan(
-                setId: set.id,
-                setName: set.name,
+                setId: scheduledSet.id,
+                setName: scheduledSet.name,
                 previews: previews,
                 expectedConfig: expectedConfig,
                 previewedDestinations: previewedDestinations
             )
         }
+    }
+
+    /// The set as **`run-set` will resolve it**: scheduling scope, with
+    /// anything disabled on this machine already dropped. `nil` means the set
+    /// does not run here at all.
+    static func scheduledSet(_ model: AppModel, id: UUID) -> BackupSet? {
+        model.resolvedConfig.sets.first { $0.id == id }
     }
 
     /// **Reclaim space**, step 1: run restic's non-mutating `prune
@@ -715,11 +750,11 @@ final class MaintenanceModel: ObservableObject {
         let resultTask: () async -> HelperResult
         switch plan.action {
         case .retention(let expectedConfig, let previewedDestinations):
-            // Fail closed exactly like reclaim. The dialog names a snapshot
-            // count computed against a specific destination list; if that
-            // list moved underneath us, the count is about a different
-            // repository set than the one we are about to change.
-            guard set.destinations == previewedDestinations else {
+            // Fail closed exactly like reclaim, and against the same
+            // scheduling-scoped set the preview measured — comparing the
+            // addressable destinations here would reintroduce the mismatch.
+            guard let scheduled = Self.scheduledSet(model, id: plan.setId),
+                  scheduled.destinations == previewedDestinations else {
                 self.prunePlan = nil
                 self.activity = Self.activity(
                     title: "Apply retention",
@@ -729,7 +764,7 @@ final class MaintenanceModel: ObservableObject {
                 )
                 return
             }
-            destIds = set.destinations.map(\.id)
+            destIds = scheduled.destinations.map(\.id)
             title = "Apply retention"
             // The helper independently re-checks this against config.json on
             // disk: the app's in-memory copy is not evidence about what the

--- a/App/Sources/ViewModels/AppModel+Maintenance.swift
+++ b/App/Sources/ViewModels/AppModel+Maintenance.swift
@@ -392,8 +392,20 @@ final class MaintenanceModel: ObservableObject {
             prunePlan = nil
             retentionPreview = .idle
             activity = nil
+            // Clearing is not enough on its own. A dry run already awaiting
+            // I/O — easily seconds against a remote repository, and the
+            // picker stays enabled throughout — will still complete and
+            // write its result back, restoring the *previous* set's preview,
+            // activity and (destructive) plan under the newly selected set.
+            // Bumping the generation makes those completions no-ops.
+            previewGeneration &+= 1
         }
     }
+
+    /// Incremented whenever a completion measured against an earlier
+    /// selection must be discarded. Every async maintenance preview captures
+    /// it and refuses to publish if it has moved.
+    private var previewGeneration: UInt64 = 0
 
     @Published private(set) var sizes: [UUID: SizeState] = [:]
     @Published private(set) var retentionPreview: RetentionPreviewState = .idle
@@ -531,9 +543,11 @@ final class MaintenanceModel: ObservableObject {
             return
         }
         retentionPreview = .loading
+        let generation = previewGeneration
         Task { [weak self] in
             let previews = await Self.dryRun(set: set, policy: policy, runner: runner)
-            self?.retentionPreview = .ready(previews: previews, at: Date())
+            guard let self, self.previewGeneration == generation else { return }
+            self.retentionPreview = .ready(previews: previews, at: Date())
         }
     }
 
@@ -553,15 +567,30 @@ final class MaintenanceModel: ObservableObject {
             retentionPreview = .failed(Self.describe(error))
             return
         }
+        // The fingerprint must describe a configuration that resolves to the
+        // set this preview is about to measure. Fingerprinting the bytes
+        // alone is not enough: if `config.json` was replaced by fleet sync or
+        // `config import` while the app has been open, `set`, `policy` and
+        // the runner still come from the app's *old* in-memory config, while
+        // the bytes on disk are the *new* one. The helper would then load the
+        // new config, see the fingerprint match, and apply a retention plan
+        // nobody reviewed — the exact failure this binding exists to stop.
+        let store = ConfigStore(paths: model.paths)
+        let expectedConfig = store.fileFingerprint()
+        guard let onDisk = try? store.load(),
+              onDisk.addressable(for: model.machine).set(id: set.id) == set else {
+            retentionPreview = .failed(
+                "Settings on disk have changed since this window loaded them. "
+                    + "Reload settings, then preview cleanup again."
+            )
+            return
+        }
         isPreparingPrune = true
-        // Captured before the dry run, so the fingerprint describes the
-        // configuration the counts were measured against — not whatever the
-        // file happens to be by the time the user reads them.
-        let expectedConfig = ConfigStore(paths: model.paths).fileFingerprint()
         let previewedDestinations = set.destinations
+        let generation = previewGeneration
         Task { [weak self] in
             let previews = await Self.dryRun(set: set, policy: policy, runner: runner)
-            guard let self else { return }
+            guard let self, self.previewGeneration == generation else { return }
             self.isPreparingPrune = false
             let now = Date()
             self.retentionPreview = .ready(previews: previews, at: now)
@@ -582,10 +611,11 @@ final class MaintenanceModel: ObservableObject {
     /// snapshots in place.
     func prepareReclaimSpace(for set: BackupSet, destination: Destination, in model: AppModel) {
         isPreparingPrune = true
+        let generation = previewGeneration
         Task { [weak self] in
             let preview = await model.helper.previewReclaimSpace(setId: set.id, destId: destination.id)
             let result = preview.result
-            guard let self else { return }
+            guard let self, self.previewGeneration == generation else { return }
             self.isPreparingPrune = false
             guard result.isSuccess else {
                 self.activity = Self.activity(

--- a/App/Sources/ViewModels/AppModel+Maintenance.swift
+++ b/App/Sources/ViewModels/AppModel+Maintenance.swift
@@ -389,16 +389,7 @@ final class MaintenanceModel: ObservableObject {
     @Published var selectedSetId: UUID? {
         didSet {
             guard oldValue != selectedSetId else { return }
-            prunePlan = nil
-            retentionPreview = .idle
-            activity = nil
-            // Clearing is not enough on its own. A dry run already awaiting
-            // I/O — easily seconds against a remote repository, and the
-            // picker stays enabled throughout — will still complete and
-            // write its result back, restoring the *previous* set's preview,
-            // activity and (destructive) plan under the newly selected set.
-            // Bumping the generation makes those completions no-ops.
-            previewGeneration &+= 1
+            invalidatePreviewWork()
         }
     }
 
@@ -406,6 +397,45 @@ final class MaintenanceModel: ObservableObject {
     /// selection must be discarded. Every async maintenance preview captures
     /// it and refuses to publish if it has moved.
     private var previewGeneration: UInt64 = 0
+
+    /// Discards everything measured against the previous selection, in one
+    /// place so no field is forgotten.
+    ///
+    /// Clearing published state is not enough on its own: a dry run already
+    /// awaiting I/O — easily seconds against a remote repository, and the
+    /// picker stays enabled throughout — completes later and would write the
+    /// previous set's preview, activity and destructive plan back under the
+    /// newly selected set. Bumping the generation makes those completions
+    /// no-ops.
+    ///
+    /// `isPreparingPrune` must be reset here too, and that is the subtle
+    /// part: a generation-checked completion returns *before* it would have
+    /// cleared the flag, so leaving it set wedges every retention and
+    /// reclaim control until the model is recreated. Ownership of the flag
+    /// belongs to whoever is current, not to a task that has been discarded.
+    /// Marks preview preparation in flight and returns the generation that
+    /// owns it. Ownership is the point: only the generation that set the flag
+    /// may clear it, so a discarded completion cannot release a newer task's
+    /// busy state — nor, as happened here, decline to release its own and
+    /// wedge every control that keys off it.
+    func beginPreparation() -> UInt64 {
+        isPreparingPrune = true
+        return previewGeneration
+    }
+
+    /// Whether a completion measured against `generation` may still publish.
+    /// When it may not, it must also not touch `isPreparingPrune`.
+    func shouldPublish(_ generation: UInt64) -> Bool {
+        previewGeneration == generation
+    }
+
+    func invalidatePreviewWork() {
+        previewGeneration &+= 1
+        prunePlan = nil
+        retentionPreview = .idle
+        activity = nil
+        isPreparingPrune = false
+    }
 
     @Published private(set) var sizes: [UUID: SizeState] = [:]
     @Published private(set) var retentionPreview: RetentionPreviewState = .idle
@@ -546,7 +576,7 @@ final class MaintenanceModel: ObservableObject {
         let generation = previewGeneration
         Task { [weak self] in
             let previews = await Self.dryRun(set: set, policy: policy, runner: runner)
-            guard let self, self.previewGeneration == generation else { return }
+            guard let self, self.shouldPublish(generation) else { return }
             self.retentionPreview = .ready(previews: previews, at: Date())
         }
     }
@@ -576,21 +606,33 @@ final class MaintenanceModel: ObservableObject {
         // new config, see the fingerprint match, and apply a retention plan
         // nobody reviewed — the exact failure this binding exists to stop.
         let store = ConfigStore(paths: model.paths)
-        let expectedConfig = store.fileFingerprint()
-        guard let onDisk = try? store.load(),
-              onDisk.addressable(for: model.machine).set(id: set.id) == set else {
+        guard let snapshot = try? store.snapshot(),
+              snapshot.config.addressable(for: model.machine).set(id: set.id) == set else {
             retentionPreview = .failed(
                 "Settings on disk have changed since this window loaded them. "
                     + "Reload settings, then preview cleanup again."
             )
             return
         }
-        isPreparingPrune = true
+        // Binds the whole effective picture — machine identity, both files,
+        // the resolved set and the restic binary — not just the shared
+        // config. `machine.json` decides which overrides apply and which
+        // destinations are enabled here, so hashing `config.json` alone let
+        // the helper resolve a different destination list while the hash
+        // still matched.
+        let expectedConfig = MaintenanceBinding.effectiveSetFingerprint(
+            machineId: model.machine.machineId,
+            set: set,
+            configFingerprint: snapshot.fingerprint,
+            machineFingerprint: store.machineFileFingerprint(),
+            resticExecutableIdentity: (try? MaintenanceLookup.resticRunner(model))?
+                .maintenanceExecutable()?.identity
+        )
         let previewedDestinations = set.destinations
-        let generation = previewGeneration
+        let generation = beginPreparation()
         Task { [weak self] in
             let previews = await Self.dryRun(set: set, policy: policy, runner: runner)
-            guard let self, self.previewGeneration == generation else { return }
+            guard let self, self.shouldPublish(generation) else { return }
             self.isPreparingPrune = false
             let now = Date()
             self.retentionPreview = .ready(previews: previews, at: now)
@@ -610,12 +652,11 @@ final class MaintenanceModel: ObservableObject {
     /// destructive action never gets a bypass simply because it leaves
     /// snapshots in place.
     func prepareReclaimSpace(for set: BackupSet, destination: Destination, in model: AppModel) {
-        isPreparingPrune = true
-        let generation = previewGeneration
+        let generation = beginPreparation()
         Task { [weak self] in
             let preview = await model.helper.previewReclaimSpace(setId: set.id, destId: destination.id)
             let result = preview.result
-            guard let self, self.previewGeneration == generation else { return }
+            guard let self, self.shouldPublish(generation) else { return }
             self.isPreparingPrune = false
             guard result.isSuccess else {
                 self.activity = Self.activity(

--- a/App/Sources/Views/Maintenance/RetentionSection.swift
+++ b/App/Sources/Views/Maintenance/RetentionSection.swift
@@ -27,6 +27,14 @@ struct RetentionSection: View {
         return !retention.isEmpty
     }
 
+    /// **Apply retention now** goes through `run-set --kind prune`, which
+    /// resolves the *scheduling* view. A set disabled on this machine is not
+    /// in that view at all, so the helper would refuse — better to say so
+    /// than to offer a destructive button that cannot work.
+    private var runsOnThisMachine: Bool {
+        MaintenanceModel.scheduledSet(model, id: backupSet.id) != nil
+    }
+
     private var isPruning: Bool {
         maintenance.isBusy(.prune(setId: backupSet.id))
     }
@@ -119,8 +127,11 @@ struct RetentionSection: View {
                         Label("Apply retention now", systemImage: "trash")
                     }
                 }
-                .disabled(!hasPolicy || isPruning || maintenance.isPreparingPrune || isPreviewing)
-                .help("Runs the retention policy. It permanently deletes snapshots the policy no longer keeps.")
+                .disabled(!hasPolicy || !runsOnThisMachine || isPruning
+                    || maintenance.isPreparingPrune || isPreviewing)
+                .help(runsOnThisMachine
+                    ? "Runs the retention policy. It permanently deletes snapshots the policy no longer keeps."
+                    : "This backup set does not run on this machine, so retention cannot be applied here.")
 
                 Menu {
                     ForEach(backupSet.destinations) { destination in

--- a/App/Tests/AppModelMachineOverrideTests.swift
+++ b/App/Tests/AppModelMachineOverrideTests.swift
@@ -238,4 +238,53 @@ struct AppModelMachineOverrideTests {
             #expect(resolved.nonSecretEnv != rawEnvironment)
         }
     }
+
+    /// Switching sets while a preview is in flight must discard that
+    /// preview's result *and* release the busy state it took.
+    ///
+    /// The generation check alone caused a regression: a discarded completion
+    /// returns before it would clear `isPreparingPrune`, and nothing else
+    /// reset it, so every retention and reclaim control stayed disabled until
+    /// the model was recreated. This drives the real ownership seams rather
+    /// than a copy of the logic.
+    @Test("changing sets during a preview releases the busy state it took")
+    func selectionChangeReleasesPreviewBusyState() {
+        let maintenance = MaintenanceModel()
+        maintenance.selectedSetId = UUID()
+
+        let generation = maintenance.beginPreparation()
+        #expect(maintenance.isPreparingPrune)
+        #expect(maintenance.shouldPublish(generation))
+
+        maintenance.selectedSetId = UUID()
+
+        // The in-flight completion is now stale...
+        #expect(!maintenance.shouldPublish(generation))
+        // ...and must not have taken the busy flag with it.
+        #expect(!maintenance.isPreparingPrune)
+        #expect(maintenance.prunePlan == nil)
+        #expect(maintenance.activity == nil)
+        if case .idle = maintenance.retentionPreview {} else {
+            Issue.record("retention preview should be idle after a selection change")
+        }
+
+        // A new operation on the newly selected set can still start.
+        let next = maintenance.beginPreparation()
+        #expect(maintenance.shouldPublish(next))
+        #expect(maintenance.isPreparingPrune)
+    }
+
+    /// Re-selecting the same set must not discard work in flight for it.
+    @Test("re-selecting the same set does not invalidate its preview")
+    func reselectingSameSetKeepsPreview() {
+        let maintenance = MaintenanceModel()
+        let setId = UUID()
+        maintenance.selectedSetId = setId
+
+        let generation = maintenance.beginPreparation()
+        maintenance.selectedSetId = setId
+
+        #expect(maintenance.shouldPublish(generation))
+        #expect(maintenance.isPreparingPrune)
+    }
 }

--- a/App/Tests/AppModelMachineOverrideTests.swift
+++ b/App/Tests/AppModelMachineOverrideTests.swift
@@ -287,4 +287,88 @@ struct AppModelMachineOverrideTests {
         #expect(maintenance.shouldPublish(generation))
         #expect(maintenance.isPreparingPrune)
     }
+
+    /// **Apply Retention must use the scheduling view, not the addressable
+    /// one.** The Maintenance screen reads addressable — right for sizes,
+    /// inspection and restore — but `run-set --kind prune` resolves
+    /// scheduling, where a destination disabled here has been dropped.
+    ///
+    /// Binding the addressable set made the app and helper fingerprint
+    /// different `BackupSet` values for a perfectly valid configuration, so
+    /// every apply failed closed with `operation_not_allowed`; and the
+    /// dialog would have counted snapshots on a destination that was never
+    /// going to be touched.
+    @Test("Apply Retention resolves the scheduling set, not the addressable one")
+    func applyRetentionUsesTheSchedulingSet() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("restic-station-app-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let paths = AppPaths(root: root)
+        let machineId = "test-mac"
+        let setId = UUID()
+        let primary = Destination(id: UUID(), label: "Primary", repoURL: "/repos/primary", isPrimary: true)
+        let disabledMirror = Destination(
+            id: UUID(), label: "Mirror", repoURL: "/repos/mirror", isPrimary: false,
+            machines: [machineId: DestinationMachineOverride(enabled: false)]
+        )
+        let set = BackupSet(
+            id: setId, name: "Documents", sources: ["/Users/shared/Documents"],
+            schedule: .daily(hour: 2, minute: 30),
+            retention: RetentionPolicy(keepLast: 3),
+            destinations: [primary, disabledMirror]
+        )
+        try ConfigStore(paths: paths).save(AppConfig(sets: [set]))
+        try MachineStore(paths: paths).save(MachineConfig(machineId: machineId))
+
+        let model = AppModel(paths: paths)
+
+        let addressable = try #require(MaintenanceLookup.set(model, id: setId))
+        let scheduled = try #require(MaintenanceModel.scheduledSet(model, id: setId))
+
+        // Addressable still reaches the mirror; scheduling has dropped it.
+        #expect(addressable.destinations.count == 2)
+        #expect(scheduled.destinations.count == 1)
+        #expect(scheduled.destinations.first?.label == "Primary")
+
+        // Which is exactly why binding the addressable set could never match
+        // what the helper computes.
+        func fingerprint(_ set: BackupSet) -> String {
+            MaintenanceBinding.effectiveSetFingerprint(
+                machineId: machineId, set: set,
+                configFingerprint: "c", machineFingerprint: "m",
+                resticExecutableIdentity: "restic"
+            )
+        }
+        #expect(fingerprint(addressable) != fingerprint(scheduled))
+        // The helper resolves scheduling, so this is the pair that must agree.
+        #expect(fingerprint(scheduled) == fingerprint(scheduled))
+    }
+
+    /// A set disabled outright on this machine has no scheduling
+    /// representation, so Apply Retention must be refused rather than offered.
+    @Test("a set that does not run here has no scheduling set to apply retention to")
+    func disabledSetHasNoSchedulingSet() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("restic-station-app-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let paths = AppPaths(root: root)
+        let machineId = "test-mac"
+        let setId = UUID()
+        let set = BackupSet(
+            id: setId, name: "Documents", sources: ["/Users/shared/Documents"],
+            schedule: .daily(hour: 2, minute: 30),
+            retention: RetentionPolicy(keepLast: 3),
+            destinations: [Destination(id: UUID(), label: "Primary", repoURL: "/repos/p", isPrimary: true)],
+            machines: [machineId: BackupSetMachineOverride(enabled: false)]
+        )
+        try ConfigStore(paths: paths).save(AppConfig(sets: [set]))
+        try MachineStore(paths: paths).save(MachineConfig(machineId: machineId))
+
+        let model = AppModel(paths: paths)
+
+        #expect(MaintenanceLookup.set(model, id: setId) != nil)      // still addressable
+        #expect(MaintenanceModel.scheduledSet(model, id: setId) == nil)  // but never scheduled
+    }
 }

--- a/Core/Sources/ResticStationCore/Config/AppPaths.swift
+++ b/Core/Sources/ResticStationCore/Config/AppPaths.swift
@@ -1,5 +1,13 @@
 import Foundation
 
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
+
 /// Single source of truth for every runtime path Restic Station reads or
 /// writes. Never hard-code a path elsewhere — go through `AppPaths`.
 ///
@@ -197,6 +205,14 @@ public struct AppPaths: Equatable, Sendable {
         stateDir.appendingPathComponent("preview-tokens.lock", isDirectory: false)
     }
 
+    /// Serializes the read-modify-write of `schedule-state.json`, which is
+    /// one file shared by every set. The per-set locks cannot cover it: two
+    /// helper processes operating on *different* sets both rewrite the whole
+    /// document, so without this one can clobber the other's entry.
+    public var scheduleStateLockFile: URL {
+        stateDir.appendingPathComponent("schedule-state.lock", isDirectory: false)
+    }
+
     // MARK: - locks/
 
     public var locksDir: URL {
@@ -270,5 +286,15 @@ public struct AppPaths: Equatable, Sendable {
         for directory in [runsDir, stateDir, locksDir] {
             try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
         }
+        // `state/` holds `preview-tokens.json` — live capabilities for
+        // destructive operations — so it is owner-only regardless of umask,
+        // and re-asserted rather than set once at creation.
+        //
+        // `root` is deliberately NOT re-tightened here. An operator's chosen
+        // data directory mode is theirs (`scripts/secret-cli-test.sh` pins a
+        // pre-existing 755 dir staying 755), and the protection that matters
+        // is per-file: the token index is 0600 and refuses to load if it is
+        // not. This narrows the exposure without overriding that choice.
+        _ = chmod(stateDir.path, 0o700)
     }
 }

--- a/Core/Sources/ResticStationCore/Config/ConfigStore.swift
+++ b/Core/Sources/ResticStationCore/Config/ConfigStore.swift
@@ -41,6 +41,53 @@ public struct ConfigStore: Sendable {
             .appendingPathComponent(paths.configFile.lastPathComponent + ".tmp", isDirectory: false)
     }
 
+    /// One read of `config.json`: the bytes, their fingerprint, and the
+    /// configuration decoded **from those same bytes**.
+    ///
+    /// `load()` followed by `fileFingerprint()` is two reads, so the decoded
+    /// value and the hashed value are not guaranteed to be the same snapshot
+    /// — a file replaced between them yields a configuration that does not
+    /// correspond to the fingerprint a destructive confirmation is checked
+    /// against. This closes that window.
+    ///
+    /// A migration rewrites the file, so when one happens the snapshot is
+    /// retaken over the post-migration bytes. Migration is one-way and
+    /// terminates, so the retry cannot loop.
+    public func snapshot() throws -> ConfigSnapshot {
+        guard let bytes = try? Data(contentsOf: paths.configFile) else {
+            return ConfigSnapshot(bytes: Data(), fingerprint: "absent", config: AppConfig())
+        }
+        let decoded = try Self.makeDecoder().decode(AppConfig.self, from: bytes)
+        if decoded.version > AppConfig.currentVersion {
+            throw ConfigError.newerVersion(found: decoded.version, supported: AppConfig.currentVersion)
+        }
+        try decoded.validate()
+        guard decoded.version == AppConfig.currentVersion else {
+            _ = try load()   // migrates and rewrites
+            return try snapshotAfterMigration()
+        }
+        return ConfigSnapshot(bytes: bytes, fingerprint: SHA256Digest.hex(bytes), config: decoded)
+    }
+
+    private func snapshotAfterMigration() throws -> ConfigSnapshot {
+        guard let bytes = try? Data(contentsOf: paths.configFile) else {
+            return ConfigSnapshot(bytes: Data(), fingerprint: "absent", config: AppConfig())
+        }
+        let decoded = try Self.makeDecoder().decode(AppConfig.self, from: bytes)
+        try decoded.validate()
+        return ConfigSnapshot(bytes: bytes, fingerprint: SHA256Digest.hex(bytes), config: decoded)
+    }
+
+    /// Fingerprint of `machine.json`'s bytes. It is not part of
+    /// `config.json`, but it decides machine identity, which overrides apply,
+    /// which destinations are enabled here, and the restic path — so a
+    /// destructive confirmation that binds only the shared config can still
+    /// be honoured against a materially different effective set.
+    public func machineFileFingerprint() -> String {
+        guard let data = try? Data(contentsOf: paths.machineFile) else { return "absent" }
+        return SHA256Digest.hex(data)
+    }
+
     /// A fingerprint of `config.json` **as bytes on disk**, for binding a
     /// destructive confirmation to the configuration the operator reviewed.
     ///
@@ -336,5 +383,20 @@ public enum ConfigStoreError: Error, Equatable, Sendable, CustomStringConvertibl
         case .renameFailed(let errno, let from, let to):
             return "rename(\(from), \(to)) failed: errno \(errno)"
         }
+    }
+}
+
+/// `config.json`'s bytes, their fingerprint, and the configuration decoded
+/// from exactly those bytes — so a caller cannot bind a hash of one revision
+/// while acting on another.
+public struct ConfigSnapshot: Sendable {
+    public let bytes: Data
+    public let fingerprint: String
+    public let config: AppConfig
+
+    public init(bytes: Data, fingerprint: String, config: AppConfig) {
+        self.bytes = bytes
+        self.fingerprint = fingerprint
+        self.config = config
     }
 }

--- a/Core/Sources/ResticStationCore/Config/ConfigStore.swift
+++ b/Core/Sources/ResticStationCore/Config/ConfigStore.swift
@@ -41,6 +41,22 @@ public struct ConfigStore: Sendable {
             .appendingPathComponent(paths.configFile.lastPathComponent + ".tmp", isDirectory: false)
     }
 
+    /// A fingerprint of `config.json` **as bytes on disk**, for binding a
+    /// destructive confirmation to the configuration the operator reviewed.
+    ///
+    /// Deliberately hashes the file rather than a decoded `AppConfig`: the
+    /// app and the helper are separate processes that resolve and migrate
+    /// config differently, so hashing decoded objects would make them
+    /// disagree and refuse legitimate operations. The bytes are the one
+    /// thing both sides see identically.
+    ///
+    /// A missing file is a valid, empty configuration (see ``load()``), so
+    /// it fingerprints as a fixed sentinel rather than failing.
+    public func fileFingerprint() -> String {
+        guard let data = try? Data(contentsOf: paths.configFile) else { return "absent" }
+        return SHA256Digest.hex(data)
+    }
+
     /// Missing file → default empty config. Version newer than this build
     /// supports → `ConfigError.newerVersion`. Otherwise decodes, validates
     /// (`AppConfig.validate()` is called on every load) and, for an older
@@ -218,7 +234,7 @@ public struct ConfigStore: Sendable {
     }
 
     private static func warn(_ message: String) {
-        FileHandle.standardError.write(Data("restic-station: config migration: \(message)\n".utf8))
+        StandardStream.write(Data("restic-station: config migration: \(message)\n".utf8), to: .standardError)
     }
 
     /// Validates, encodes (`.sortedKeys` + `.prettyPrinted` + ISO 8601 with

--- a/Core/Sources/ResticStationCore/Engine/BackupEngine.swift
+++ b/Core/Sources/ResticStationCore/Engine/BackupEngine.swift
@@ -557,7 +557,20 @@ public final class BackupEngine: Sendable {
     ///
     /// A dry run first is the UI's job (`ResticCommand.forget(dryRun:)`);
     /// this is the real one.
-    public func runPrune(_ set: BackupSet) async -> RunStatus {
+    /// `expectedExecutableIdentity` binds every `forget --prune` this call
+    /// makes to one restic binary. It is what makes the caller's fingerprint
+    /// check more than advisory: validating the executable and then launching
+    /// unpinned leaves a window — across the lock acquisition and every
+    /// earlier destination — in which a replacement receives the destructive
+    /// command instead.
+    ///
+    /// `nil` means the caller made no such promise, which is the scheduled
+    /// path. A *bound* caller must pass a real identity and refuse if it
+    /// cannot read one; see `RunSet`.
+    public func runPrune(
+        _ set: BackupSet,
+        expectedExecutableIdentity: String? = nil
+    ) async -> RunStatus {
         guard let primary = set.destinations.first(where: { $0.isPrimary }) else {
             logWarning("BackupEngine: backup set \"\(set.name)\" has no primary destination — cannot prune")
             return .failed
@@ -587,7 +600,8 @@ public final class BackupEngine: Sendable {
             policy: retention,
             setId: set.id,
             trigger: .manual,
-            groupId: nil
+            groupId: nil,
+            expectedExecutableIdentity: expectedExecutableIdentity
         ) else {
             return .skipped
         }
@@ -616,7 +630,8 @@ public final class BackupEngine: Sendable {
                 policy: retention,
                 setId: set.id,
                 trigger: .manual,
-                groupId: groupId
+                groupId: groupId,
+                expectedExecutableIdentity: expectedExecutableIdentity
             ) {
                 statuses.append(prune.child.status)
             }
@@ -1383,7 +1398,13 @@ public final class BackupEngine: Sendable {
         policy: RetentionPolicy?,
         setId: UUID,
         trigger: RunTrigger,
-        groupId: String?
+        groupId: String?,
+        /// Non-nil when the caller authorized this operation against a
+        /// specific restic binary. `ResticRunner` rechecks it immediately
+        /// before spawning, so a binary replaced after authorization — the
+        /// window spans every earlier destination in a multi-destination
+        /// prune — never receives `forget --prune`.
+        expectedExecutableIdentity: String? = nil
     ) async -> ChildRun? {
         guard let policy, !policy.isEmpty else {
             return nil
@@ -1396,7 +1417,10 @@ public final class BackupEngine: Sendable {
             groupId: groupId,
             phase: "retention",
             command: .forget(repo: destination.repoURL, policy: policy, prune: true),
-            invocation: ResticInvocation(destination: destination),
+            invocation: ResticInvocation(
+                destination: destination,
+                expectedExecutableIdentity: expectedExecutableIdentity
+            ),
             streamProgress: false
         )
     }

--- a/Core/Sources/ResticStationCore/Engine/BackupEngine.swift
+++ b/Core/Sources/ResticStationCore/Engine/BackupEngine.swift
@@ -1208,7 +1208,7 @@ public final class BackupEngine: Sendable {
         setId: UUID,
         trigger: RunTrigger,
         groupId: String?,
-        executable: ResticRunner.MaintenanceExecutable?
+        executable: ResticRunner.MaintenanceExecutable
     ) async -> ChildRun? {
         let fullIDByShortID = Dictionary(
             snapshotIDs.map { (String($0.prefix(8)), $0) },
@@ -1241,7 +1241,7 @@ public final class BackupEngine: Sendable {
             // path the golden argv tests and `docs/restic-cli.md` describe.
             invocation: ResticInvocation(
                 destination: destination,
-                expectedExecutableIdentity: executable?.identity
+                expectedExecutableIdentity: executable.identity
             ),
             streamProgress: false,
             purgeSnapshotRewrites: { outcome in

--- a/Core/Sources/ResticStationCore/Engine/BackupEngine.swift
+++ b/Core/Sources/ResticStationCore/Engine/BackupEngine.swift
@@ -1002,13 +1002,20 @@ public final class BackupEngine: Sendable {
             )
         }
         guard tokenDestinations.contains(where: { !$0.snapshotIDs.isEmpty }) else { return nil }
+        // Thrown, not `return nil`. `nil` from this method means "there is
+        // nothing destructive to do", and a restic binary that cannot be
+        // identified is emphatically not that — returning nil would report
+        // an empty plan for a set that has one.
+        guard let executable = restic.maintenanceExecutable() else {
+            throw PurgeApplyError.resticUnavailable
+        }
         return try previewTokens.issue(
             machineId: machineId,
             setId: set.id,
             destinations: tokenDestinations,
             config: config,
             patterns: set.purgeExcludes,
-            executableIdentity: restic.maintenanceExecutable()?.identity
+            executableIdentity: executable.identity
         )
     }
 
@@ -1067,8 +1074,11 @@ public final class BackupEngine: Sendable {
         let requestedIds = Set(destinations.map(\.id))
         let tokenIds = Set(preview.destinations.map(\.destinationId))
         // Resolved once and carried all the way to the launch, so the value
-        // that is validated is the value that runs.
-        let executable = restic.maintenanceExecutable()
+        // that is validated is the value that runs — and *required*, because
+        // a nil on both sides used to compare equal while binding nothing.
+        guard let executable = restic.maintenanceExecutable() else {
+            throw PurgeApplyError.resticUnavailable
+        }
         let fingerprint: String
         do {
             // Recomputed here, from the executable this process would
@@ -1076,7 +1086,7 @@ public final class BackupEngine: Sendable {
             // must not authorize a rewrite by this one.
             fingerprint = try PreviewTokenStore.purgeFingerprint(
                 config,
-                executableIdentity: executable?.identity
+                executableIdentity: executable.identity
             )
         } catch {
             throw PurgeApplyError.unavailable
@@ -1262,6 +1272,9 @@ public final class BackupEngine: Sendable {
     ) async throws -> PurgeRunResult {
         guard await secretsAvailable(for: [destination]) else { throw PurgeApplyError.unavailable }
         let plan = try await currentPurgePlan(set: set, destination: destination, patterns: patterns)
+        guard let executable = restic.maintenanceExecutable() else {
+            throw PurgeApplyError.resticUnavailable
+        }
         let token: PreviewToken
         do {
             token = try previewTokens.issue(
@@ -1270,8 +1283,10 @@ public final class BackupEngine: Sendable {
                 destinations: [PreviewTokenDestination(destinationId: destination.id, snapshotIDs: plan.matched.map(\.id))],
                 config: config,
                 patterns: patterns,
-                executableIdentity: restic.maintenanceExecutable()?.identity
+                executableIdentity: executable.identity
             )
+        } catch let error as PurgeApplyError {
+            throw error
         } catch {
             throw PurgeApplyError.unavailable
         }

--- a/Core/Sources/ResticStationCore/Engine/BackupEngine.swift
+++ b/Core/Sources/ResticStationCore/Engine/BackupEngine.swift
@@ -992,7 +992,8 @@ public final class BackupEngine: Sendable {
             setId: set.id,
             destinations: tokenDestinations,
             config: config,
-            patterns: set.purgeExcludes
+            patterns: set.purgeExcludes,
+            executableIdentity: restic.maintenanceExecutable()?.identity
         )
     }
 
@@ -1052,7 +1053,13 @@ public final class BackupEngine: Sendable {
         let tokenIds = Set(preview.destinations.map(\.destinationId))
         let fingerprint: String
         do {
-            fingerprint = try PreviewTokenStore.configFingerprint(config)
+            // Recomputed here, from the executable this process would
+            // actually run: a token issued against a different restic binary
+            // must not authorize a rewrite by this one.
+            fingerprint = try PreviewTokenStore.purgeFingerprint(
+                config,
+                executableIdentity: restic.maintenanceExecutable()?.identity
+            )
         } catch {
             throw PurgeApplyError.unavailable
         }
@@ -1227,7 +1234,8 @@ public final class BackupEngine: Sendable {
                 setId: set.id,
                 destinations: [PreviewTokenDestination(destinationId: destination.id, snapshotIDs: plan.matched.map(\.id))],
                 config: config,
-                patterns: patterns
+                patterns: patterns,
+                executableIdentity: restic.maintenanceExecutable()?.identity
             )
         } catch {
             throw PurgeApplyError.unavailable
@@ -2171,5 +2179,5 @@ final class ProgressReporter: @unchecked Sendable {
 // MARK: - Logging
 
 private func logWarning(_ message: String) {
-    FileHandle.standardError.write(Data((message + "\n").utf8))
+    StandardStream.write(Data((message + "\n").utf8), to: .standardError)
 }

--- a/Core/Sources/ResticStationCore/Engine/BackupEngine.swift
+++ b/Core/Sources/ResticStationCore/Engine/BackupEngine.swift
@@ -1051,6 +1051,9 @@ public final class BackupEngine: Sendable {
 
         let requestedIds = Set(destinations.map(\.id))
         let tokenIds = Set(preview.destinations.map(\.destinationId))
+        // Resolved once and carried all the way to the launch, so the value
+        // that is validated is the value that runs.
+        let executable = restic.maintenanceExecutable()
         let fingerprint: String
         do {
             // Recomputed here, from the executable this process would
@@ -1058,7 +1061,7 @@ public final class BackupEngine: Sendable {
             // must not authorize a rewrite by this one.
             fingerprint = try PreviewTokenStore.purgeFingerprint(
                 config,
-                executableIdentity: restic.maintenanceExecutable()?.identity
+                executableIdentity: executable?.identity
             )
         } catch {
             throw PurgeApplyError.unavailable
@@ -1122,7 +1125,8 @@ public final class BackupEngine: Sendable {
                 patterns: preview.patterns,
                 setId: set.id,
                 trigger: trigger,
-                groupId: resolvedGroupId
+                groupId: resolvedGroupId,
+                executable: executable
             ) else {
                 return PurgeRunResult(status: .failed, children: children)
             }
@@ -1178,7 +1182,8 @@ public final class BackupEngine: Sendable {
         patterns: [String],
         setId: UUID,
         trigger: RunTrigger,
-        groupId: String?
+        groupId: String?,
+        executable: ResticRunner.MaintenanceExecutable?
     ) async -> ChildRun? {
         let fullIDByShortID = Dictionary(
             snapshotIDs.map { (String($0.prefix(8)), $0) },
@@ -1197,7 +1202,22 @@ public final class BackupEngine: Sendable {
                 excludes: patterns,
                 forget: true
             ),
-            invocation: ResticInvocation(destination: destination),
+            // Pin the executable the token was validated against. Without
+            // this the fingerprint check was advisory: restic could be
+            // replaced between validation and launch — the window includes
+            // `currentPurgePlan`'s repository queries, which are slow — and
+            // the replacement would run `rewrite --forget` under an
+            // already-consumed token. `ResticRunner` rechecks the identity
+            // immediately before it spawns.
+            //
+            // Identity only, deliberately no `resticPathOverride`: the runner
+            // resolves symlinks when it recomputes, so a retargeted link
+            // still fails the check, while `argv[0]` stays the configured
+            // path the golden argv tests and `docs/restic-cli.md` describe.
+            invocation: ResticInvocation(
+                destination: destination,
+                expectedExecutableIdentity: executable?.identity
+            ),
             streamProgress: false,
             purgeSnapshotRewrites: { outcome in
                 Dictionary(uniqueKeysWithValues: parseRewrite(outcome.rawOutput).snapshots.compactMap { rewrite in

--- a/Core/Sources/ResticStationCore/Engine/PurgePlan.swift
+++ b/Core/Sources/ResticStationCore/Engine/PurgePlan.swift
@@ -115,4 +115,9 @@ public enum PurgeApplyError: Error, Equatable, Sendable {
     case busy
     case destinationOffline(destinationId: UUID)
     case unavailable
+    /// No restic executable could be identified, so no destructive purge
+    /// capability may be minted or honoured. Distinct from ``unavailable``
+    /// because the remedy is specific: restore the configured binary
+    /// (#109 exact-head review).
+    case resticUnavailable
 }

--- a/Core/Sources/ResticStationCore/Engine/StateStore.swift
+++ b/Core/Sources/ResticStationCore/Engine/StateStore.swift
@@ -262,11 +262,16 @@ public struct FdaCheckResult: Codable, Equatable, Sendable {
 
 public enum StateStoreError: Error, Equatable, Sendable, CustomStringConvertible {
     case renameFailed(errno: Int32, from: String, to: String)
+    /// `schedule-state.json`'s companion lock could not be acquired within
+    /// the bounded retry window.
+    case scheduleStateLockTimeout(path: String)
 
     public var description: String {
         switch self {
         case .renameFailed(let errno, let from, let to):
             return "rename(\(from), \(to)) failed: errno \(errno)"
+        case .scheduleStateLockTimeout(let path):
+            return "timed out waiting for schedule state lock \(path)"
         }
     }
 }
@@ -297,14 +302,41 @@ public struct StateStore: Sendable {
         read(ScheduleState.self, from: paths.scheduleStateFile)
     }
 
+    /// How long to retry for the schedule-state lock before giving up. The
+    /// critical section is a decode, one dictionary mutation and an atomic
+    /// write, so real contention is measured in milliseconds.
+    private static let stateLockTimeout: TimeInterval = 5
+    private static let stateLockPollInterval: UInt32 = 20_000  // 20ms
+
     /// Loads the current `ScheduleState` (or an empty one), applies
     /// `mutate` to `setId`'s entry (creating it if absent), and writes the
     /// result back atomically.
+    ///
+    /// Held under ``AppPaths/scheduleStateLockFile`` for the whole
+    /// read-modify-write. The write itself was always atomic, but atomicity
+    /// is not isolation: `schedule-state.json` is one document shared by
+    /// every set, while the only other lock is per-set. A scheduled tick for
+    /// set A and a manual operation on set B run in different processes,
+    /// take no common lock, and each rewrite the whole file — so B could read
+    /// before A's write and write after it, silently discarding A's entry.
+    /// That entry now carries `appliedPurgeExcludes`, i.e. destructive
+    /// bookkeeping, so a lost update is no longer merely scheduling hygiene.
     @discardableResult
     public func updateScheduleState(
         setId: UUID,
         mutate: (inout SetScheduleState) -> Void
     ) throws -> ScheduleState {
+        try paths.ensureDirectories()
+        let lock = FileLock(path: paths.scheduleStateLockFile)
+        let deadline = Date().addingTimeInterval(Self.stateLockTimeout)
+        while !lock.tryAcquire() {
+            if Date() > deadline {
+                throw StateStoreError.scheduleStateLockTimeout(path: paths.scheduleStateLockFile.path)
+            }
+            usleep(Self.stateLockPollInterval)
+        }
+        defer { lock.release() }
+
         var state = readScheduleState() ?? ScheduleState()
         var entry = state.sets[setId] ?? SetScheduleState()
         mutate(&entry)

--- a/Core/Sources/ResticStationCore/Engine/StateStore.swift
+++ b/Core/Sources/ResticStationCore/Engine/StateStore.swift
@@ -321,6 +321,14 @@ public struct StateStore: Sendable {
     /// before A's write and write after it, silently discarding A's entry.
     /// That entry now carries `appliedPurgeExcludes`, i.e. destructive
     /// bookkeeping, so a lost update is no longer merely scheduling hygiene.
+    ///
+    /// **This method blocks** while waiting for the lock. That is fine for the
+    /// helper, which is a one-shot process whose contention is with *other
+    /// processes*, but callers must not fan it out across Swift Concurrency
+    /// tasks: blocking the cooperative pool prevents the lock holder from
+    /// being scheduled to release, so waiters spin to the timeout. A test that
+    /// did exactly that turned a 0.3s case into a 50s one on a two-core runner
+    /// and stalled the whole suite behind it.
     @discardableResult
     public func updateScheduleState(
         setId: UUID,

--- a/Core/Sources/ResticStationCore/Restic/RemoteResticCommand.swift
+++ b/Core/Sources/ResticStationCore/Restic/RemoteResticCommand.swift
@@ -21,7 +21,14 @@ public struct RemoteResticCommand: Equatable, Sendable {
     static let sshPrefix = [
         "/usr/bin/ssh",
         "-o", "BatchMode=yes",
-        "-o", "StrictHostKeyChecking=accept-new",
+        // `yes`, not `accept-new`. This channel carries the repository
+        // password on stdin for `restic -p /dev/stdin`, so trust-on-first-use
+        // means a MITM present at first contact is handed the password and
+        // then answers `restic version` convincingly. The operator has
+        // already ssh'd to this host to set the destination up, so the key is
+        // normally pinned; when it is not, failing with an actionable message
+        // is better than silently trusting whoever answers.
+        "-o", "StrictHostKeyChecking=yes",
         "-o", "ConnectTimeout=15",
         "-o", "ServerAliveInterval=15",
         "-o", "ServerAliveCountMax=3",

--- a/Core/Sources/ResticStationCore/Restic/ResticRunner.swift
+++ b/Core/Sources/ResticStationCore/Restic/ResticRunner.swift
@@ -265,6 +265,13 @@ public final class ResticRunner: Sendable {
         maintenanceExecutable(path: resticPath)
     }
 
+    /// The identity as of *right now*, hashed rather than recalled. Used
+    /// only where the answer authorizes a destructive launch; see
+    /// ``ExecutableIdentityCache``.
+    func revalidatedMaintenanceExecutable(path: String) -> MaintenanceExecutable? {
+        maintenanceExecutable(path: path, bypassingCache: true)
+    }
+
     // MARK: - Secret-store pre-flight
 
     private func preflightSecrets(destination: Destination) async throws {
@@ -364,8 +371,12 @@ public final class ResticRunner: Sendable {
         timeout: TimeInterval?
     ) async throws -> ResticOutcome {
         let resolvedExecutablePath = executablePath ?? resticPath
+        // `revalidated…`, not the cached accessor: the whole point of this
+        // check is that the bytes on disk may have changed since the
+        // preview, and a metadata-keyed cache cannot see an in-place
+        // overwrite that preserves size and mtime.
         if let expectedExecutableIdentity,
-           maintenanceExecutable(path: resolvedExecutablePath)?.identity != expectedExecutableIdentity {
+           revalidatedMaintenanceExecutable(path: resolvedExecutablePath)?.identity != expectedExecutableIdentity {
             throw ResticRunnerError.launchFailed("the restic executable changed after the maintenance preview")
         }
         // Destructive preview tokens are consumed here, after every launch
@@ -437,12 +448,12 @@ public final class ResticRunner: Sendable {
     /// the file.
     private static let executableCache = ExecutableIdentityCache()
 
-    private func maintenanceExecutable(path: String) -> MaintenanceExecutable? {
+    private func maintenanceExecutable(path: String, bypassingCache: Bool = false) -> MaintenanceExecutable? {
         guard path.hasPrefix("/") else { return nil }
         let executable = URL(fileURLWithPath: path)
             .resolvingSymlinksInPath()
             .standardizedFileURL
-        return Self.executableCache.identity(for: executable)
+        return Self.executableCache.identity(for: executable, bypassingCache: bypassingCache)
     }
 
     /// Classifies a finished run.
@@ -492,15 +503,27 @@ private final class MessageCollector: @unchecked Sendable {
 
 /// Process-local memo for ``ResticRunner/MaintenanceExecutable``.
 ///
-/// The cache key includes device, inode, size and mtime, so replacing the
-/// binary — the exact thing the digest exists to detect — misses the cache
-/// and is re-hashed. Only a byte-identical file at the same inode with
-/// unchanged metadata reuses an entry.
+/// The cache key includes device, inode, size and mtime, so *most* ways of
+/// replacing the binary miss the cache and are re-hashed.
+///
+/// **Metadata is not a substitute for the bytes, and this cache must never
+/// be trusted to enforce a pin.** An in-place overwrite that keeps the same
+/// inode, writes the same number of bytes and restores the original mtime —
+/// exactly what an updater preserving timestamps does — produces an
+/// unchanged key and returns the *previous* digest. The launch-time
+/// revalidation would then compare a stale identity to itself and let the
+/// replacement receive the destructive command, defeating the pin it exists
+/// to enforce. So every revalidation passes `bypassingCache: true` and
+/// hashes the file (#109 exact-head review).
+///
+/// The cache still does its job — `335e33d` added it so a multi-step purge
+/// does not re-hash restic on every step — because only the comparatively
+/// rare destructive *launch* pays for a fresh hash.
 final class ExecutableIdentityCache: @unchecked Sendable {
     private let lock = NSLock()
     private var entries: [String: ResticRunner.MaintenanceExecutable] = [:]
 
-    func identity(for executable: URL) -> ResticRunner.MaintenanceExecutable? {
+    func identity(for executable: URL, bypassingCache: Bool = false) -> ResticRunner.MaintenanceExecutable? {
         guard let attributes = try? FileManager.default.attributesOfItem(atPath: executable.path) else {
             return nil
         }
@@ -510,10 +533,12 @@ final class ExecutableIdentityCache: @unchecked Sendable {
         let device = (attributes[.systemNumber] as? NSNumber)?.uint64Value ?? 0
         let key = "\(executable.path)|\(device)|\(inode)|\(size)|\(modified)"
 
-        lock.lock()
-        let cached = entries[key]
-        lock.unlock()
-        if let cached { return cached }
+        if !bypassingCache {
+            lock.lock()
+            let cached = entries[key]
+            lock.unlock()
+            if let cached { return cached }
+        }
 
         guard let data = try? Data(contentsOf: executable) else { return nil }
         let value = ResticRunner.MaintenanceExecutable(

--- a/Core/Sources/ResticStationCore/Restic/ResticRunner.swift
+++ b/Core/Sources/ResticStationCore/Restic/ResticRunner.swift
@@ -231,6 +231,17 @@ public final class ResticRunner: Sendable {
         do { result = try await runner.run(command.argv, env: nil, stdin: nil, currentDirectory: nil, onStdoutLine: nil, onStderrLine: nil, timeout: 20) }
         catch { throw ResticRunnerError.launchFailed("remote maintenance SSH could not be launched") }
         guard result.exitCode == 0, let info = try? parseVersion(result.stdout), info.meetsMinimum("0.17.0") else {
+            // An unpinned host key is the one failure here with a specific,
+            // actionable remedy, and it is invisible in the generic message.
+            let stderr = String(decoding: result.stderr, as: UTF8.self)
+            if stderr.contains("Host key verification failed")
+                || stderr.contains("No RSA host key is known")
+                || stderr.contains("no matching host key") {
+                throw ResticRunnerError.launchFailed(
+                    "the maintenance host's SSH key is not known. Connect to it once with ssh to "
+                        + "verify and record the key, then retry."
+                )
+            }
             throw ResticRunnerError.launchFailed("remote restic is unavailable or below version 0.17")
         }
         return info

--- a/Core/Sources/ResticStationCore/Restic/ResticRunner.swift
+++ b/Core/Sources/ResticStationCore/Restic/ResticRunner.swift
@@ -423,16 +423,26 @@ public final class ResticRunner: Sendable {
         )
     }
 
+    /// Digesting the restic binary is not cheap — it is ~28 MB, and
+    /// `SHA256Digest` is a dependency-free Swift implementation, so a single
+    /// call costs about 10s in a debug build and is far from free in a
+    /// release one. A purge preview and apply ask for the identity several
+    /// times each, which turned one engine test from 0.3s into 40s.
+    ///
+    /// Cached per process, keyed by the file's identity *and* its mutable
+    /// metadata, so an in-place replacement invalidates the entry. This does
+    /// not weaken the binding it feeds: preview and confirmation run in
+    /// **different** helper processes, so the cross-process check that
+    /// actually guards the destructive operation still re-reads and re-hashes
+    /// the file.
+    private static let executableCache = ExecutableIdentityCache()
+
     private func maintenanceExecutable(path: String) -> MaintenanceExecutable? {
         guard path.hasPrefix("/") else { return nil }
         let executable = URL(fileURLWithPath: path)
             .resolvingSymlinksInPath()
             .standardizedFileURL
-        guard let data = try? Data(contentsOf: executable) else { return nil }
-        return MaintenanceExecutable(
-            path: executable.path,
-            identity: "\(executable.path):\(SHA256Digest.hex(data))"
-        )
+        return Self.executableCache.identity(for: executable)
     }
 
     /// Classifies a finished run.
@@ -477,5 +487,42 @@ private final class MessageCollector: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         _messages.append(message)
+    }
+}
+
+/// Process-local memo for ``ResticRunner/MaintenanceExecutable``.
+///
+/// The cache key includes device, inode, size and mtime, so replacing the
+/// binary — the exact thing the digest exists to detect — misses the cache
+/// and is re-hashed. Only a byte-identical file at the same inode with
+/// unchanged metadata reuses an entry.
+final class ExecutableIdentityCache: @unchecked Sendable {
+    private let lock = NSLock()
+    private var entries: [String: ResticRunner.MaintenanceExecutable] = [:]
+
+    func identity(for executable: URL) -> ResticRunner.MaintenanceExecutable? {
+        guard let attributes = try? FileManager.default.attributesOfItem(atPath: executable.path) else {
+            return nil
+        }
+        let size = (attributes[.size] as? NSNumber)?.uint64Value ?? 0
+        let modified = (attributes[.modificationDate] as? Date)?.timeIntervalSince1970 ?? 0
+        let inode = (attributes[.systemFileNumber] as? NSNumber)?.uint64Value ?? 0
+        let device = (attributes[.systemNumber] as? NSNumber)?.uint64Value ?? 0
+        let key = "\(executable.path)|\(device)|\(inode)|\(size)|\(modified)"
+
+        lock.lock()
+        let cached = entries[key]
+        lock.unlock()
+        if let cached { return cached }
+
+        guard let data = try? Data(contentsOf: executable) else { return nil }
+        let value = ResticRunner.MaintenanceExecutable(
+            path: executable.path,
+            identity: "\(executable.path):\(SHA256Digest.hex(data))"
+        )
+        lock.lock()
+        entries[key] = value
+        lock.unlock()
+        return value
     }
 }

--- a/Core/Sources/ResticStationCore/Runs/RunStore.swift
+++ b/Core/Sources/ResticStationCore/Runs/RunStore.swift
@@ -547,5 +547,5 @@ public struct RunStore: Sendable {
 }
 
 private func warn(_ message: String) {
-    FileHandle.standardError.write(Data((message + "\n").utf8))
+    StandardStream.write(Data((message + "\n").utf8), to: .standardError)
 }

--- a/Core/Sources/ResticStationCore/Secrets/FileSecretStore.swift
+++ b/Core/Sources/ResticStationCore/Secrets/FileSecretStore.swift
@@ -93,7 +93,7 @@ public struct FileSecretStore: SecretStore {
                 _ = path.withCString { chmod($0, mode) }
             },
             warningHandler: { message in
-                FileHandle.standardError.write(Data((message + "\n").utf8))
+                StandardStream.write(Data((message + "\n").utf8), to: .standardError)
             }
         )
     }

--- a/Core/Sources/ResticStationCore/Support/CLIError.swift
+++ b/Core/Sources/ResticStationCore/Support/CLIError.swift
@@ -413,6 +413,18 @@ extension CLIFailure {
             )
         case .busy:
             return CLIFailure.setBusy(setId: setId)
+        case .resticUnavailable:
+            // Named specifically rather than folded into the cause-neutral
+            // `.unavailable` advice: unlike secret storage or a failed
+            // listing, this one has a single, stateable remedy, and it is
+            // the refusal that stops an unbound destructive capability from
+            // being minted at all.
+            return CLIFailure(
+                code: .resticNotFound,
+                message: "The restic executable could not be identified, so the purge was refused. "
+                    + "Restore the configured restic binary and run purge preview again.",
+                details: CLIErrorDetails(setId: setId)
+            )
         case .destinationOffline(let destinationId):
             return CLIFailure(
                 code: .repositoryOffline,

--- a/Core/Sources/ResticStationCore/Support/HelperCommand.swift
+++ b/Core/Sources/ResticStationCore/Support/HelperCommand.swift
@@ -23,7 +23,10 @@ public enum HelperCommand: Equatable, Sendable {
     /// `run-set --set <uuid> --kind backup` — "Back Up Now".
     case backUpNow(setId: UUID)
     /// `run-set --set <uuid> --kind prune`.
-    case prune(setId: UUID)
+    /// `run-set --set <uuid> --kind prune [--expected-config <fingerprint>]`.
+    /// `expectedConfig` is the `config.json` fingerprint the caller reviewed;
+    /// the helper refuses if the file changed underneath it.
+    case prune(setId: UUID, expectedConfig: String? = nil)
     /// `run-set --set <uuid> --kind check`.
     case check(setId: UUID)
     /// `maintenance prune --set <uuid> [--dest <uuid>] [--expected-destination <preview-token>] [--dry-run]`.
@@ -67,8 +70,11 @@ public enum HelperCommand: Equatable, Sendable {
             return ["tick"]
         case .backUpNow(let setId):
             return Self.runSet(setId: setId, kind: "backup")
-        case .prune(let setId):
-            return Self.runSet(setId: setId, kind: "prune")
+        case .prune(let setId, let expectedConfig):
+            var argv = Self.runSet(setId: setId, kind: "prune")
+            // Attached form so a fingerprint can never be reparsed as an option.
+            if let expectedConfig { argv.append("--expected-config=\(expectedConfig)") }
+            return argv
         case .check(let setId):
             return Self.runSet(setId: setId, kind: "check")
         case .maintenancePrune(let setId, let destId, let expectedDestination, let dryRun, let json):

--- a/Core/Sources/ResticStationCore/Support/MaintenanceBinding.swift
+++ b/Core/Sources/ResticStationCore/Support/MaintenanceBinding.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// What a destructive maintenance confirmation is bound to.
+///
+/// `config.json`'s bytes alone are not enough. The helper resolves an
+/// **effective** set from `config.json` *and* `machine.json`, and machine
+/// state decides machine identity, which per-machine overrides apply, which
+/// destinations are enabled here, and which restic binary runs. A
+/// confirmation that binds only the shared config can therefore be honoured
+/// against a materially different effective set: replace `machine.json`
+/// between preview and apply and the config hash still matches, while the
+/// helper prunes a different destination list under a different identity.
+///
+/// This binds the whole effective picture, so any of those moving invalidates
+/// the confirmation instead of silently redefining it.
+public enum MaintenanceBinding {
+    /// Deterministic: `.sortedKeys` plus the model's explicit-null encoding.
+    /// Both processes must compute byte-identical input from the same state.
+    private struct EffectiveSet: Encodable {
+        let machineId: String
+        let configFingerprint: String
+        let machineFingerprint: String
+        let resticExecutableIdentity: String?
+        let set: BackupSet
+    }
+
+    public static func effectiveSetFingerprint(
+        machineId: String,
+        set: BackupSet,
+        configFingerprint: String,
+        machineFingerprint: String,
+        resticExecutableIdentity: String?
+    ) -> String {
+        let effective = EffectiveSet(
+            machineId: machineId,
+            configFingerprint: configFingerprint,
+            machineFingerprint: machineFingerprint,
+            resticExecutableIdentity: resticExecutableIdentity,
+            set: set
+        )
+        // Encoding in-memory values cannot fail in practice. If it ever did,
+        // a fixed sentinel would compare equal on both sides and authorize
+        // the operation it was supposed to refuse; a random value can never
+        // match a stored one, so the failure mode is a refusal.
+        guard let data = try? ConfigStore.makeEncoder().encode(effective) else {
+            return "unbindable-" + UUID().uuidString
+        }
+        return SHA256Digest.hex(data)
+    }
+}

--- a/Core/Sources/ResticStationCore/Support/PreviewToken.swift
+++ b/Core/Sources/ResticStationCore/Support/PreviewToken.swift
@@ -119,6 +119,7 @@ public struct PreviewTokenStore: Sendable {
         destinations: [PreviewTokenDestination],
         config: AppConfig,
         patterns: [String],
+        executableIdentity: String?,
         lifetime: TimeInterval = defaultLifetime
     ) throws -> PreviewToken {
         try withStoreLock {
@@ -130,7 +131,7 @@ public struct PreviewTokenStore: Sendable {
                 machineId: machineId,
                 setId: setId,
                 destinations: destinations,
-                configFingerprint: try Self.configFingerprint(config),
+                configFingerprint: try Self.purgeFingerprint(config, executableIdentity: executableIdentity),
                 patterns: patterns,
                 createdAt: createdAt,
                 expiresAt: createdAt.addingTimeInterval(lifetime)
@@ -269,6 +270,20 @@ public struct PreviewTokenStore: Sendable {
         return SHA256Digest.hex(data)
     }
 
+    /// What a **purge** token binds. Config alone left a gap the maintenance
+    /// binding did not have: `pruneConfirmationFingerprint` also covers the
+    /// restic executable's identity, so an in-place binary swap between
+    /// preview and apply invalidates a reclaim confirmation but did not
+    /// invalidate a purge one — even though purge is the operation that
+    /// rewrites snapshot history.
+    public static func purgeFingerprint(
+        _ config: AppConfig,
+        executableIdentity: String?
+    ) throws -> String {
+        let base = try configFingerprint(config)
+        return SHA256Digest.hex(Data("\(base):\(executableIdentity ?? "none")".utf8))
+    }
+
     private struct Index: Codable, Sendable {
         var tokens: [String: PreviewToken] = [:]
     }
@@ -282,6 +297,10 @@ public struct PreviewTokenStore: Sendable {
             try paths.ensureDirectories()
             let lock = FileLock(path: paths.previewTokensLockFile)
             guard lock.tryAcquire() else { throw PreviewTokenError.unavailable }
+            // Owner-only: a lock file another user can open is a lock another
+            // user can hold, which would wedge every destructive confirmation
+            // on the machine. Fail-closed, but total.
+            _ = chmod(paths.previewTokensLockFile.path, 0o600)
             defer { lock.release() }
             return try body()
         } catch let error as PreviewTokenError {
@@ -344,7 +363,13 @@ public struct PreviewTokenStore: Sendable {
     private static func writeOwnerOnly(_ data: Data, to url: URL) throws {
         let path = url.path
         _ = unlink(path)
-        let fd = path.withCString { open($0, O_WRONLY | O_CREAT | O_TRUNC, 0o600) }
+        // O_EXCL|O_NOFOLLOW: refuse to write through a symlink or into a file
+        // someone else recreated between the unlink and the open. The 0700
+        // root makes that unreachable cross-user today, which is exactly why
+        // it should stay unreachable if the root is ever loosened.
+        let fd = path.withCString {
+            open($0, O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW, 0o600)
+        }
         guard fd >= 0 else { throw PreviewTokenError.unavailable }
         defer {
             #if canImport(Darwin)

--- a/Core/Sources/ResticStationCore/Support/PreviewToken.swift
+++ b/Core/Sources/ResticStationCore/Support/PreviewToken.swift
@@ -119,7 +119,7 @@ public struct PreviewTokenStore: Sendable {
         destinations: [PreviewTokenDestination],
         config: AppConfig,
         patterns: [String],
-        executableIdentity: String?,
+        executableIdentity: String,
         lifetime: TimeInterval = defaultLifetime
     ) throws -> PreviewToken {
         try withStoreLock {
@@ -276,12 +276,22 @@ public struct PreviewTokenStore: Sendable {
     /// preview and apply invalidates a reclaim confirmation but did not
     /// invalidate a purge one — even though purge is the operation that
     /// rewrites snapshot history.
+    ///
+    /// `executableIdentity` is **nonoptional**, and that is the point rather
+    /// than tidiness. It used to accept `nil` and fold it to the literal
+    /// `"none"`, so a token minted while restic was missing bound no
+    /// executable at all — and an apply that also saw no restic recomputed
+    /// the same `"none"` fingerprint and matched. Both halves agreeing on
+    /// "no binary" authorized a `rewrite --forget` by whatever binary turned
+    /// up in between. Making the parameter nonoptional means an unbound
+    /// destructive capability cannot be expressed, instead of every caller
+    /// having to remember a guard (#109 exact-head review).
     public static func purgeFingerprint(
         _ config: AppConfig,
-        executableIdentity: String?
+        executableIdentity: String
     ) throws -> String {
         let base = try configFingerprint(config)
-        return SHA256Digest.hex(Data("\(base):\(executableIdentity ?? "none")".utf8))
+        return SHA256Digest.hex(Data("\(base):\(executableIdentity)".utf8))
     }
 
     private struct Index: Codable, Sendable {

--- a/Core/Sources/ResticStationCore/Support/ProcessRunning.swift
+++ b/Core/Sources/ResticStationCore/Support/ProcessRunning.swift
@@ -83,7 +83,15 @@ public extension ProcessRunning {
 /// work on Linux via swift-corelibs-foundation) plus `kill(2)` for signaling,
 /// imported from `Darwin` or `Glibc` depending on platform.
 public struct DefaultProcessRunner: ProcessRunning {
-    public init() {}
+    public init() {
+        // Install before anything can spawn, rather than lazily inside the
+        // call that also spawns. `static let` initialization is thread-safe,
+        // but doing it at first use leaves one window where a thread is
+        // inside `posix_spawn` — which reads the process's signal
+        // dispositions — while another installs the handler. Nothing is known
+        // to have gone wrong there, but the ordering is free.
+        SIGPIPEGuard.ensureInstalled()
+    }
 
     private static func withSIGPIPEIgnored<T>(_ body: () -> T) -> T {
         SIGPIPEGuard.withIgnored(body)
@@ -371,27 +379,34 @@ private actor TimeoutFlag {
 /// Installed **once**, permanently, as a no-op *handler* — deliberately not
 /// `SIG_IGN`. POSIX resets signals "set to be caught" to the default action on
 /// `exec`, while it preserves an *ignored* disposition. So a handler protects
-/// the parent and every child still dies on a broken pipe exactly as before,
+/// this process and every child still dies on a broken pipe exactly as before,
 /// with no window to serialize and no lock to contend on.
 ///
-/// The earlier design scoped `SIG_IGN` to each write under a lock shared with
-/// `Process.run()`. That was correct, but it coupled two unrelated things: a
-/// slow or blocked write to stdout held the lock, and every subprocess spawn
-/// in the process queued behind it. No failure was ever traced to that
-/// coupling — this is removing a hazard, not fixing a proven bug — but the
-/// handler achieves the same guarantee with no shared state at all.
+/// Both halves rest on deterministic experiments, not inference:
 ///
-/// Verified from both directions by `childrenKeepTheDefaultSIGPIPEDisposition`
-/// (child still exits with signal 13, and the Linux container proves it, since
-/// swift-corelibs-foundation does not scrub child dispositions the way macOS
-/// Foundation does) and `standardStreamSurvivesAClosedReader` (this process
-/// gets `EPIPE` instead of dying).
+/// - A permanent `SIG_IGN` **does** leak. Linux CI failed
+///   `childrenKeepTheDefaultSIGPIPEDisposition` against it — the child printed
+///   `survived` and exited 0 — because swift-corelibs-foundation does not
+///   reset child dispositions, though macOS's Foundation does, which hides it
+///   locally.
+/// - A no-op handler does **not** leak: with one installed, a spawned
+///   `kill -PIPE $$; echo survived` still exits with signal 13 and prints
+///   nothing, while a write to a closed pipe in this process throws `EPIPE`
+///   instead of dying.
+/// - `pthread_sigmask` around the write is not sufficient on its own; that was
+///   tried first and the process still died.
 enum SIGPIPEGuard {
     /// `Void` static: the runtime guarantees exactly one initialization,
     /// whichever thread gets there first.
     private static let installed: Void = {
         _ = signal(SIGPIPE, { _ in })
     }()
+
+    /// Forces installation at a deterministic point, before any subprocess
+    /// work begins.
+    static func ensureInstalled() {
+        _ = installed
+    }
 
     static func withIgnored<T>(_ body: () -> T) -> T {
         _ = installed

--- a/Core/Sources/ResticStationCore/Support/ProcessRunning.swift
+++ b/Core/Sources/ResticStationCore/Support/ProcessRunning.swift
@@ -365,43 +365,41 @@ private actor TimeoutFlag {
     }
 }
 
-/// The process-wide SIGPIPE disposition, and the lock that keeps it from
-/// leaking into a child.
+/// Keeps a broken pipe from killing this process, without changing what any
+/// child inherits.
 ///
-/// SIGPIPE has to be handled process-wide rather than with a
-/// `pthread_sigmask`: Foundation does not always raise it on the thread that
-/// called `write`. But POSIX preserves an *ignored* disposition across
-/// `exec`, and swift-corelibs-foundation does not reset child dispositions
-/// (macOS's Foundation happens to, which hides this locally) — so a child
-/// spawned while SIGPIPE is ignored inherits that and no longer dies on a
-/// broken pipe. Every spawn and every ignore-window therefore take this one
-/// lock, making the overlap impossible.
+/// Installed **once**, permanently, as a no-op *handler* — deliberately not
+/// `SIG_IGN`. POSIX resets signals "set to be caught" to the default action on
+/// `exec`, while it preserves an *ignored* disposition. So a handler protects
+/// the parent and every child still dies on a broken pipe exactly as before,
+/// with no window to serialize and no lock to contend on.
 ///
-/// Pinned by `childrenKeepTheDefaultSIGPIPEDisposition`, which fails on Linux
-/// against a permanently installed `signal(SIGPIPE, SIG_IGN)`.
+/// The earlier design scoped `SIG_IGN` to each write under a lock shared with
+/// `Process.run()`. That was correct, but it coupled two unrelated things: a
+/// slow or blocked write to stdout held the lock, and every subprocess spawn
+/// in the process queued behind it. No failure was ever traced to that
+/// coupling — this is removing a hazard, not fixing a proven bug — but the
+/// handler achieves the same guarantee with no shared state at all.
+///
+/// Verified from both directions by `childrenKeepTheDefaultSIGPIPEDisposition`
+/// (child still exits with signal 13, and the Linux container proves it, since
+/// swift-corelibs-foundation does not scrub child dispositions the way macOS
+/// Foundation does) and `standardStreamSurvivesAClosedReader` (this process
+/// gets `EPIPE` instead of dying).
 enum SIGPIPEGuard {
-    private static let lock = NSLock()
+    /// `Void` static: the runtime guarantees exactly one initialization,
+    /// whichever thread gets there first.
+    private static let installed: Void = {
+        _ = signal(SIGPIPE, { _ in })
+    }()
 
     static func withIgnored<T>(_ body: () -> T) -> T {
-        lock.lock()
-        let previous = signal(SIGPIPE, SIG_IGN)
-        defer {
-            // C function pointers are not Equatable; compare the raw bit
-            // patterns so a failed `signal` is never restored as a handler.
-            if unsafeBitCast(previous, to: UInt.self) != unsafeBitCast(SIG_ERR, to: UInt.self) {
-                signal(SIGPIPE, previous)
-            }
-            lock.unlock()
-        }
+        _ = installed
         return body()
     }
 
-    /// Spawns under the same lock, so the disposition is always the default
-    /// at `posix_spawn` time. Synchronous on purpose: `NSLock` is unavailable
-    /// from an async context, and the critical section must not suspend.
     static func launch(_ process: Process) throws {
-        lock.lock()
-        defer { lock.unlock() }
+        _ = installed
         try process.run()
     }
 }

--- a/Core/Sources/ResticStationCore/Support/ProcessRunning.swift
+++ b/Core/Sources/ResticStationCore/Support/ProcessRunning.swift
@@ -85,50 +85,12 @@ public extension ProcessRunning {
 public struct DefaultProcessRunner: ProcessRunning {
     public init() {}
 
-    /// Serializes the SIGPIPE window below against every `posix_spawn`.
-    ///
-    /// The disposition is process-wide state, and POSIX preserves an
-    /// *ignored* disposition across `exec`. swift-corelibs-foundation does
-    /// not reset child dispositions (macOS's Foundation happens to, which
-    /// hides this locally), so a child spawned while SIGPIPE is ignored
-    /// inherits that and no longer dies on a broken pipe. Holding this lock
-    /// across both the spawn and the window makes that overlap impossible.
-    private static let spawnLock = NSLock()
-
-    /// Runs `body` with SIGPIPE ignored, then restores the previous
-    /// disposition.
-    ///
-    /// Writing to a subprocess pipe whose read end is already closed raises
-    /// SIGPIPE, whose default disposition terminates the process. A helper
-    /// that dies that way in the middle of a destructive maintenance command
-    /// leaves no run record and no diagnosis.
-    ///
-    /// The signal is raised synchronously on the writing thread, so the
-    /// window only has to cover this call. It is deliberately not left
-    /// installed process-wide: see ``spawnLock``, and
-    /// `childrenKeepTheDefaultSIGPIPEDisposition`, which fails on Linux
-    /// against a permanent `signal(SIGPIPE, SIG_IGN)`.
     private static func withSIGPIPEIgnored<T>(_ body: () -> T) -> T {
-        spawnLock.lock()
-        let previous = signal(SIGPIPE, SIG_IGN)
-        defer {
-            // C function pointers are not Equatable; compare the raw bit
-            // patterns so a failed `signal` is never restored as a handler.
-            if unsafeBitCast(previous, to: UInt.self) != unsafeBitCast(SIG_ERR, to: UInt.self) {
-                signal(SIGPIPE, previous)
-            }
-            spawnLock.unlock()
-        }
-        return body()
+        SIGPIPEGuard.withIgnored(body)
     }
 
-    /// Spawns under ``spawnLock``. Synchronous on purpose: `NSLock` is
-    /// unavailable from an async context, and the critical section must not
-    /// suspend anyway.
     private static func launch(_ process: Process) throws {
-        spawnLock.lock()
-        defer { spawnLock.unlock() }
-        try process.run()
+        try SIGPIPEGuard.launch(process)
     }
 
     public func run(
@@ -400,5 +362,46 @@ private actor TimeoutFlag {
 
     func trigger() {
         triggered = true
+    }
+}
+
+/// The process-wide SIGPIPE disposition, and the lock that keeps it from
+/// leaking into a child.
+///
+/// SIGPIPE has to be handled process-wide rather than with a
+/// `pthread_sigmask`: Foundation does not always raise it on the thread that
+/// called `write`. But POSIX preserves an *ignored* disposition across
+/// `exec`, and swift-corelibs-foundation does not reset child dispositions
+/// (macOS's Foundation happens to, which hides this locally) — so a child
+/// spawned while SIGPIPE is ignored inherits that and no longer dies on a
+/// broken pipe. Every spawn and every ignore-window therefore take this one
+/// lock, making the overlap impossible.
+///
+/// Pinned by `childrenKeepTheDefaultSIGPIPEDisposition`, which fails on Linux
+/// against a permanently installed `signal(SIGPIPE, SIG_IGN)`.
+enum SIGPIPEGuard {
+    private static let lock = NSLock()
+
+    static func withIgnored<T>(_ body: () -> T) -> T {
+        lock.lock()
+        let previous = signal(SIGPIPE, SIG_IGN)
+        defer {
+            // C function pointers are not Equatable; compare the raw bit
+            // patterns so a failed `signal` is never restored as a handler.
+            if unsafeBitCast(previous, to: UInt.self) != unsafeBitCast(SIG_ERR, to: UInt.self) {
+                signal(SIGPIPE, previous)
+            }
+            lock.unlock()
+        }
+        return body()
+    }
+
+    /// Spawns under the same lock, so the disposition is always the default
+    /// at `posix_spawn` time. Synchronous on purpose: `NSLock` is unavailable
+    /// from an async context, and the critical section must not suspend.
+    static func launch(_ process: Process) throws {
+        lock.lock()
+        defer { lock.unlock() }
+        try process.run()
     }
 }

--- a/Core/Sources/ResticStationCore/Support/SHA256Digest.swift
+++ b/Core/Sources/ResticStationCore/Support/SHA256Digest.swift
@@ -1,15 +1,36 @@
 import Foundation
 
-/// Minimal dependency-free SHA-256 for fingerprints that must be identical
-/// on macOS and the `swift:6.1` Linux container. The token store needs a
-/// collision-resistant config binding, but Core deliberately has no
-/// swift-crypto package dependency.
+#if canImport(CryptoKit)
+import CryptoKit
+#endif
+
+/// SHA-256 for fingerprints that must be identical on macOS and the
+/// `swift:6.1` Linux container. The token store needs a collision-resistant
+/// binding, but Core deliberately has no swift-crypto package dependency —
+/// hence the portable implementation below.
+///
+/// On Darwin it defers to CryptoKit, which is a system framework (no new
+/// dependency) and hardware-accelerated. That matters because these digests
+/// cover whole files: hashing the 28 MB restic binary for a maintenance
+/// binding costs ~0.2s through the Swift implementation in a release build
+/// and **~10s in a debug build**, which made one engine test take 40s. Both
+/// paths are pinned to the same published vectors by `sha256Vectors`.
 enum SHA256Digest {
     static func hex(_ data: Data) -> String {
         digest(data).map { String(format: "%02x", $0) }.joined()
     }
 
     static func digest(_ data: Data) -> [UInt8] {
+        #if canImport(CryptoKit)
+        return Array(CryptoKit.SHA256.hash(data: data))
+        #else
+        return portableDigest(data)
+        #endif
+    }
+
+    /// Exposed unconditionally so the vectors exercise it on every platform,
+    /// not only the one that lacks CryptoKit.
+    static func portableDigest(_ data: Data) -> [UInt8] {
         var message = Array(data)
         let bitLength = UInt64(message.count) &* 8
         message.append(0x80)

--- a/Core/Sources/ResticStationCore/Support/StandardStream.swift
+++ b/Core/Sources/ResticStationCore/Support/StandardStream.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
+
+/// Writing to stdout/stderr when the reader has gone away.
+///
+/// When the app spawns the helper, the helper's stdout and stderr are pipes
+/// back to the app. If the app crashes or is force-quit mid-operation, the
+/// next write raises SIGPIPE, whose default disposition kills the helper —
+/// and `FileHandle.write(_:)` additionally raises an uncatchable ObjC
+/// exception rather than throwing. A helper that dies at, say, the warning it
+/// emits when `RunStore.finish` fails takes the run record with it: the one
+/// artifact that would have explained what happened.
+///
+/// The guard is the same one `DefaultProcessRunner` uses for child stdin, and
+/// for the same reason it must not be left installed process-wide: POSIX
+/// preserves an *ignored* disposition across `exec`, and
+/// swift-corelibs-foundation does not reset child dispositions, so a restic
+/// child spawned inside the window would stop dying on a broken pipe. Sharing
+/// `SIGPIPEGuard` means these writes and every spawn take one lock, so the
+/// window can never overlap a `posix_spawn`.
+public enum StandardStream {
+    public static func write(_ text: String, to handle: FileHandle) {
+        write(Data(text.utf8), to: handle)
+    }
+
+    /// Best-effort by design: if the reader is gone there is nowhere left to
+    /// report that fact, and the caller's real work must continue.
+    public static func write(_ data: Data, to handle: FileHandle) {
+        SIGPIPEGuard.withIgnored {
+            try? handle.write(contentsOf: data)
+        }
+    }
+
+    /// Spelled out for call sites whose argument spans several lines, where
+    /// a trailing `to:` label reads worse than the destination in the name.
+    public static func writeToStandardError(_ data: Data) {
+        write(data, to: .standardError)
+    }
+
+    public static func writeToStandardOutput(_ data: Data) {
+        write(data, to: .standardOutput)
+    }
+}

--- a/Core/Sources/ResticStationCore/Support/StandardStream.swift
+++ b/Core/Sources/ResticStationCore/Support/StandardStream.swift
@@ -14,17 +14,15 @@ import Musl
 /// back to the app. If the app crashes or is force-quit mid-operation, the
 /// next write raises SIGPIPE, whose default disposition kills the helper —
 /// and `FileHandle.write(_:)` additionally raises an uncatchable ObjC
-/// exception rather than throwing. A helper that dies at, say, the warning it
-/// emits when `RunStore.finish` fails takes the run record with it: the one
-/// artifact that would have explained what happened.
+/// exception rather than throwing. A death at, say, the warning emitted when
+/// `RunStore.finish` fails takes the run record with it: the one artifact
+/// that would have explained what happened.
 ///
-/// The guard is the same one `DefaultProcessRunner` uses for child stdin, and
-/// for the same reason it must not be left installed process-wide: POSIX
-/// preserves an *ignored* disposition across `exec`, and
-/// swift-corelibs-foundation does not reset child dispositions, so a restic
-/// child spawned inside the window would stop dying on a broken pipe. Sharing
-/// `SIGPIPEGuard` means these writes and every spawn take one lock, so the
-/// window can never overlap a `posix_spawn`.
+/// Protection comes from `SIGPIPEGuard`'s permanently installed no-op
+/// handler, which covers the whole process on both platforms and costs
+/// nothing here: no lock, no per-call state, and nothing a logging call can
+/// do to perturb subprocess creation. The throwing `write(contentsOf:)` then
+/// surfaces `EPIPE` as an ordinary error instead of an exception.
 public enum StandardStream {
     public static func write(_ text: String, to handle: FileHandle) {
         write(Data(text.utf8), to: handle)
@@ -33,9 +31,8 @@ public enum StandardStream {
     /// Best-effort by design: if the reader is gone there is nowhere left to
     /// report that fact, and the caller's real work must continue.
     public static func write(_ data: Data, to handle: FileHandle) {
-        SIGPIPEGuard.withIgnored {
-            try? handle.write(contentsOf: data)
-        }
+        SIGPIPEGuard.ensureInstalled()
+        try? handle.write(contentsOf: data)
     }
 
     /// Spelled out for call sites whose argument spans several lines, where

--- a/Core/Tests/ResticStationCoreTests/Engine/BackupEngineTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Engine/BackupEngineTests.swift
@@ -1810,6 +1810,171 @@ struct BackupEngineTests {
         #expect(!env.resticArgvs.contains { $0.contains("rewrite") })
     }
 
+    // MARK: - #109 exact-head review: no unbound destructive capability
+
+    /// The token issuer used to accept a missing executable and fold it to
+    /// the literal `"none"`. A token minted that way bound no binary at all,
+    /// and an apply that also saw no restic recomputed the same `"none"`
+    /// fingerprint and matched — so a replacement appearing in between could
+    /// run `rewrite --forget` unpinned.
+    @Test("purge preview mints no token at all when restic has vanished")
+    func purgeTokenRefusesWithoutAnExecutable() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("restic-station-purge-noexec-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let fakeRestic = root.appendingPathComponent("restic", isDirectory: false)
+        try Data("original restic".utf8).write(to: fakeRestic)
+
+        let sourcePaths = [Self.setId: Set(["/Users/user/example/src"])]
+        let hostnames = [Self.setId: Set(["example-mac.local"])]
+        let env = Self.makeEnv(
+            script: [], retention: nil, purgeExcludes: ["build/**"], reachableSecondaries: [],
+            purgeSourcePaths: sourcePaths, purgeHostnames: hostnames,
+            resticPath: fakeRestic.path
+        )
+        defer { env.cleanUp() }
+
+        let snapshots = try parseSnapshots(Data(try FixtureLoader.string("snapshots.json").utf8))
+        let plan = PurgePlan(
+            destinationId: env.primary.id, snapshots: snapshots,
+            sourcePaths: sourcePaths[Self.setId]!, hostnames: hostnames[Self.setId]!,
+            patterns: env.set.purgeExcludes
+        )
+
+        // The preview queries have completed; restic disappears before the
+        // capability is minted. That is the window the finding describes.
+        try FileManager.default.removeItem(at: fakeRestic)
+
+        #expect(throws: PurgeApplyError.resticUnavailable) {
+            _ = try env.engine.issuePurgeToken(
+                set: env.set, destinations: [env.primary], plans: [plan]
+            )
+        }
+    }
+
+    /// The other half: even a token minted while restic existed must not be
+    /// honoured once it cannot be identified at apply time. Without this the
+    /// nil-bound fingerprint compared equal and `purgeChild` was launched
+    /// with no `expectedExecutableIdentity`.
+    @Test("purge apply refuses a token when restic cannot be identified")
+    func purgeApplyRefusesWithoutAnExecutable() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("restic-station-purge-noexec2-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let fakeRestic = root.appendingPathComponent("restic", isDirectory: false)
+        try Data("original restic".utf8).write(to: fakeRestic)
+
+        let sourcePaths = [Self.setId: Set(["/Users/user/example/src"])]
+        let hostnames = [Self.setId: Set(["example-mac.local"])]
+        let env = Self.makeEnv(
+            script: [], retention: nil, purgeExcludes: ["build/**"], reachableSecondaries: [],
+            purgeSourcePaths: sourcePaths, purgeHostnames: hostnames,
+            resticPath: fakeRestic.path
+        )
+        defer { env.cleanUp() }
+
+        let snapshots = try parseSnapshots(Data(try FixtureLoader.string("snapshots.json").utf8))
+        let plan = PurgePlan(
+            destinationId: env.primary.id, snapshots: snapshots,
+            sourcePaths: sourcePaths[Self.setId]!, hostnames: hostnames[Self.setId]!,
+            patterns: env.set.purgeExcludes
+        )
+        let token = try #require(try env.engine.issuePurgeToken(
+            set: env.set, destinations: [env.primary], plans: [plan]
+        ))
+
+        try FileManager.default.removeItem(at: fakeRestic)
+
+        await #expect(throws: PurgeApplyError.resticUnavailable) {
+            _ = try await env.engine.runPurge(
+                set: env.set, destinations: [env.primary], token: token.value
+            )
+        }
+        // The decisive assertion, as elsewhere in this suite: nothing
+        // destructive was ever spawned.
+        #expect(!env.resticArgvs.contains { $0.contains("rewrite") })
+    }
+
+    /// The pin added in `9d47b55` reads the executable identity through a
+    /// metadata-keyed cache. An updater that overwrites restic in place,
+    /// writes the same number of bytes and restores the original mtime
+    /// leaves device, inode, size and mtime untouched — so the cache key is
+    /// unchanged, the launch check compares the *previous* digest to itself,
+    /// and the replacement binary receives `rewrite --forget`.
+    ///
+    /// The mtime is pinned to a fixed whole-second value on **both** writes
+    /// rather than captured and restored. A captured mtime does not
+    /// round-trip: `setAttributes` loses sub-microsecond precision, so the
+    /// key changes, the cache misses, and the test passes without ever
+    /// exercising the path it is about. It did exactly that on first
+    /// writing.
+    @Test("a same-size, same-mtime in-place swap still fails the destructive launch check")
+    func purgeRefusesACacheDefeatingSwap() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("restic-station-purge-swap-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let fakeRestic = root.appendingPathComponent("restic", isDirectory: false)
+        let pinnedMtime = Date(timeIntervalSince1970: 1_700_000_000)
+        try Data("original restic!".utf8).write(to: fakeRestic)
+        try FileManager.default.setAttributes(
+            [.modificationDate: pinnedMtime], ofItemAtPath: fakeRestic.path
+        )
+
+        let sourcePaths = [Self.setId: Set(["/Users/user/example/src"])]
+        let hostnames = [Self.setId: Set(["example-mac.local"])]
+        let swapPath = fakeRestic.path
+        let env = Self.makeEnv(
+            script: [], retention: nil, purgeExcludes: ["build/**"], reachableSecondaries: [],
+            onSpawn: { argv in
+                guard argv.contains("snapshots") else { return }
+                // Same inode, same 16-byte length, same pinned mtime: every
+                // field of the cache key is identical to the entry the
+                // preview populated, so a cached lookup returns the *old*
+                // digest for genuinely different bytes.
+                let handle = FileHandle(forWritingAtPath: swapPath)
+                try? handle?.write(contentsOf: Data("a totally other!".utf8))
+                try? handle?.close()
+                try? FileManager.default.setAttributes(
+                    [.modificationDate: pinnedMtime], ofItemAtPath: swapPath
+                )
+            },
+            purgeSourcePaths: sourcePaths, purgeHostnames: hostnames,
+            resticPath: fakeRestic.path
+        )
+        defer { env.cleanUp() }
+
+        let snapshotsJSON = try FixtureLoader.string("snapshots.json")
+        let snapshots = try parseSnapshots(Data(snapshotsJSON.utf8))
+        let plan = PurgePlan(
+            destinationId: env.primary.id, snapshots: snapshots,
+            sourcePaths: sourcePaths[Self.setId]!, hostnames: hostnames[Self.setId]!,
+            patterns: env.set.purgeExcludes
+        )
+        let token = try #require(try env.engine.issuePurgeToken(
+            set: env.set, destinations: [env.primary], plans: [plan]
+        ))
+
+        env.fake.script = [
+            .init(
+                argvPrefix: [fakeRestic.path, "-r", env.primary.repoURL, "snapshots", "--json"],
+                stdoutLines: [snapshotsJSON]
+            ),
+        ]
+
+        let result = try await env.engine.runPurge(
+            set: env.set, destinations: [env.primary], token: token.value
+        )
+
+        #expect(result.status == .failed)
+        #expect(
+            !env.resticArgvs.contains { $0.contains("rewrite") },
+            "a cache-defeating in-place swap must not reach the destructive command"
+        )
+    }
+
     @Test("runPurge: a valid token revalidates ids, records rewrite mapping, and is single-use")
     func purgeApplyUsesTokenAndRecordsMapping() async throws {
         let sourcePaths = [Self.setId: Set(["/Users/user/example/src"])]

--- a/Core/Tests/ResticStationCoreTests/Engine/BackupEngineTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Engine/BackupEngineTests.swift
@@ -141,7 +141,11 @@ struct BackupEngineTests {
         onSpawn: (@Sendable ([String]) -> Void)? = nil,
         purgeSourcePaths: [UUID: Set<String>] = [:],
         purgeHostnames: [UUID: Set<String>] = [:],
-        machineId: String = "example-machine"
+        machineId: String = "example-machine",
+        /// Overridable so a test can point the engine at a binary it is
+        /// allowed to modify, and assert what happens when restic is
+        /// replaced mid-operation.
+        resticPath: String = BackupEngineTests.resticPath
     ) -> Env {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("restic-station-engine-\(UUID().uuidString)", isDirectory: true)
@@ -1742,6 +1746,70 @@ struct BackupEngineTests {
     /// tests deliberately build it from the captured snapshots fixture so
     /// the only ids a `rewrite --forget` can ever receive are the pure
     /// attribution result, never a caller-supplied filter.
+    /// The purge token binds the restic executable's identity, but binding is
+    /// only meaningful if the validated executable is the one that actually
+    /// receives `rewrite --forget`. It was not: the destructive child was
+    /// launched with an unpinned invocation, so a binary swapped after
+    /// validation — the window includes `currentPurgePlan`'s repository
+    /// queries, which are slow — would have run under an already-consumed
+    /// token.
+    @Test("runPurge: a restic replaced after validation never receives the rewrite")
+    func purgeApplyRefusesASwappedExecutable() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("restic-station-swap-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let fakeRestic = root.appendingPathComponent("restic", isDirectory: false)
+        try Data("original restic".utf8).write(to: fakeRestic)
+
+        let sourcePaths = [Self.setId: Set(["/Users/user/example/src"])]
+        let hostnames = [Self.setId: Set(["example-mac.local"])]
+        // Swap the binary from inside the `snapshots` spawn — i.e. *after*
+        // the token fingerprint has been revalidated (an earlier swap is
+        // already refused as `tokenDoesNotMatchCurrentPlan`) and while
+        // `currentPurgePlan` is querying the repository. Only a recheck at
+        // launch can catch this one.
+        let swapPath = fakeRestic.path
+        let env = Self.makeEnv(
+            script: [], retention: nil, purgeExcludes: ["build/**"], reachableSecondaries: [],
+            onSpawn: { argv in
+                guard argv.contains("snapshots") else { return }
+                try? Data("a different restic entirely".utf8)
+                    .write(to: URL(fileURLWithPath: swapPath))
+            },
+            purgeSourcePaths: sourcePaths, purgeHostnames: hostnames,
+            resticPath: fakeRestic.path
+        )
+        defer { env.cleanUp() }
+
+        let snapshotsJSON = try FixtureLoader.string("snapshots.json")
+        let snapshots = try parseSnapshots(Data(snapshotsJSON.utf8))
+        let plan = PurgePlan(
+            destinationId: env.primary.id, snapshots: snapshots,
+            sourcePaths: sourcePaths[Self.setId]!, hostnames: hostnames[Self.setId]!,
+            patterns: env.set.purgeExcludes
+        )
+        let token = try #require(try env.engine.issuePurgeToken(
+            set: env.set, destinations: [env.primary], plans: [plan]
+        ))
+
+        // Built against the injected path, not the shared `resticPath` helper.
+        env.fake.script = [
+            .init(
+                argvPrefix: [fakeRestic.path, "-r", env.primary.repoURL, "snapshots", "--json"],
+                stdoutLines: [snapshotsJSON]
+            ),
+        ]
+
+        let result = try await env.engine.runPurge(
+            set: env.set, destinations: [env.primary], token: token.value
+        )
+
+        #expect(result.status == .failed)
+        // The decisive assertion: no rewrite argv was ever produced.
+        #expect(!env.resticArgvs.contains { $0.contains("rewrite") })
+    }
+
     @Test("runPurge: a valid token revalidates ids, records rewrite mapping, and is single-use")
     func purgeApplyUsesTokenAndRecordsMapping() async throws {
         let sourcePaths = [Self.setId: Set(["/Users/user/example/src"])]

--- a/Core/Tests/ResticStationCoreTests/Engine/BackupEngineTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Engine/BackupEngineTests.swift
@@ -72,7 +72,29 @@ struct BackupEngineTests {
 
     // MARK: Fixed identifiers / clock
 
-    static let resticPath = "/opt/homebrew/bin/restic"
+    /// A **real file**, not merely a plausible path.
+    ///
+    /// `maintenanceExecutable()` hashes the bytes at this path, and since the
+    /// #109 exact-head fix a purge refuses to mint or honour a destructive
+    /// capability when it cannot identify a binary. A fixture path that only
+    /// looks like restic therefore passes on a dev Mac that happens to have
+    /// it installed at `/opt/homebrew/bin/restic` and fails in the Linux CI
+    /// container, which does not — the tests were silently depending on
+    /// ambient host state, and tolerating a nil identity is what hid it.
+    ///
+    /// Used for `argv[0]` as well, so the golden argv assertions keep
+    /// comparing the configured path against itself on both platforms.
+    static let resticPath: String = {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("restic-station-fixture-restic", isDirectory: false)
+        if !FileManager.default.fileExists(atPath: url.path) {
+            FileManager.default.createFile(
+                atPath: url.path,
+                contents: Data("restic fixture binary".utf8)
+            )
+        }
+        return url.path
+    }()
     static let setId = UUID(uuidString: "6F9619FF-8B86-D011-B42D-00C04FC964FF")!
     static let primaryId = UUID(uuidString: "0A1B2C3D-8B86-D011-B42D-00C04FC964FF")!
     static let secondaryAId = UUID(uuidString: "1B2C3D4E-8B86-D011-B42D-00C04FC964FF")!

--- a/Core/Tests/ResticStationCoreTests/Engine/StateStoreTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Engine/StateStoreTests.swift
@@ -424,4 +424,38 @@ struct StateStoreTests {
         formatter.formatOptions = [.withInternetDateTime]
         return formatter.date(from: iso)!
     }
+
+    /// `schedule-state.json` is one document shared by every set, while the
+    /// only other lock is per-set — so two helper processes working on
+    /// *different* sets take no common lock and each rewrite the whole file.
+    /// Without the companion lock, one reads before the other's write and
+    /// writes after it, silently discarding the other's entry. That entry now
+    /// carries `appliedPurgeExcludes`, i.e. destructive bookkeeping.
+    ///
+    /// Interleaved deliberately: each mutation sleeps inside the critical
+    /// section, so a read-modify-write that is not held under a lock will
+    /// overlap and lose an entry essentially every run.
+    @Test("concurrent updates for different sets do not lose one another")
+    func concurrentScheduleStateUpdatesDoNotLoseEntries() async throws {
+        let (store, root) = makeStore()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let setIds = (0..<8).map { _ in UUID() }
+        await withTaskGroup(of: Void.self) { group in
+            for (index, setId) in setIds.enumerated() {
+                group.addTask {
+                    try? store.updateScheduleState(setId: setId) { entry in
+                        // Widen the window between read and write.
+                        usleep(20_000)
+                        entry.checkSliceCursor = index
+                    }
+                }
+            }
+        }
+
+        let state = try #require(store.readScheduleState())
+        for (index, setId) in setIds.enumerated() {
+            #expect(state.sets[setId]?.checkSliceCursor == index, "lost the entry for set \(index)")
+        }
+    }
 }

--- a/Core/Tests/ResticStationCoreTests/Engine/StateStoreTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Engine/StateStoreTests.swift
@@ -441,21 +441,28 @@ struct StateStoreTests {
         defer { try? FileManager.default.removeItem(at: root) }
 
         let setIds = (0..<8).map { _ in UUID() }
-        // Real threads, not a `TaskGroup`. `updateScheduleState` blocks —
-        // it sleeps between lock attempts — and the writers sleep inside the
-        // critical section on purpose to widen the read/write window. Doing
-        // that on Swift Concurrency's cooperative pool starves it: on a
-        // two-core CI runner the lock holder cannot be scheduled to release
-        // while every thread sits in `usleep`, so waiters spin to the 5s
-        // timeout and every other async test in the suite stalls behind them.
-        // That is exactly what happened — the whole 674-test run took 60s and
-        // unrelated parsing tests reported 50s wall time.
-        DispatchQueue.concurrentPerform(iterations: setIds.count) { index in
-            try? store.updateScheduleState(setId: setIds[index]) { entry in
-                usleep(20_000)
-                entry.checkSliceCursor = index
+        // Dedicated threads, deliberately not a `TaskGroup` and not the
+        // global concurrent queue.
+        //
+        // `updateScheduleState` blocks — it sleeps between lock attempts —
+        // and the writers sleep inside the critical section on purpose to
+        // widen the read/write window. Blocking Swift Concurrency's
+        // cooperative pool starves it, so the lock holder cannot be scheduled
+        // to release and waiters spin to the timeout. Blocking the global
+        // dispatch pool is nearly as rude: it is shared with Foundation's own
+        // machinery, including `Process`, and this suite spawns subprocesses
+        // concurrently. Owning the threads keeps the pressure local to this
+        // test.
+        let threads = setIds.enumerated().map { index, setId in
+            Thread {
+                try? store.updateScheduleState(setId: setId) { entry in
+                    usleep(20_000)
+                    entry.checkSliceCursor = index
+                }
             }
         }
+        threads.forEach { $0.start() }
+        while threads.contains(where: { !$0.isFinished }) { usleep(2_000) }
 
         let state = try #require(store.readScheduleState())
         for (index, setId) in setIds.enumerated() {

--- a/Core/Tests/ResticStationCoreTests/Engine/StateStoreTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Engine/StateStoreTests.swift
@@ -436,20 +436,24 @@ struct StateStoreTests {
     /// section, so a read-modify-write that is not held under a lock will
     /// overlap and lose an entry essentially every run.
     @Test("concurrent updates for different sets do not lose one another")
-    func concurrentScheduleStateUpdatesDoNotLoseEntries() async throws {
+    func concurrentScheduleStateUpdatesDoNotLoseEntries() throws {
         let (store, root) = makeStore()
         defer { try? FileManager.default.removeItem(at: root) }
 
         let setIds = (0..<8).map { _ in UUID() }
-        await withTaskGroup(of: Void.self) { group in
-            for (index, setId) in setIds.enumerated() {
-                group.addTask {
-                    try? store.updateScheduleState(setId: setId) { entry in
-                        // Widen the window between read and write.
-                        usleep(20_000)
-                        entry.checkSliceCursor = index
-                    }
-                }
+        // Real threads, not a `TaskGroup`. `updateScheduleState` blocks —
+        // it sleeps between lock attempts — and the writers sleep inside the
+        // critical section on purpose to widen the read/write window. Doing
+        // that on Swift Concurrency's cooperative pool starves it: on a
+        // two-core CI runner the lock holder cannot be scheduled to release
+        // while every thread sits in `usleep`, so waiters spin to the 5s
+        // timeout and every other async test in the suite stalls behind them.
+        // That is exactly what happened — the whole 674-test run took 60s and
+        // unrelated parsing tests reported 50s wall time.
+        DispatchQueue.concurrentPerform(iterations: setIds.count) { index in
+            try? store.updateScheduleState(setId: setIds[index]) { entry in
+                usleep(20_000)
+                entry.checkSliceCursor = index
             }
         }
 

--- a/Core/Tests/ResticStationCoreTests/Restic/RemoteResticCommandTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Restic/RemoteResticCommandTests.swift
@@ -52,6 +52,10 @@ import Testing
             #expect(argv.contains("ServerAliveCountMax=3"))
             #expect(argv.contains("BatchMode=yes"))
             #expect(argv.contains("ConnectTimeout=15"))
+            // Never `accept-new`: this channel carries the repository
+            // password, so trust-on-first-use hands it to whoever answers.
+            #expect(argv.contains("StrictHostKeyChecking=yes"))
+            #expect(!argv.contains("StrictHostKeyChecking=accept-new"))
         }
     }
 }

--- a/Core/Tests/ResticStationCoreTests/Restic/ResticRunnerTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Restic/ResticRunnerTests.swift
@@ -773,3 +773,69 @@ private final class MessageBox: @unchecked Sendable {
         _raw.append(line)
     }
 }
+
+// MARK: - #109: the identity cache must never be trusted to enforce a pin
+
+@Suite("ExecutableIdentityCache")
+struct ExecutableIdentityCacheTests {
+    /// A whole-second mtime, set explicitly on **both** writes. A captured
+    /// mtime does not round-trip through `setAttributes` — it loses
+    /// sub-microsecond precision — which changes the cache key and makes a
+    /// test of this hazard pass without reaching it.
+    private static let pinnedMtime = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private func write(_ contents: String, to url: URL) throws {
+        try Data(contents.utf8).write(to: url)
+        try FileManager.default.setAttributes(
+            [.modificationDate: Self.pinnedMtime], ofItemAtPath: url.path
+        )
+    }
+
+    private func cacheKeyFields(_ path: String) throws -> String {
+        let a = try FileManager.default.attributesOfItem(atPath: path)
+        let size = (a[.size] as? NSNumber)?.uint64Value ?? 0
+        let inode = (a[.systemFileNumber] as? NSNumber)?.uint64Value ?? 0
+        let device = (a[.systemNumber] as? NSNumber)?.uint64Value ?? 0
+        let mtime = (a[.modificationDate] as? Date)?.timeIntervalSince1970 ?? 0
+        return "\(device)|\(inode)|\(size)|\(mtime)"
+    }
+
+    @Test("an in-place swap that preserves every key field returns a stale digest unless bypassed")
+    func bypassRehashesWhereTheKeyCannotSeeTheChange() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("restic-station-idcache-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let binary = root.appendingPathComponent("restic", isDirectory: false)
+
+        try write("original restic!", to: binary)
+        let keyBefore = try cacheKeyFields(binary.path)
+
+        let cache = ExecutableIdentityCache()
+        let first = try #require(cache.identity(for: binary))
+
+        // Same inode, same 16-byte length, same pinned mtime.
+        let handle = try #require(FileHandle(forWritingAtPath: binary.path))
+        try handle.write(contentsOf: Data("a totally other!".utf8))
+        try handle.close()
+        try FileManager.default.setAttributes(
+            [.modificationDate: Self.pinnedMtime], ofItemAtPath: binary.path
+        )
+
+        // The precondition this test is *about*. If a platform cannot
+        // reproduce an identical key, say so instead of reporting a pass
+        // that proved nothing.
+        try #require(
+            cacheKeyFields(binary.path) == keyBefore,
+            "could not reproduce an identical cache key on this platform — the hazard was not exercised"
+        )
+
+        // The hazard, stated as an assertion: the cached read cannot see it.
+        #expect(
+            cache.identity(for: binary)?.identity == first.identity,
+            "the metadata key is unchanged, so a cached read necessarily returns the old digest"
+        )
+        // The fix: revalidation hashes the bytes and sees the new binary.
+        #expect(cache.identity(for: binary, bypassingCache: true)?.identity != first.identity)
+    }
+}

--- a/Core/Tests/ResticStationCoreTests/Support/DefaultProcessRunnerTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Support/DefaultProcessRunnerTests.swift
@@ -210,4 +210,27 @@ private final class LineCollector: @unchecked Sendable {
         defer { lock.unlock() }
         _lines.append(line)
     }
+
+    /// When the app spawns the helper, the helper's stdout/stderr are pipes
+    /// back to the app. If the app dies mid-operation, the next write raises
+    /// SIGPIPE — and the default disposition kills the helper, taking with it
+    /// the run record that would have explained what happened.
+    ///
+    /// Exercised through a real subprocess so the assertion is about actual
+    /// signal delivery, not about which function was called: the child writes
+    /// to a pipe whose read end is already closed, and must survive to report
+    /// its own exit status.
+    @Test("StandardStream survives a reader that has gone away")
+    func standardStreamSurvivesAClosedReader() throws {
+        let pipe = Pipe()
+        let writer = pipe.fileHandleForWriting
+        try pipe.fileHandleForReading.close()
+
+        // Would raise SIGPIPE and kill this test binary without the guard.
+        StandardStream.write("this reader is gone\n", to: writer)
+        StandardStream.writeToStandardError(Data())
+
+        #expect(Bool(true), "reached the next statement, i.e. was not killed by SIGPIPE")
+        try? writer.close()
+    }
 }

--- a/Core/Tests/ResticStationCoreTests/Support/PreviewTokenTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Support/PreviewTokenTests.swift
@@ -65,7 +65,8 @@ struct PreviewTokenStoreTests {
             setId: setId,
             destinations: [PreviewTokenDestination(destinationId: destinationId, snapshotIDs: ["b", "a"])],
             config: config,
-            patterns: ["DerivedData"]
+            patterns: ["DerivedData"],
+            executableIdentity: "restic-under-test"
         )
 
         #expect(token.value.count >= 43, "a URL-safe encoding of 256 random bits")
@@ -126,6 +127,7 @@ struct PreviewTokenStoreTests {
             destinations: [PreviewTokenDestination(destinationId: destinationId, snapshotIDs: [])],
             config: config,
             patterns: ["DerivedData"],
+            executableIdentity: "restic-under-test",
             lifetime: 1
         )
         clock.advance(1)

--- a/Core/Tests/ResticStationCoreTests/Support/PreviewTokenTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Support/PreviewTokenTests.swift
@@ -145,4 +145,55 @@ struct PreviewTokenStoreTests {
         clock.advance(1)
         #expect(throws: PreviewTokenError.expired) { try store.token(expiring.value) }
     }
+
+    /// The app previews Apply Retention and the helper executes it in two
+    /// different processes; they must derive byte-identical fingerprints from
+    /// the same state, and must diverge whenever anything the helper resolves
+    /// from has changed.
+    @Test("the effective-set binding matches across processes and moves with every input")
+    func effectiveSetBindingIsStableAndComplete() {
+        let destination = Destination(id: UUID(), label: "Primary", repoURL: "/repo", isPrimary: true)
+        let set = BackupSet(
+            id: UUID(), name: "Docs", sources: ["/Users/example/Docs"],
+            schedule: .daily(hour: 2, minute: 0),
+            retention: RetentionPolicy(keepLast: 3),
+            destinations: [destination]
+        )
+        func fingerprint(
+            machineId: String = "example-mac",
+            set: BackupSet = set,
+            config: String = "config-a",
+            machine: String = "machine-a",
+            identity: String? = "restic-a"
+        ) -> String {
+            MaintenanceBinding.effectiveSetFingerprint(
+                machineId: machineId, set: set,
+                configFingerprint: config, machineFingerprint: machine,
+                resticExecutableIdentity: identity
+            )
+        }
+
+        // Same inputs, independently computed — the cross-process contract.
+        #expect(fingerprint() == fingerprint())
+
+        // Every input must move it. `machineFingerprint` is the one the
+        // shared-config-only binding missed: machine.json decides which
+        // overrides apply and which destinations are enabled here.
+        #expect(fingerprint() != fingerprint(machineId: "other-mac"))
+        #expect(fingerprint() != fingerprint(config: "config-b"))
+        #expect(fingerprint() != fingerprint(machine: "machine-b"))
+        #expect(fingerprint() != fingerprint(identity: "restic-b"))
+
+        // A dropped destination — exactly what scheduling-scope resolution
+        // does to a destination disabled on this machine — must not compare
+        // equal to the set that still has it.
+        var withoutDestination = set
+        withoutDestination.destinations = []
+        #expect(fingerprint() != fingerprint(set: withoutDestination))
+
+        // And a changed retention policy, since that is what gets applied.
+        var otherPolicy = set
+        otherPolicy.retention = RetentionPolicy(keepLast: 9)
+        #expect(fingerprint() != fingerprint(set: otherPolicy))
+    }
 }

--- a/Core/Tests/ResticStationCoreTests/Support/PreviewTokenTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Support/PreviewTokenTests.swift
@@ -25,6 +25,18 @@ struct PreviewTokenStoreTests {
         }
     }
 
+    /// Both implementations, on every platform. `digest` uses CryptoKit where
+    /// it exists, so without this the portable path would go unexercised on
+    /// macOS — and it is the one that runs in the Linux container.
+    @Test("both SHA-256 implementations agree, and match published vectors")
+    func portableAndPlatformDigestsAgree() {
+        for sample in [Data(), Data("abc".utf8),
+                       Data(repeating: 0x61, count: 55), Data(repeating: 0x61, count: 56),
+                       Data(repeating: 0x61, count: 64), Data(repeating: 0x61, count: 1000)] {
+            #expect(SHA256Digest.digest(sample) == SHA256Digest.portableDigest(sample))
+        }
+    }
+
     @Test("SHA-256 config fingerprint primitive matches published vectors")
     func sha256Vectors() {
         #expect(SHA256Digest.hex(Data()) == "e3b0c44298fc1c149afbf4c8996fb924"

--- a/Helper/Sources/CLIJSON.swift
+++ b/Helper/Sources/CLIJSON.swift
@@ -30,8 +30,8 @@ enum CLIJSON {
     static func print<T: Encodable>(_ value: T) {
         do {
             let data = try ConfigStore.makeEncoder().encode(CLISuccessEnvelope(value))
-            FileHandle.standardOutput.write(data)
-            FileHandle.standardOutput.write(Data("\n".utf8))
+            StandardStream.write(data, to: .standardOutput)
+            StandardStream.write(Data("\n".utf8), to: .standardOutput)
         } catch {
             // Encoding one of these value types failing is a programmer
             // error (they are plain Codable structs of strings/numbers/

--- a/Helper/Sources/Commands/Cli.swift
+++ b/Helper/Sources/Commands/Cli.swift
@@ -180,7 +180,7 @@ enum CliPathWarning {
         guard !CLIInstaller.isDirectoryOnPath(directory, pathEnvironment: environment["PATH"]) else {
             return
         }
-        FileHandle.standardError.write(Data(
+        StandardStream.writeToStandardError(Data(
             ("warning: \(directory.path) is not on PATH — add it to your shell profile, e.g. "
                 + "`export PATH=\"\(directory.path):$PATH\"`, so restic-station is found.\n").utf8
         ))

--- a/Helper/Sources/Commands/Config.swift
+++ b/Helper/Sources/Commands/Config.swift
@@ -129,8 +129,8 @@ struct ConfigExport: AsyncParsableCommand {
             // No `--out`: stdout IS the export, so nothing else may share
             // it — matches the `--json` convention even though this isn't
             // spelled `--json` (the output *is* config.json's own bytes).
-            FileHandle.standardOutput.write(data)
-            FileHandle.standardOutput.write(Data("\n".utf8))
+            StandardStream.write(data, to: .standardOutput)
+            StandardStream.write(Data("\n".utf8), to: .standardOutput)
         }
         HelperExit.code(0)
     }

--- a/Helper/Sources/Commands/FdaCheck.swift
+++ b/Helper/Sources/Commands/FdaCheck.swift
@@ -118,7 +118,7 @@ struct FdaCheck: AsyncParsableCommand, JSONRenderable {
         do {
             try stateStore.writeFdaCheck(result)
         } catch {
-            FileHandle.standardError.write(Data("fda-check: could not write state: \(error)\n".utf8))
+            StandardStream.write(Data("fda-check: could not write state: \(error)\n".utf8), to: .standardError)
         }
         return result
         #else

--- a/Helper/Sources/Commands/ProbeRepo.swift
+++ b/Helper/Sources/Commands/ProbeRepo.swift
@@ -92,7 +92,7 @@ struct ProbeRepo: AsyncParsableCommand, JSONRenderable {
                 }
             }
         } catch {
-            FileHandle.standardError.write(Data("probe-repo: could not write repo-status: \(error)\n".utf8))
+            StandardStream.write(Data("probe-repo: could not write repo-status: \(error)\n".utf8), to: .standardError)
         }
 
         let outcome: Report.Outcome

--- a/Helper/Sources/Commands/RunSet.swift
+++ b/Helper/Sources/Commands/RunSet.swift
@@ -24,30 +24,24 @@ struct RunSet: AsyncParsableCommand {
     @Option(name: .long, help: "Which operation to run.")
     var kind: Kind = .backup
 
-    /// Refuse unless `config.json` is byte-identical to what the caller
+    /// Refuse unless the **effective set** still matches what the caller
     /// reviewed. The app sends this for **Apply retention now**, whose
     /// preview is app-direct and therefore has no helper-issued token the
-    /// way `maintenance prune` does. Without it, a config change landing
-    /// between the dialog and the click — a hand edit, or this fleet's
-    /// config sync — silently applied a policy the operator never saw to a
-    /// destination list they were never shown.
+    /// way `maintenance prune` does. Without it, a configuration change
+    /// landing between the dialog and the click — a hand edit, or this
+    /// fleet's config sync — silently applied a policy the operator never
+    /// saw to a destination list they were never shown.
+    ///
+    /// This binds the resolved set, machine identity, both configuration
+    /// files and the restic executable, not just `config.json`: the helper
+    /// resolves what it prunes from `machine.json` too, so hashing the
+    /// shared config alone left a real gap.
     @Option(name: .long, parsing: .unconditional,
-            help: "Refuse unless config.json still matches this fingerprint.")
+            help: "Refuse unless the effective backup set still matches this fingerprint.")
     var expectedConfig: String?
 
     func run() async throws {
         let context = try await HelperContext.make()
-        if let expectedConfig {
-            let current = ConfigStore(paths: context.paths).fileFingerprint()
-            guard current == expectedConfig else {
-                throw CLIFailure(
-                    code: .operationNotAllowed,
-                    message: "The configuration changed after this operation was reviewed. "
-                        + "Review the updated settings and try again.",
-                    details: CLIErrorDetails(setId: set)
-                )
-            }
-        }
         // `scheduled`: backup, check and prune are all things this machine
         // *does to* a set, so a set disabled here must not run — unlike the
         // repository utilities, which use `addressable`.
@@ -71,6 +65,29 @@ struct RunSet: AsyncParsableCommand {
             let status = await context.engine.runCheck(backupSet, trigger: .manual)
             handle(status, kind: .check, setId: backupSet.id, since: before, context: context)
         case .prune:
+            // Checked against the set the engine is about to receive, after
+            // the context has resolved it — not against a separately re-read
+            // file, which would leave the decoded value and the hashed value
+            // as two different snapshots.
+            if let expectedConfig {
+                let store = ConfigStore(paths: context.paths)
+                let snapshot = try? store.snapshot()
+                let current = MaintenanceBinding.effectiveSetFingerprint(
+                    machineId: context.scheduled.machineId,
+                    set: backupSet,
+                    configFingerprint: snapshot?.fingerprint ?? "unreadable",
+                    machineFingerprint: store.machineFileFingerprint(),
+                    resticExecutableIdentity: context.restic.maintenanceExecutable()?.identity
+                )
+                guard current == expectedConfig else {
+                    throw CLIFailure(
+                        code: .operationNotAllowed,
+                        message: "The configuration changed after this operation was reviewed. "
+                            + "Review the updated settings and try again.",
+                        details: CLIErrorDetails(setId: set)
+                    )
+                }
+            }
             let before = Date()
             let status = await context.engine.runPrune(backupSet)
             handle(status, kind: .prune, setId: backupSet.id, since: before, context: context)

--- a/Helper/Sources/Commands/RunSet.swift
+++ b/Helper/Sources/Commands/RunSet.swift
@@ -69,7 +69,19 @@ struct RunSet: AsyncParsableCommand {
             // the context has resolved it — not against a separately re-read
             // file, which would leave the decoded value and the hashed value
             // as two different snapshots.
+            var pinnedExecutable: String?
             if let expectedConfig {
+                // Required, not optional. Encoding `nil` on both sides makes
+                // the fingerprints match while binding no executable at all —
+                // the check would pass and authorize an unpinned launch.
+                guard let executable = context.restic.maintenanceExecutable() else {
+                    throw CLIFailure(
+                        code: .resticNotFound,
+                        message: "The configured restic executable could not be read, so this "
+                            + "operation cannot be bound to it. Recheck restic and try again.",
+                        details: CLIErrorDetails(setId: set)
+                    )
+                }
                 let store = ConfigStore(paths: context.paths)
                 let snapshot = try? store.snapshot()
                 let current = MaintenanceBinding.effectiveSetFingerprint(
@@ -77,7 +89,7 @@ struct RunSet: AsyncParsableCommand {
                     set: backupSet,
                     configFingerprint: snapshot?.fingerprint ?? "unreadable",
                     machineFingerprint: store.machineFileFingerprint(),
-                    resticExecutableIdentity: context.restic.maintenanceExecutable()?.identity
+                    resticExecutableIdentity: executable.identity
                 )
                 guard current == expectedConfig else {
                     throw CLIFailure(
@@ -87,9 +99,15 @@ struct RunSet: AsyncParsableCommand {
                         details: CLIErrorDetails(setId: set)
                     )
                 }
+                // Carried to every `forget --prune` below, so the binary that
+                // was validated is the binary that runs.
+                pinnedExecutable = executable.identity
             }
             let before = Date()
-            let status = await context.engine.runPrune(backupSet)
+            let status = await context.engine.runPrune(
+                backupSet,
+                expectedExecutableIdentity: pinnedExecutable
+            )
             handle(status, kind: .prune, setId: backupSet.id, since: before, context: context)
         }
     }

--- a/Helper/Sources/Commands/RunSet.swift
+++ b/Helper/Sources/Commands/RunSet.swift
@@ -24,8 +24,30 @@ struct RunSet: AsyncParsableCommand {
     @Option(name: .long, help: "Which operation to run.")
     var kind: Kind = .backup
 
+    /// Refuse unless `config.json` is byte-identical to what the caller
+    /// reviewed. The app sends this for **Apply retention now**, whose
+    /// preview is app-direct and therefore has no helper-issued token the
+    /// way `maintenance prune` does. Without it, a config change landing
+    /// between the dialog and the click — a hand edit, or this fleet's
+    /// config sync — silently applied a policy the operator never saw to a
+    /// destination list they were never shown.
+    @Option(name: .long, parsing: .unconditional,
+            help: "Refuse unless config.json still matches this fingerprint.")
+    var expectedConfig: String?
+
     func run() async throws {
         let context = try await HelperContext.make()
+        if let expectedConfig {
+            let current = ConfigStore(paths: context.paths).fileFingerprint()
+            guard current == expectedConfig else {
+                throw CLIFailure(
+                    code: .operationNotAllowed,
+                    message: "The configuration changed after this operation was reviewed. "
+                        + "Review the updated settings and try again.",
+                    details: CLIErrorDetails(setId: set)
+                )
+            }
+        }
         // `scheduled`: backup, check and prune are all things this machine
         // *does to* a set, so a set disabled here must not run — unlike the
         // repository utilities, which use `addressable`.

--- a/Helper/Sources/Commands/Runs.swift
+++ b/Helper/Sources/Commands/Runs.swift
@@ -102,7 +102,7 @@ struct RunsShow: AsyncParsableCommand, JSONRenderable {
 
         if json {
             if log {
-                FileHandle.standardError.write(
+                StandardStream.writeToStandardError(
                     Data("--log has no effect with --json; the log is not part of the metadata shape\n".utf8)
                 )
             }

--- a/Helper/Sources/Commands/Secret.swift
+++ b/Helper/Sources/Commands/Secret.swift
@@ -263,7 +263,7 @@ struct PrintPassword: AsyncParsableCommand {
         // Raw bytes, no newline: restic trims a trailing newline itself, but
         // emitting one would make `secret set` / `print-password` a lossy
         // round trip for a password that legitimately ends in one.
-        FileHandle.standardOutput.write(Data(password.utf8))
+        StandardStream.write(Data(password.utf8), to: .standardOutput)
         HelperExit.code(0)
     }
 }
@@ -285,11 +285,11 @@ enum SecretInput {
         guard isatty(STDIN_FILENO) == 1 else {
             return stripOneTrailingNewline(readAllStdin())
         }
-        FileHandle.standardError.write(Data(prompt.utf8))
+        StandardStream.write(Data(prompt.utf8), to: .standardError)
         let line = withEchoDisabled { readLine(strippingNewline: true) ?? "" }
         // The user's Return was swallowed by the disabled echo; put the
         // cursor back on its own line.
-        FileHandle.standardError.write(Data("\n".utf8))
+        StandardStream.write(Data("\n".utf8), to: .standardError)
         return line
     }
 

--- a/Helper/Sources/Commands/Tick.swift
+++ b/Helper/Sources/Commands/Tick.swift
@@ -137,7 +137,7 @@ struct Tick: AsyncParsableCommand {
                         }
                     }
                 } catch {
-                    FileHandle.standardError.write(
+                    StandardStream.writeToStandardError(
                         Data("tick: could not write repo-status for \(destination.id): \(error)\n".utf8)
                     )
                 }
@@ -158,7 +158,7 @@ struct Tick: AsyncParsableCommand {
                 print("recovered interrupted run \(run.runId)")
             }
         } catch {
-            FileHandle.standardError.write(Data("tick: could not recover interrupted runs: \(error)\n".utf8))
+            StandardStream.write(Data("tick: could not recover interrupted runs: \(error)\n".utf8), to: .standardError)
         }
 
         // Unconditionally, not only for what `recoverInterrupted()` just
@@ -235,7 +235,7 @@ struct Tick: AsyncParsableCommand {
                 try stateStore.clearCurrentRun(setId: setId)
                 print("  cleared abandoned progress \(paths.currentRunFile(setId: setId).lastPathComponent)")
             } catch {
-                FileHandle.standardError.write(
+                StandardStream.writeToStandardError(
                     Data("tick: could not clear abandoned progress for set \(setId): \(error)\n".utf8)
                 )
             }

--- a/Helper/Sources/HelperContext.swift
+++ b/Helper/Sources/HelperContext.swift
@@ -20,7 +20,7 @@ enum HelperExit {
     /// Writes `message` to stderr, then exits with `code` (default 1 —
     /// "error" in the T10 contract).
     static func fail(_ message: String, code: Int32 = 1) -> Never {
-        FileHandle.standardError.write(Data((message + "\n").utf8))
+        StandardStream.write(Data((message + "\n").utf8), to: .standardError)
         exit(code)
     }
 

--- a/Helper/Sources/HelperOutput.swift
+++ b/Helper/Sources/HelperOutput.swift
@@ -41,7 +41,7 @@ enum HelperOutput {
         if json {
             writeEnvelope(failure)
         } else {
-            FileHandle.standardError.write(Data((failure.message + "\n").utf8))
+            StandardStream.write(Data((failure.message + "\n").utf8), to: .standardError)
         }
         exit(code)
     }
@@ -61,8 +61,8 @@ enum HelperOutput {
         } catch {
             data = Data(Self.lastResortEnvelope.utf8)
         }
-        FileHandle.standardOutput.write(data)
-        FileHandle.standardOutput.write(Data("\n".utf8))
+        StandardStream.write(data, to: .standardOutput)
+        StandardStream.write(Data("\n".utf8), to: .standardOutput)
     }
 
     /// Hand-written so it cannot itself fail to encode.

--- a/Helper/Sources/ResticPathResolution.swift
+++ b/Helper/Sources/ResticPathResolution.swift
@@ -165,6 +165,6 @@ enum ResticResolution: Sendable {
 /// systemd capture both streams anyway.
 enum HelperLog {
     static func info(_ message: String) {
-        FileHandle.standardError.write(Data("info: \(message)\n".utf8))
+        StandardStream.write(Data("info: \(message)\n".utf8), to: .standardError)
     }
 }

--- a/docs/cli-json.md
+++ b/docs/cli-json.md
@@ -232,7 +232,8 @@ exception: they mutate, and they carry `--json` because the app drives them.
 Every defined code now has a producer. `repository_offline` was wired by #79
 and is also emitted by `purge preview` (exit 3); `operation_not_allowed` is
 emitted by `purge apply` and `maintenance prune` when a confirmation does not
-match the current plan. `preview_expired` is emitted by both when a binding
+match the current plan, and by `run-set` when `--expected-config` no longer
+matches `config.json`. `preview_expired` is emitted by both when a binding
 outlives `PreviewTokenStore.defaultLifetime`.
 
 ## Confirmation bindings are an app gate, not a CLI gate
@@ -240,6 +241,13 @@ outlives `PreviewTokenStore.defaultLifetime`.
 `purge apply` cannot run without a valid `--preview-token`: `BackupEngine`
 refuses every request not bound to a current preview, and there is no force,
 yes, or environment bypass.
+
+`run-set --kind prune` (the app's **Apply retention now**) takes
+`--expected-config`, a SHA-256 of `config.json`'s bytes. Retention's preview
+runs in the app rather than through the helper, so there is no helper-issued
+token to mint; the file fingerprint is what both processes can compute
+identically, and the helper refuses if the file moved between the preview the
+operator read and the run they authorised.
 
 `maintenance prune` is deliberately different. `--expected-destination` is
 optional, and omitting it runs a real `restic prune` with no binding check —

--- a/docs/restic-cli.md
+++ b/docs/restic-cli.md
@@ -37,12 +37,20 @@ Everything in this document was **verified against restic 0.18.1 on macOS (arm64
 ## Remote maintenance
 
 For an `sftp:` destination whose `remoteMaintenance.enabled` is true,
-standalone pack reclamation runs on the SSH host. Restic Station invokes SSH
-with BatchMode, strict host-key acceptance, and a 15-second connection limit;
-the remote login shell receives every operand single-quote escaped. The
-repository password is written only to SSH stdin and remote restic reads it
-with `-p /dev/stdin`. If SSH or remote restic is unavailable, prune fails; it
-never falls back to a local network prune. Rewrite remains local.
+standalone pack reclamation runs on the SSH host. The remote login shell
+receives every operand single-quote escaped. The repository password is
+written only to SSH stdin and remote restic reads it with `-p /dev/stdin`. If
+SSH or remote restic is unavailable, prune fails; it never falls back to a
+local network prune. Rewrite remains local.
+
+SSH options, and why each is there:
+
+| Option | Reason |
+|---|---|
+| `BatchMode=yes` | Never prompt. A scheduled helper has no one to answer. |
+| `StrictHostKeyChecking=yes` | **Not `accept-new`.** This channel carries the repository password, so trust-on-first-use would hand it to whoever answers the first connection — and that MITM then satisfies the `restic version` preflight. The operator has already ssh'd to the host to configure the destination, so the key is normally pinned; when it is not, the preflight recognises the host-key failure and says to connect once with `ssh` to verify and record the key. |
+| `ConnectTimeout=15` | Bounds the handshake. |
+| `ServerAliveInterval=15`, `ServerAliveCountMax=3` | Bounds a session that is *established but dead*. `ConnectTimeout` does not cover this: a NAT or firewall dropping an idle flow mid-prune leaves ssh blocked forever, and the helper hangs **holding the set lock**, silently stopping every scheduled backup for that set. A wall-clock timeout is deliberately not used instead — a legitimate prune runs for hours, and only a keepalive distinguishes slow from gone. |
 
 ## Exit codes (verified)
 


### PR DESCRIPTION
Fixes the five issues filed from the Fable review of epic #85. One commit per issue.

### #104 — retention apply had no fail-closed binding

`confirmApplyRetention`'s reclaim arm re-resolves the set, requires full `Destination` equality against what the dialog showed, and forwards a helper-issued binding the helper revalidates. The retention arm forwarded only `setId`, so a config change landing between the dialog and the click meant the helper applied the **new** policy to the **new** destination list — the user authorised deleting five named snapshots and could get something else.

The asymmetry had a cause: reclaim's preview goes through the helper, retention's is app-direct, so there was nothing to mint a token from. Rather than rebuild the preview, this binds on `config.json`'s **bytes** — the one thing both processes see identically. Hashing decoded `AppConfig` values would make app and helper disagree about migration and resolution, and refuse legitimate work.

### #105 — Maintenance UI acted on a set it was no longer showing

Selection change now clears plan/preview/activity. Also: the destructive alert no longer re-presents itself with no user gesture (its prominent button is "Reclaim Space", under an in-flight Return keypress); a busy refusal no longer discards the preview and re-runs `stats` against every destination after changing nothing; a vanished set reports instead of silently closing the dialog.

### #107 — schedule-state lost update

`updateScheduleState` read-modify-wrote a file shared by every set with only per-set locks in existence. Now under a companion lock using the same bounded-retry shape `RunStore` already uses for its index. **The regression test loses 7 of 8 entries without it.**

### #108 — the helper's own stdout/stderr could kill it

All 23 write sites now route through `StandardStream`, sharing `SIGPIPEGuard` with `DefaultProcessRunner` — extracted rather than duplicated, because the guard's correctness depends on one lock covering both the ignore window and every `posix_spawn`. Red-checked: signal 13 without it.

### #106 — the tractable half

`StrictHostKeyChecking=yes` instead of `accept-new` on a channel carrying the repository password, with an actionable error when the key is unpinned; purge tokens now bind the restic executable identity like maintenance tokens already did; token-store temp file `O_EXCL|O_NOFOLLOW`; lock file 0600.

Deliberately left open in #106: moving capability values off argv, where Linux's `/proc/<pid>/cmdline` exposes them to other local users. That needs a stdin/fd channel through `HelperCommand` and the app's invoker.

### Two things I got wrong on the way

- I first re-tightened the **data root** to 0700. That broke `secret-cli-test.sh`, which pins a pre-existing 755 dir staying 755 — the repo deliberately leaves an operator's chosen directory mode alone. Narrowed to `state/`, which holds the token capabilities, rather than overriding a documented decision on a reviewer's say-so.
- An earlier red-check restored an **uncommitted** file with `git checkout --`, silently reverting the whole #107 lock fix. The concurrency test caught it.

### Verification

`scripts/local-ci.sh` green (7/7 available). Behavioural fixes red-checked against unfixed sources. `docs/restic-cli.md` and `docs/cli-json.md` updated in the same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VVUQTf9Xcm49R4PUMcL8nL