### PR TITLE
Bind the purge preview and its token to one restic binary

### DIFF
--- a/Core/Sources/ResticStationCore/Engine/BackupEngine.swift
+++ b/Core/Sources/ResticStationCore/Engine/BackupEngine.swift
@@ -1112,7 +1112,19 @@ public final class BackupEngine: Sendable {
     /// `cat config` where needed, `snapshots --json`, and `rewrite --dry-run`.
     /// In particular, this method cannot reach `rewrite --forget`, `prune`, or
     /// the run-record machinery.
-    public func previewPurge(set: BackupSet, destination: Destination) async -> PurgePlanResult {
+    ///
+    /// `executable` is the binary this preview is *attributed to*: both
+    /// queries are pinned to it, so a transcript can only be produced by the
+    /// program the resulting token will name.  Deliberately not resolved
+    /// here — one preview pass over several destinations must be one binary,
+    /// which only the caller above can guarantee, so
+    /// ``previewPurgeSession(set:destinations:)`` is the entry point and
+    /// this is internal (#118).
+    func previewPurge(
+        set: BackupSet,
+        destination: Destination,
+        executable: ResticRunner.MaintenanceExecutable
+    ) async -> PurgePlanResult {
         let emptyPlan = PurgePlan(
             destinationId: destination.id,
             snapshots: [],
@@ -1149,7 +1161,10 @@ public final class BackupEngine: Sendable {
             return PurgePlanResult(plan: emptyPlan, status: .failed, message: "secret store unavailable")
         }
 
-        let probe = await reachability.probe(destination)
+        let probe = await reachability.probe(
+            destination,
+            expectedExecutableIdentity: executable.identity
+        )
         switch probe {
         case .reachable:
             break
@@ -1171,7 +1186,10 @@ public final class BackupEngine: Sendable {
         do {
             snapshotsOutcome = try await restic.run(
                 .snapshots(repo: destination.repoURL),
-                for: ResticInvocation(destination: destination)
+                for: ResticInvocation(
+                    destination: destination,
+                    expectedExecutableIdentity: executable.identity
+                )
             )
         } catch {
             return PurgePlanResult(plan: emptyPlan, status: .failed, message: "could not list snapshots: \(error)")
@@ -1215,7 +1233,10 @@ public final class BackupEngine: Sendable {
                     excludes: plan.patterns,
                     dryRun: true
                 ),
-                for: ResticInvocation(destination: destination)
+                for: ResticInvocation(
+                    destination: destination,
+                    expectedExecutableIdentity: executable.identity
+                )
             )
         } catch {
             return PurgePlanResult(plan: plan, status: .failed, message: "could not preview rewrite: \(error)")
@@ -1233,12 +1254,89 @@ public final class BackupEngine: Sendable {
         return PurgePlanResult(plan: plan, changed: changed, rewrite: rewrite, status: .ready)
     }
 
+    /// Previews a purge across `destinations` and mints the capability for
+    /// what it found — the only public way to obtain a purge token.
+    ///
+    /// The restic executable is resolved **once, before the first query**,
+    /// and that one identity pins every preview command and binds the token.
+    /// #109 bound the token to the executable observed *after* the previews
+    /// had run, which left a real gap: a binary replaced between the last
+    /// dry-run and issuance produced a transcript from one program and a
+    /// capability naming another.  Multi-destination made that window wide
+    /// rather than theoretical, because issuance waited for every
+    /// destination's network round trips (#118).
+    ///
+    /// A destination that does not finish its preview ends the pass with no
+    /// token: a capability must never describe a plan the operator could not
+    /// be shown in full.  The caller still sees the partial results and
+    /// reports the failure from them.
+    public func previewPurgeSession(
+        set: BackupSet,
+        destinations: [Destination]
+    ) async throws -> PurgePreviewSession {
+        // Preserve the no-op contract without making restic itself a
+        // prerequisite. There is no query to attribute and no destructive
+        // capability to mint when the policy is empty.
+        guard !set.purgeExcludes.isEmpty else {
+            return PurgePreviewSession(
+                previews: destinations.map { destination in
+                    let plan = PurgePlan(
+                        destinationId: destination.id,
+                        snapshots: [],
+                        sourcePaths: sourcePaths(for: set),
+                        hostnames: hostnames(for: set),
+                        patterns: []
+                    )
+                    return PurgePreviewSession.DestinationPreview(
+                        destination: destination,
+                        result: PurgePlanResult(
+                            plan: plan,
+                            status: .empty,
+                            message: "nothing to purge: purgeExcludes is empty"
+                        )
+                    )
+                },
+                token: nil
+            )
+        }
+        // Before any query, so there is no window in which a preview could
+        // have been produced by a binary this pass never identified.
+        guard let executable = restic.maintenanceExecutable() else {
+            throw PurgeApplyError.resticUnavailable
+        }
+        var previews: [PurgePreviewSession.DestinationPreview] = []
+        for destination in destinations {
+            let result = await previewPurge(set: set, destination: destination, executable: executable)
+            previews.append(PurgePreviewSession.DestinationPreview(destination: destination, result: result))
+            switch result.status {
+            case .empty, .ready:
+                continue
+            case .busy, .offline, .infrastructureFailure, .failed:
+                return PurgePreviewSession(previews: previews, token: nil)
+            }
+        }
+        return PurgePreviewSession(
+            previews: previews,
+            token: try issuePurgeToken(
+                set: set,
+                destinations: previews.map(\.destination),
+                plans: previews.map(\.result.plan),
+                executable: executable
+            )
+        )
+    }
+
     /// Stores the approved result of one or more successful purge previews.
     /// An empty plan gets no capability: there is nothing destructive to do.
-    public func issuePurgeToken(
+    ///
+    /// `executable` is passed in rather than resolved, so this cannot bind a
+    /// capability to a binary that did not produce `plans`.  Internal for the
+    /// same reason ``previewPurge`` is: the pairing is the guarantee.
+    func issuePurgeToken(
         set: BackupSet,
         destinations: [Destination],
-        plans: [PurgePlan]
+        plans: [PurgePlan],
+        executable: ResticRunner.MaintenanceExecutable
     ) throws -> PreviewToken? {
         guard !set.purgeExcludes.isEmpty, destinations.count == plans.count else { return nil }
         guard Set(plans.map(\.destinationId)).count == plans.count else { return nil }
@@ -1254,21 +1352,24 @@ public final class BackupEngine: Sendable {
             )
         }
         guard tokenDestinations.contains(where: { !$0.snapshotIDs.isEmpty }) else { return nil }
-        // Thrown, not `return nil`. `nil` from this method means "there is
-        // nothing destructive to do", and a restic binary that cannot be
-        // identified is emphatically not that — returning nil would report
-        // an empty plan for a set that has one.
-        guard let executable = restic.maintenanceExecutable() else {
-            throw PurgeApplyError.resticUnavailable
+        // Wrapped exactly as `runPurgeLocked` wraps its own token reads. A
+        // bare `PreviewTokenError` means nothing to `classifyPurgeOperation`,
+        // so an unusable confirmation store reached the operator as
+        // `internal_error` — losing the specific "check the permissions on
+        // the data directory" advice #117 added, on the one path where the
+        // store is being *written* and is therefore likeliest to be broken.
+        do {
+            return try previewTokens.issue(
+                machineId: machineId,
+                setId: set.id,
+                destinations: tokenDestinations,
+                config: config,
+                patterns: set.purgeExcludes,
+                executableIdentity: executable.identity
+            )
+        } catch let error as PreviewTokenError {
+            throw PurgeApplyError.token(error)
         }
-        return try previewTokens.issue(
-            machineId: machineId,
-            setId: set.id,
-            destinations: tokenDestinations,
-            config: config,
-            patterns: set.purgeExcludes,
-            executableIdentity: executable.identity
-        )
     }
 
     /// Lets the helper choose exactly the destinations an opaque token bound.
@@ -1368,7 +1469,8 @@ public final class BackupEngine: Sendable {
             let plan = try await currentPurgePlan(
                 set: set,
                 destination: destination,
-                patterns: preview.patterns
+                patterns: preview.patterns,
+                executable: executable
             )
             guard let tokenDestination = preview.destinations.first(where: { $0.destinationId == destination.id }),
                   tokenDestination.snapshotIDs.sorted() == plan.matched.map(\.id).sorted() else {
@@ -1453,12 +1555,25 @@ public final class BackupEngine: Sendable {
     /// Obtains a fresh attributed plan for token validation.  It is purposely
     /// independent of the earlier dry-run transcript: a repository can
     /// change during the preview window, and the apply must fail closed.
+    ///
+    /// Pinned to the executable the apply captured, so the program that
+    /// answers "is this token still valid?" is the program that will act on
+    /// the answer.  Unpinned, a binary substituted during this query could
+    /// return a listing matching the token while the repository had in fact
+    /// changed — the staleness check would pass on a lie.  It could not
+    /// widen the purge, because the ids must equal the token's exactly, and
+    /// the launch itself already failed closed on the mismatch; this closes
+    /// the validation half too (#118).
     private func currentPurgePlan(
         set: BackupSet,
         destination: Destination,
-        patterns: [String]
+        patterns: [String],
+        executable: ResticRunner.MaintenanceExecutable
     ) async throws -> PurgePlan {
-        let probe = await reachability.probe(destination)
+        let probe = await reachability.probe(
+            destination,
+            expectedExecutableIdentity: executable.identity
+        )
         guard probe == .reachable else {
             throw PurgeApplyError.destinationOffline(destinationId: destination.id)
         }
@@ -1466,7 +1581,10 @@ public final class BackupEngine: Sendable {
         do {
             outcome = try await restic.run(
                 .snapshots(repo: destination.repoURL),
-                for: ResticInvocation(destination: destination)
+                for: ResticInvocation(
+                    destination: destination,
+                    expectedExecutableIdentity: executable.identity
+                )
             )
         } catch {
             throw PurgeApplyError.unavailable
@@ -1557,10 +1675,18 @@ public final class BackupEngine: Sendable {
         groupId: String
     ) async throws -> PurgeRunResult {
         guard await secretsAvailable(for: [destination]) else { throw PurgeApplyError.unavailable }
-        let plan = try await currentPurgePlan(set: set, destination: destination, patterns: patterns)
+        // Captured before the plan query, not after it: the automatic path
+        // mints and spends its own token, so the same "one binary for the
+        // whole operation" rule applies here (#118).
         guard let executable = restic.maintenanceExecutable() else {
             throw PurgeApplyError.resticUnavailable
         }
+        let plan = try await currentPurgePlan(
+            set: set,
+            destination: destination,
+            patterns: patterns,
+            executable: executable
+        )
         let token: PreviewToken
         do {
             token = try previewTokens.issue(

--- a/Core/Sources/ResticStationCore/Engine/PurgePlan.swift
+++ b/Core/Sources/ResticStationCore/Engine/PurgePlan.swift
@@ -97,6 +97,40 @@ public struct PurgePlanResult: Equatable, Sendable {
     }
 }
 
+/// One purge preview pass over a set's destinations, together with the
+/// capability it earned.
+///
+/// This type exists so that the preview and the token cannot disagree about
+/// which restic binary they describe.  ``BackupEngine/previewPurgeSession``
+/// resolves the executable **once, before the first query**, pins every
+/// preview command to it, and mints the token against that same identity —
+/// so "what the operator reviewed" and "what the token authorizes" are the
+/// same program by construction, not by the caller remembering to make them
+/// so (#118).
+///
+/// ``token`` is `nil` when there is nothing destructive to authorize: no
+/// patterns, no attributed snapshots, or a destination that did not finish
+/// its preview.
+public struct PurgePreviewSession: Sendable {
+    public struct DestinationPreview: Sendable {
+        public let destination: Destination
+        public let result: PurgePlanResult
+
+        public init(destination: Destination, result: PurgePlanResult) {
+            self.destination = destination
+            self.result = result
+        }
+    }
+
+    public let previews: [DestinationPreview]
+    public let token: PreviewToken?
+
+    public init(previews: [DestinationPreview], token: PreviewToken?) {
+        self.previews = previews
+        self.token = token
+    }
+}
+
 /// A completed token-gated purge group.  `children` are ordinary run records
 /// (`RunKind.purge`), so callers can report and audit every destination
 /// without ever exposing the preview token itself.

--- a/Core/Sources/ResticStationCore/Engine/Reachability.swift
+++ b/Core/Sources/ResticStationCore/Engine/Reachability.swift
@@ -37,12 +37,17 @@ public struct Reachability: Sendable {
 
     public func probe(
         _ dest: Destination,
-        destinationSecretEnv: [String: String]? = nil
+        destinationSecretEnv: [String: String]? = nil,
+        expectedExecutableIdentity: String? = nil
     ) async -> RepoProbeResult {
         if dest.kind == .localPath {
             return Self.probeLocal(dest)
         }
-        return await probeRemote(dest, destinationSecretEnv: destinationSecretEnv)
+        return await probeRemote(
+            dest,
+            destinationSecretEnv: destinationSecretEnv,
+            expectedExecutableIdentity: expectedExecutableIdentity
+        )
     }
 
     // MARK: - Local
@@ -76,14 +81,16 @@ public struct Reachability: Sendable {
 
     private func probeRemote(
         _ dest: Destination,
-        destinationSecretEnv: [String: String]?
+        destinationSecretEnv: [String: String]?,
+        expectedExecutableIdentity: String?
     ) async -> RepoProbeResult {
         do {
             let outcome = try await restic.run(
                 .catConfig(repo: dest.repoURL),
                 for: ResticInvocation(
                     destination: dest,
-                    destinationSecretEnv: destinationSecretEnv
+                    destinationSecretEnv: destinationSecretEnv,
+                    expectedExecutableIdentity: expectedExecutableIdentity
                 ),
                 timeout: Self.probeTimeout
             )

--- a/Core/Sources/ResticStationCore/Support/CLIError.swift
+++ b/Core/Sources/ResticStationCore/Support/CLIError.swift
@@ -394,7 +394,13 @@ extension CLIFailure {
     /// Error mapping for token-gated destructive operations. Token material
     /// never reaches the envelope; ids make the refusal actionable without
     /// disclosing a capability or repository path.
-    public static func classifyPurgeApply(_ error: any Error, setId: UUID) -> CLIFailure {
+    ///
+    /// Named for the whole purge *operation*, not just apply: `purge
+    /// preview` mints the capability and so raises the same errors. While
+    /// this was called `classifyPurgeApply` the preview command did not
+    /// call it at all, and reported a missing restic binary as
+    /// `internal_error` (#118).
+    public static func classifyPurgeOperation(_ error: any Error, setId: UUID) -> CLIFailure {
         guard let purgeError = error as? PurgeApplyError else {
             return classify(error)
         }
@@ -482,6 +488,14 @@ extension CLIFailure {
                 details: CLIErrorDetails(setId: setId)
             )
         }
+    }
+
+    /// Compatibility entry point for callers that are specifically
+    /// classifying the destructive apply half of a purge. Preview and apply
+    /// intentionally share the same taxonomy, but #117 exposed this public
+    /// spelling before #118 broadened the classifier's use.
+    public static func classifyPurgeApply(_ error: any Error, setId: UUID) -> CLIFailure {
+        classifyPurgeOperation(error, setId: setId)
     }
 
     public static func invalidArguments(_ message: String) -> CLIFailure {

--- a/Core/Tests/ResticStationCoreTests/Engine/BackupEngineTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Engine/BackupEngineTests.swift
@@ -124,13 +124,34 @@ struct BackupEngineTests {
         let runStore: RunStore
         let stateStore: StateStore
         let engine: BackupEngine
+        let restic: ResticRunner
+        /// The path this env actually configured, which is **not** always
+        /// ``BackupEngineTests/resticPath``: the executable-swap tests point
+        /// the engine at a binary they may modify. ``resticArgvs`` filtered
+        /// on the static fixture path, so in exactly those tests it matched
+        /// nothing and every "no rewrite was ever spawned" assertion built
+        /// on it was vacuously true (#118).
+        let resticPath: String
         let machineId: String
         let set: BackupSet
         let primary: Destination
         let secondaries: [Destination]
 
+        /// The executable a purge preview would resolve and bind. Tests that
+        /// mint a token by hand must pass this rather than letting the issuer
+        /// resolve its own, which is the coupling #118 removed.
+        ///
+        /// A throwing function rather than an optional unwrapped at the call
+        /// site: these calls sit inside `#require`, and `#require` cannot be
+        /// nested inside itself.
+        func requireResticExecutable() throws -> ResticRunner.MaintenanceExecutable {
+            struct NoResticExecutable: Error {}
+            guard let executable = restic.maintenanceExecutable() else { throw NoResticExecutable() }
+            return executable
+        }
+
         var resticArgvs: [[String]] {
-            fake.invocations.map(\.argv).filter { $0.first == BackupEngineTests.resticPath }
+            fake.invocations.map(\.argv).filter { $0.first == resticPath }
         }
 
         var indexEntries: [RunIndexEntry] {
@@ -172,6 +193,8 @@ struct BackupEngineTests {
         purgeSourcePaths: [UUID: Set<String>] = [:],
         purgeHostnames: [UUID: Set<String>] = [:],
         machineId: String = "example-machine",
+        primaryRepoURL: String? = nil,
+        onSecretPasswordRead: (@Sendable (UUID) -> Void)? = nil,
         /// Overridable so a test can point the engine at a binary it is
         /// allowed to modify, and assert what happens when restic is
         /// replaced mid-operation.
@@ -193,7 +216,7 @@ struct BackupEngineTests {
         let primary = Destination(
             id: primaryId,
             label: "Primary",
-            repoURL: repo("primary", exists: primaryReachable),
+            repoURL: primaryRepoURL ?? repo("primary", exists: primaryReachable),
             isPrimary: true
         )
         let secondaryIds = [secondaryAId, secondaryBId]
@@ -225,7 +248,11 @@ struct BackupEngineTests {
         let processRunner: ProcessRunning = onSpawn.map {
             ObservingProcessRunner(inner: fake, onSpawn: $0)
         } ?? fake
-        let secrets = FakeSecretStore(defaultPassword: "repo-password", backend: secretBackend)
+        let secrets = FakeSecretStore(
+            defaultPassword: "repo-password",
+            backend: secretBackend,
+            onPasswordRead: onSecretPasswordRead
+        )
         for id in secretsUnavailableFor {
             secrets.failPassword(for: id)
         }
@@ -260,6 +287,8 @@ struct BackupEngineTests {
             runStore: runStore,
             stateStore: stateStore,
             engine: engine,
+            restic: restic,
+            resticPath: resticPath,
             machineId: machineId,
             set: set,
             primary: primary,
@@ -2508,7 +2537,8 @@ struct BackupEngineTests {
             patterns: env.set.purgeExcludes
         )
         let token = try #require(try env.engine.issuePurgeToken(
-            set: env.set, destinations: [env.primary], plans: [plan]
+            set: env.set, destinations: [env.primary], plans: [plan],
+            executable: try env.requireResticExecutable()
         ))
 
         // Built against the injected path, not the shared `resticPath` helper.
@@ -2553,22 +2583,45 @@ struct BackupEngineTests {
         )
         defer { env.cleanUp() }
 
-        let snapshots = try parseSnapshots(Data(try FixtureLoader.string("snapshots.json").utf8))
-        let plan = PurgePlan(
-            destinationId: env.primary.id, snapshots: snapshots,
-            sourcePaths: sourcePaths[Self.setId]!, hostnames: hostnames[Self.setId]!,
-            patterns: env.set.purgeExcludes
-        )
-
-        // The preview queries have completed; restic disappears before the
-        // capability is minted. That is the window the finding describes.
+        // #118 moved this refusal earlier: the session resolves the binary
+        // before its first query, so a vanished restic is caught before any
+        // transcript exists to be reviewed, rather than after the previews
+        // had already run.
         try FileManager.default.removeItem(at: fakeRestic)
 
-        #expect(throws: PurgeApplyError.resticUnavailable) {
-            _ = try env.engine.issuePurgeToken(
-                set: env.set, destinations: [env.primary], plans: [plan]
+        await #expect(throws: PurgeApplyError.resticUnavailable) {
+            _ = try await env.engine.previewPurgeSession(
+                set: env.set, destinations: [env.primary]
             )
         }
+        #expect(env.fake.invocations.isEmpty, "no query may run for a binary that cannot be identified")
+    }
+
+    @Test("an empty purge policy needs no restic executable")
+    func purgePreviewSessionEmptyWithoutAnExecutable() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("restic-station-empty-purge-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let fakeRestic = root.appendingPathComponent("restic", isDirectory: false)
+        try Data("temporary restic".utf8).write(to: fakeRestic)
+        let env = Self.makeEnv(
+            script: [], retention: nil, purgeExcludes: [], reachableSecondaries: [],
+            resticPath: fakeRestic.path
+        )
+        defer { env.cleanUp() }
+        try FileManager.default.removeItem(at: fakeRestic)
+
+        let session = try await env.engine.previewPurgeSession(
+            set: env.set,
+            destinations: [env.primary]
+        )
+
+        #expect(session.token == nil)
+        #expect(session.previews.count == 1)
+        #expect(session.previews[0].result.status == .empty)
+        #expect(session.previews[0].result.message == "nothing to purge: purgeExcludes is empty")
+        #expect(env.fake.invocations.isEmpty)
     }
 
     /// The other half: even a token minted while restic existed must not be
@@ -2600,7 +2653,8 @@ struct BackupEngineTests {
             patterns: env.set.purgeExcludes
         )
         let token = try #require(try env.engine.issuePurgeToken(
-            set: env.set, destinations: [env.primary], plans: [plan]
+            set: env.set, destinations: [env.primary], plans: [plan],
+            executable: try env.requireResticExecutable()
         ))
 
         try FileManager.default.removeItem(at: fakeRestic)
@@ -2672,7 +2726,8 @@ struct BackupEngineTests {
             patterns: env.set.purgeExcludes
         )
         let token = try #require(try env.engine.issuePurgeToken(
-            set: env.set, destinations: [env.primary], plans: [plan]
+            set: env.set, destinations: [env.primary], plans: [plan],
+            executable: try env.requireResticExecutable()
         ))
 
         env.fake.script = [
@@ -2693,6 +2748,371 @@ struct BackupEngineTests {
         )
     }
 
+    // MARK: - #118: one binary for the whole purge, preview included
+
+    @Test("a remote preview pins its reachability probe before credentials reach restic")
+    func purgePreviewPinsRemoteReachabilityProbe() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("restic-station-preview-remote-swap-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let fakeRestic = root.appendingPathComponent("restic", isDirectory: false)
+        try Data("original restic".utf8).write(to: fakeRestic)
+        let remoteRepo = "s3:https://example.invalid/preview"
+        let swapPath = fakeRestic.path
+        let env = Self.makeEnv(
+            script: [
+                .init(argvPrefix: [fakeRestic.path, "-r", remoteRepo, "cat", "config"]),
+            ],
+            retention: nil,
+            purgeExcludes: ["build/**"],
+            reachableSecondaries: [],
+            primaryRepoURL: remoteRepo,
+            onSecretPasswordRead: { _ in
+                try? Data("replacement restic".utf8).write(to: URL(fileURLWithPath: swapPath))
+            },
+            resticPath: fakeRestic.path
+        )
+        defer { env.cleanUp() }
+
+        let session = try await env.engine.previewPurgeSession(
+            set: env.set,
+            destinations: [env.primary]
+        )
+
+        #expect(session.token == nil)
+        #expect(session.previews.count == 1)
+        #expect(session.previews[0].result.status == .offline)
+        #expect(
+            env.fake.invocations.isEmpty,
+            "the replacement must not receive `cat config` or the destination credential environment"
+        )
+    }
+
+    @Test("apply pins remote reachability before revalidating a purge token")
+    func purgeApplyPinsRemoteReachabilityProbe() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("restic-station-apply-remote-swap-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let fakeRestic = root.appendingPathComponent("restic", isDirectory: false)
+        try Data("original restic".utf8).write(to: fakeRestic)
+        let remoteRepo = "s3:https://example.invalid/apply"
+        let swapPath = fakeRestic.path
+        let sourcePaths = [Self.setId: Set(["/Users/user/example/src"])]
+        let hostnames = [Self.setId: Set(["example-mac.local"])]
+        let env = Self.makeEnv(
+            script: [
+                .init(argvPrefix: [fakeRestic.path, "-r", remoteRepo, "cat", "config"]),
+            ],
+            retention: nil,
+            purgeExcludes: ["build/**"],
+            reachableSecondaries: [],
+            purgeSourcePaths: sourcePaths,
+            purgeHostnames: hostnames,
+            primaryRepoURL: remoteRepo,
+            onSecretPasswordRead: { _ in
+                try? Data("replacement restic".utf8).write(to: URL(fileURLWithPath: swapPath))
+            },
+            resticPath: fakeRestic.path
+        )
+        defer { env.cleanUp() }
+        let snapshots = try parseSnapshots(Data(try FixtureLoader.string("snapshots.json").utf8))
+        let plan = PurgePlan(
+            destinationId: env.primary.id,
+            snapshots: snapshots,
+            sourcePaths: sourcePaths[Self.setId]!,
+            hostnames: hostnames[Self.setId]!,
+            patterns: env.set.purgeExcludes
+        )
+        let token = try #require(try env.engine.issuePurgeToken(
+            set: env.set,
+            destinations: [env.primary],
+            plans: [plan],
+            executable: try env.requireResticExecutable()
+        ))
+
+        await #expect(throws: PurgeApplyError.destinationOffline(destinationId: Self.primaryId)) {
+            _ = try await env.engine.runPurge(
+                set: env.set,
+                destinations: [env.primary],
+                token: token.value
+            )
+        }
+        #expect(
+            env.fake.invocations.isEmpty,
+            "the replacement must not receive remote credentials through the reachability probe"
+        )
+        #expect(throws: Never.self) { _ = try env.engine.purgeTokenDestinationIDs(token.value) }
+    }
+
+    /// #109 pinned the destructive launch and the token, but not the queries
+    /// that produced the transcript the operator reads. Both preview
+    /// commands went out as a bare `ResticInvocation(destination:)`, so a
+    /// binary replaced *between* `snapshots` and `rewrite --dry-run` wrote
+    /// half the preview and was never noticed.
+    @Test("a preview whose binary changes mid-pass produces no transcript and no token")
+    func purgePreviewRefusesASwapBetweenItsOwnQueries() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("restic-station-preview-swap-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let fakeRestic = root.appendingPathComponent("restic", isDirectory: false)
+        try Data("original restic".utf8).write(to: fakeRestic)
+
+        let sourcePaths = [Self.setId: Set(["/Users/user/example/src"])]
+        let hostnames = [Self.setId: Set(["example-mac.local"])]
+        let swapPath = fakeRestic.path
+        let env = Self.makeEnv(
+            script: [], retention: nil, purgeExcludes: ["build/**"], reachableSecondaries: [],
+            onSpawn: { argv in
+                guard argv.contains("snapshots") else { return }
+                try? Data("a replacement restic that is quite different".utf8).write(
+                    to: URL(fileURLWithPath: swapPath)
+                )
+            },
+            purgeSourcePaths: sourcePaths, purgeHostnames: hostnames,
+            resticPath: fakeRestic.path
+        )
+        defer { env.cleanUp() }
+
+        let snapshotsJSON = try FixtureLoader.string("snapshots.json")
+        env.fake.script = [
+            .init(
+                argvPrefix: [fakeRestic.path, "-r", env.primary.repoURL, "snapshots", "--json"],
+                stdoutLines: [snapshotsJSON]
+            ),
+        ]
+
+        let session = try await env.engine.previewPurgeSession(
+            set: env.set, destinations: [env.primary]
+        )
+
+        #expect(session.token == nil, "a half-written preview must earn no capability")
+        #expect(session.previews.count == 1)
+        #expect(session.previews[0].result.status == .failed)
+        #expect(
+            !env.resticArgvs.contains { $0.contains("rewrite") },
+            "the dry-run must not be answered by a binary that did not run `snapshots`"
+        )
+    }
+
+    /// The load-bearing case. `issuePurgeToken` used to run after *every*
+    /// destination's preview, so the window between the first destination's
+    /// transcript and the single shared token spanned all the later
+    /// destinations' network round trips — and the token bound only whichever
+    /// binary happened to exist at the end. One session, one executable,
+    /// resolved before the first query, closes it.
+    @Test("a binary swapped between two destinations' previews yields no shared token")
+    func purgePreviewRefusesASwapBetweenDestinations() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("restic-station-preview-multi-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let fakeRestic = root.appendingPathComponent("restic", isDirectory: false)
+        try Data("original restic".utf8).write(to: fakeRestic)
+
+        let sourcePaths = [Self.setId: Set(["/Users/user/example/src"])]
+        let hostnames = [Self.setId: Set(["example-mac.local"])]
+        let swapPath = fakeRestic.path
+        let env = Self.makeEnv(
+            script: [], retention: nil, purgeExcludes: ["build/**"], reachableSecondaries: [true],
+            onSpawn: { argv in
+                // After the first destination's dry-run has been answered,
+                // which is exactly where the old ordering left the door open.
+                guard argv.contains("rewrite") else { return }
+                try? Data("a replacement restic that is quite different".utf8).write(
+                    to: URL(fileURLWithPath: swapPath)
+                )
+            },
+            purgeSourcePaths: sourcePaths, purgeHostnames: hostnames,
+            resticPath: fakeRestic.path
+        )
+        defer { env.cleanUp() }
+
+        let secondary = try #require(env.secondaries.first)
+        let snapshotsJSON = try FixtureLoader.string("snapshots.json")
+        let snapshots = try parseSnapshots(Data(snapshotsJSON.utf8))
+        let snapshotIDs = snapshots.map(\.id)
+        let dryRun = try FixtureLoader.string("rewrite-dry-run.txt")
+            .replacingOccurrences(of: "09b3295c", with: snapshots[0].shortId)
+            .replacingOccurrences(of: "b2435423", with: snapshots[1].shortId)
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map(String.init)
+        // Both destinations are scripted all the way through, so an unpinned
+        // pass would succeed completely and mint the shared token. The
+        // refusal below therefore comes from the pin and not from the script
+        // running out — which is what the first draft of this test actually
+        // proved.
+        env.fake.script = [env.primary, secondary].flatMap { destination in
+            [
+                FakeProcessRunner.Expectation(
+                    argvPrefix: [fakeRestic.path, "-r", destination.repoURL, "snapshots", "--json"],
+                    stdoutLines: [snapshotsJSON]
+                ),
+                FakeProcessRunner.Expectation(
+                    argvPrefix: [fakeRestic.path, "-r", destination.repoURL, "rewrite", "--dry-run",
+                                 "--exclude", "build/**"] + snapshotIDs,
+                    stdoutLines: dryRun
+                ),
+            ]
+        }
+
+        let session = try await env.engine.previewPurgeSession(
+            set: env.set, destinations: [env.primary, secondary]
+        )
+
+        #expect(session.previews.count == 2, "the pass stops at the destination that failed, not before it")
+        #expect(session.previews[0].result.status == .ready)
+        #expect(session.previews[1].result.status == .failed)
+        #expect(
+            session.token == nil,
+            "one token covering both destinations must not survive a binary change between them"
+        )
+        #expect(
+            !env.resticArgvs.contains { $0.contains(secondary.repoURL) && $0.contains("rewrite") },
+            "the second destination's dry-run must never reach the replacement"
+        )
+    }
+
+    /// The apply-time half. `runPurgeLocked` captured the executable before
+    /// `currentPurgePlan`, but the plan's own `snapshots` query was
+    /// unpinned — so the program answering "is this token still valid?" was
+    /// not guaranteed to be the program that would act on the answer. The
+    /// launch check already failed closed on the rewrite; this stops the
+    /// *validation* from being answered by a substitute, and so stops the
+    /// single-use token from being spent on it.
+    @Test("apply's token-revalidation query is pinned, so the token survives a mid-apply swap")
+    func purgeApplyRefusesASwapDuringRevalidation() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("restic-station-apply-swap-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let fakeRestic = root.appendingPathComponent("restic", isDirectory: false)
+        try Data("original restic".utf8).write(to: fakeRestic)
+
+        let sourcePaths = [Self.setId: Set(["/Users/user/example/src"])]
+        let hostnames = [Self.setId: Set(["example-mac.local"])]
+        let swapPath = fakeRestic.path
+        let env = Self.makeEnv(
+            script: [], retention: nil, purgeExcludes: ["build/**"], reachableSecondaries: [true],
+            onSpawn: { argv in
+                guard argv.contains("snapshots") else { return }
+                try? Data("a replacement restic that is quite different".utf8).write(
+                    to: URL(fileURLWithPath: swapPath)
+                )
+            },
+            purgeSourcePaths: sourcePaths, purgeHostnames: hostnames,
+            resticPath: fakeRestic.path
+        )
+        defer { env.cleanUp() }
+
+        let secondary = try #require(env.secondaries.first)
+        let snapshotsJSON = try FixtureLoader.string("snapshots.json")
+        let snapshots = try parseSnapshots(Data(snapshotsJSON.utf8))
+        let plans = [env.primary, secondary].map { destination in
+            PurgePlan(
+                destinationId: destination.id, snapshots: snapshots,
+                sourcePaths: sourcePaths[Self.setId]!, hostnames: hostnames[Self.setId]!,
+                patterns: env.set.purgeExcludes
+            )
+        }
+        let token = try #require(try env.engine.issuePurgeToken(
+            set: env.set, destinations: [env.primary, secondary], plans: plans,
+            executable: try env.requireResticExecutable()
+        ))
+
+        // The first destination's revalidation query swaps the binary as it
+        // runs; the second destination's query is the one that must refuse.
+        env.fake.script = [env.primary, secondary].map { destination in
+            .init(
+                argvPrefix: [fakeRestic.path, "-r", destination.repoURL, "snapshots", "--json"],
+                stdoutLines: [snapshotsJSON]
+            )
+        }
+
+        await #expect(throws: PurgeApplyError.unavailable) {
+            _ = try await env.engine.runPurge(
+                set: env.set, destinations: [env.primary, secondary], token: token.value
+            )
+        }
+        #expect(
+            !env.resticArgvs.contains { $0.contains("rewrite") },
+            "nothing destructive may follow a revalidation the pinned binary did not answer"
+        )
+        // Single-use, and not used: the refusal happened before `consume`,
+        // so the operator can retry once the binary is restored instead of
+        // being told their preview is stale.
+        #expect(throws: Never.self) { _ = try env.engine.purgeTokenDestinationIDs(token.value) }
+    }
+
+    /// The classification half of #118, and a second instance of the same
+    /// defect the review found: `issuePurgeToken` let a bare
+    /// `PreviewTokenError` escape, where `runPurgeLocked` wraps its own.
+    /// `classifyPurgeOperation` knows nothing about the bare error, so an
+    /// unusable confirmation store lost the specific advice #117 added — on
+    /// the one path that *writes* the store, and so is likeliest to hit it.
+    ///
+    /// The fault is a directory where the token lock file belongs: root
+    /// ignores file modes and the `linux` CI job runs as root, so a
+    /// chmod-based denial would pass there for the wrong reason.
+    @Test("a preview whose token store is unusable says so, instead of failing generically")
+    func purgePreviewReportsAnUnusableTokenStore() async throws {
+        let sourcePaths = [Self.setId: Set(["/Users/user/example/src"])]
+        let hostnames = [Self.setId: Set(["example-mac.local"])]
+        let env = Self.makeEnv(
+            script: [], retention: nil, purgeExcludes: ["build/**"], reachableSecondaries: [],
+            purgeSourcePaths: sourcePaths, purgeHostnames: hostnames
+        )
+        defer { env.cleanUp() }
+
+        try env.paths.ensureDirectories()
+        try FileManager.default.createDirectory(
+            at: env.paths.previewTokensLockFile, withIntermediateDirectories: true
+        )
+
+        let snapshotsJSON = try FixtureLoader.string("snapshots.json")
+        let snapshots = try parseSnapshots(Data(snapshotsJSON.utf8))
+        let snapshotIDs = snapshots.map(\.id)
+        let dryRun = try FixtureLoader.string("rewrite-dry-run.txt")
+            .replacingOccurrences(of: "09b3295c", with: snapshots[0].shortId)
+            .replacingOccurrences(of: "b2435423", with: snapshots[1].shortId)
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map(String.init)
+        env.fake.script = Self.resticCall(
+            ["-r", env.primary.repoURL, "snapshots", "--json"],
+            dest: Self.primaryId, stdoutLines: [snapshotsJSON]
+        ) + Self.resticCall(
+            ["-r", env.primary.repoURL, "rewrite", "--dry-run", "--exclude", "build/**"] + snapshotIDs,
+            dest: Self.primaryId, stdoutLines: dryRun
+        )
+
+        var thrown: (any Error)?
+        do {
+            _ = try await env.engine.previewPurgeSession(set: env.set, destinations: [env.primary])
+        } catch {
+            thrown = error
+        }
+        let error = try #require(thrown)
+        guard case .token(.storeUnusable) = try #require(error as? PurgeApplyError) else {
+            Issue.record("expected a wrapped storeUnusable, got \(error)")
+            return
+        }
+
+        // The wrap is only worth anything if it changes what the operator is
+        // told, so assert the rendered envelope and not just the case.
+        let failure = CLIFailure.classifyPurgeOperation(error, setId: Self.setId)
+        #expect(failure.code == .internalError)
+        #expect(
+            failure.message.contains("confirmation store"),
+            "the operator must be told which store is broken, not given a generic fault: \(failure.message)"
+        )
+        #expect(
+            failure.message.contains("data directory"),
+            "the advice #117 added must survive the preview path too: \(failure.message)"
+        )
+    }
+
     @Test("runPurge: a valid token revalidates ids, records rewrite mapping, and is single-use")
     func purgeApplyUsesTokenAndRecordsMapping() async throws {
         let sourcePaths = [Self.setId: Set(["/Users/user/example/src"])]
@@ -2710,7 +3130,8 @@ struct BackupEngineTests {
             sourcePaths: sourcePaths[Self.setId]!, hostnames: hostnames[Self.setId]!, patterns: env.set.purgeExcludes
         )
         let token = try #require(try env.engine.issuePurgeToken(
-            set: env.set, destinations: [env.primary], plans: [plan]
+            set: env.set, destinations: [env.primary], plans: [plan],
+            executable: try env.requireResticExecutable()
         ))
         // A repository can hold snapshots from another backup set. Fresh
         // validation sees this one, but attribution declines it and its id
@@ -2773,7 +3194,8 @@ struct BackupEngineTests {
             patterns: env.set.purgeExcludes
         )
         let token = try #require(try env.engine.issuePurgeToken(
-            set: env.set, destinations: [env.primary], plans: [plan]
+            set: env.set, destinations: [env.primary], plans: [plan],
+            executable: try env.requireResticExecutable()
         ))
         try env.paths.ensureDirectories()
         let runId = RunStore.formatRunId(kind: .purge, setId: Self.setId, date: Self.t0)
@@ -2836,7 +3258,8 @@ struct BackupEngineTests {
             patterns: env.set.purgeExcludes
         )
         let token = try #require(try env.engine.issuePurgeToken(
-            set: env.set, destinations: [env.primary], plans: [plan]
+            set: env.set, destinations: [env.primary], plans: [plan],
+            executable: try env.requireResticExecutable()
         ))
         let rewrite = try FixtureLoader.string("rewrite-forget.txt")
             .replacingOccurrences(of: "09b3295c", with: snapshots[0].shortId)
@@ -2895,7 +3318,8 @@ struct BackupEngineTests {
         }
 
         let expired = try #require(try env.engine.issuePurgeToken(
-            set: env.set, destinations: [env.primary], plans: [plan]
+            set: env.set, destinations: [env.primary], plans: [plan],
+            executable: try env.requireResticExecutable()
         ))
         env.clock.advance(PreviewTokenStore.defaultLifetime + 1)
         do {
@@ -2906,7 +3330,8 @@ struct BackupEngineTests {
         }
 
         let changed = try #require(try env.engine.issuePurgeToken(
-            set: env.set, destinations: [env.primary], plans: [plan]
+            set: env.set, destinations: [env.primary], plans: [plan],
+            executable: try env.requireResticExecutable()
         ))
         var snapshotObjects = try #require(JSONSerialization.jsonObject(with: Data(snapshotsJSON.utf8)) as? [[String: Any]])
         snapshotObjects.removeLast()
@@ -3191,7 +3616,11 @@ struct BackupEngineTests {
             stdoutLines: dryRun
         )
 
-        let result = await env.engine.previewPurge(set: env.set, destination: env.primary)
+        let result = await env.engine.previewPurge(
+            set: env.set,
+            destination: env.primary,
+            executable: try env.requireResticExecutable()
+        )
 
         #expect(result.status == .ready)
         #expect(result.plan.matched.map(\.id) == snapshotIDs)
@@ -3209,7 +3638,11 @@ struct BackupEngineTests {
         let env = Self.makeEnv(script: [], retention: nil, purgeExcludes: [], reachableSecondaries: [])
         defer { env.cleanUp() }
 
-        let result = await env.engine.previewPurge(set: env.set, destination: env.primary)
+        let result = await env.engine.previewPurge(
+            set: env.set,
+            destination: env.primary,
+            executable: try env.requireResticExecutable()
+        )
 
         #expect(result.status == .empty)
         #expect(result.plan.matched.isEmpty)
@@ -3231,10 +3664,16 @@ struct BackupEngineTests {
             withIntermediateDirectories: true
         )
 
-        let result = await env.engine.previewPurge(set: env.set, destination: env.primary)
+        let session = try await env.engine.previewPurgeSession(
+            set: env.set,
+            destinations: [env.primary]
+        )
+        let result = try #require(session.previews.first?.result)
 
         #expect(result.status == .infrastructureFailure)
         #expect(result.message?.contains("backup-set lock unusable") == true)
+        #expect(session.previews.count == 1)
+        #expect(session.token == nil, "an incomplete preview must never earn a purge capability")
         #expect(env.fake.invocations.isEmpty, "restic must not run after local lock refusal")
     }
 

--- a/Core/Tests/ResticStationCoreTests/Support/CLIErrorTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Support/CLIErrorTests.swift
@@ -50,7 +50,7 @@ private let representative: [CLIErrorCode: CLIFailure] = [
     ),
     .resticFailed: .classify(exitClass: .fatal(stderrSummary: "repository is damaged")),
     .operationTimedOut: .classify(ResticRunnerError.timedOut),
-    .previewExpired: .classifyPurgeApply(PurgeApplyError.token(.expired), setId: setId),
+    .previewExpired: .classifyPurgeOperation(PurgeApplyError.token(.expired), setId: setId),
     .internalError: .classify(ConfigStoreError.renameFailed(errno: 13, from: "a", to: "b")),
     // `repositoryOffline` is a `Reachability` result rather than an Error,
     // so this representative remains direct. `operationNotAllowed` is also
@@ -149,12 +149,12 @@ struct CLIErrorContractTests {
 
     @Test("purge token refusals use safe, actionable envelope codes")
     func purgeTokenClassification() {
-        let expired = CLIFailure.classifyPurgeApply(PurgeApplyError.token(.expired), setId: setId)
+        let expired = CLIFailure.classifyPurgeOperation(PurgeApplyError.token(.expired), setId: setId)
         #expect(expired.code == .previewExpired)
         #expect(expired.details.setId == setId)
         #expect(!expired.retryable)
 
-        let stale = CLIFailure.classifyPurgeApply(PurgeApplyError.tokenDoesNotMatchCurrentPlan, setId: setId)
+        let stale = CLIFailure.classifyPurgeOperation(PurgeApplyError.tokenDoesNotMatchCurrentPlan, setId: setId)
         #expect(stale.code == .operationNotAllowed)
         #expect(stale.details.setId == setId)
         #expect(!stale.message.contains("token"), "capabilities never appear in an envelope")

--- a/Core/Tests/ResticStationCoreTests/Support/FakeSecretStore.swift
+++ b/Core/Tests/ResticStationCoreTests/Support/FakeSecretStore.swift
@@ -24,6 +24,7 @@ final class FakeSecretStore: SecretStore, @unchecked Sendable {
     private var _failingPasswords: Set<UUID> = []
     private var _failingSecretEnvs: Set<UUID> = []
     private let defaultPassword: String?
+    private let onPasswordRead: (@Sendable (UUID) -> Void)?
 
     /// Which backend this fake stands in for. Defaults to the platform's, so
     /// a test that does not care gets the wording a real host would produce.
@@ -37,10 +38,12 @@ final class FakeSecretStore: SecretStore, @unchecked Sendable {
     ///     wording derived from it.
     init(
         defaultPassword: String? = FakeSecretStore.standardPassword,
-        backend: SecretBackend = .platformDefault
+        backend: SecretBackend = .platformDefault,
+        onPasswordRead: (@Sendable (UUID) -> Void)? = nil
     ) {
         self.defaultPassword = defaultPassword
         self.backend = backend
+        self.onPasswordRead = onPasswordRead
     }
 
     // MARK: - Test configuration
@@ -72,6 +75,7 @@ final class FakeSecretStore: SecretStore, @unchecked Sendable {
     }
 
     func password(destId: UUID) async throws -> String {
+        onPasswordRead?(destId)
         let outcome: Result<String, SecretStoreError> = withLock {
             if _failingPasswords.contains(destId) {
                 return .failure(.backendFailed("fake: password read failed"))

--- a/Helper/Sources/Commands/Purge.swift
+++ b/Helper/Sources/Commands/Purge.swift
@@ -115,18 +115,31 @@ struct PurgePreview: AsyncParsableCommand, JSONRenderable {
             destinations = backupSet.destinations
         }
 
-        var results: [(destination: Destination, result: PurgePlanResult)] = []
-        for destination in destinations {
-            let result = await context.engine.previewPurge(set: backupSet, destination: destination)
-            try Self.validate(result: result, setId: set, destination: destination)
-            results.append((destination, result))
+        // One session, so every destination's transcript and the token that
+        // follows them describe the same restic binary. Previewing each
+        // destination here and attaching an identity afterwards is exactly
+        // the ordering #118 removed.
+        let session: PurgePreviewSession
+        do {
+            session = try await context.engine.previewPurgeSession(
+                set: backupSet,
+                destinations: destinations
+            )
+        } catch {
+            // Classified, not rethrown bare. `PurgeApplyError` means nothing
+            // to the generic mapper, which lands every case on
+            // `internal_error` — so "restic is missing" reached the operator
+            // as an internal fault, in the one command whose entire job is
+            // to tell them what is about to happen.
+            throw CLIFailure.classifyPurgeOperation(error, setId: set)
         }
-        let previewToken = try context.engine.issuePurgeToken(
-            set: backupSet,
-            destinations: results.map(\.destination),
-            plans: results.map { $0.result.plan }
-        )?.value
-        let reports = results.map {
+        // The session stops at the first destination that did not finish, so
+        // this reports that destination's failure and never a later one's.
+        for preview in session.previews {
+            try Self.validate(result: preview.result, setId: set, destination: preview.destination)
+        }
+        let previewToken = session.token?.value
+        let reports = session.previews.map {
             Report(setId: set, destination: $0.destination, result: $0.result, previewToken: previewToken)
         }
 
@@ -254,7 +267,7 @@ struct PurgeApply: AsyncParsableCommand, JSONRenderable {
         do {
             destinationIDs = try context.engine.purgeTokenDestinationIDs(previewToken)
         } catch {
-            throw CLIFailure.classifyPurgeApply(error, setId: set)
+            throw CLIFailure.classifyPurgeOperation(error, setId: set)
         }
         let destinations = destinationIDs.compactMap { id in
             backupSet.destinations.first(where: { $0.id == id })
@@ -275,7 +288,7 @@ struct PurgeApply: AsyncParsableCommand, JSONRenderable {
                 token: previewToken
             )
         } catch {
-            throw CLIFailure.classifyPurgeApply(error, setId: set)
+            throw CLIFailure.classifyPurgeOperation(error, setId: set)
         }
 
         guard result.status == .success else {


### PR DESCRIPTION
Fixes #118. Fix-forward for the post-merge review of #109 at exact head `922f3a8`.

**Rebased onto merged #117.** The exact current pair is `main` at `d566e2d` → `4cc8ffb`, with one commit. Rebase reconciliation preserves #117's infrastructure-failure taxonomy and public apply-classifier spelling, keeps later token tests on explicit executable identities, returns empty-policy previews before requiring restic, and pins remote reachability probes in both preview and apply.

## What was wrong

#109 bound the purge token to a restic executable — that closed a swap during the operator's review window, which is the long one. It resolved that executable **after** the previews had run, so the transcript the operator read and the capability they authorized were not guaranteed to name the same program.

For a single destination that window is sub-millisecond. For several it is the whole of every later destination's network round trips, because `issuePurgeToken` waited for all of them. X previews destination A, Y previews B, and the one shared token binds only Y.

Red-checking the new multi-destination test against the old ordering prints the token being minted anyway:

```
✘ Expectation failed: (session.token → PreviewToken(value: "rj837e7...",
    destinations: [PreviewTokenDestination(destinationId: 0A1B2C3D-…, snapshotIDs: […]),
                   PreviewTokenDestination(destinationId: 1B2C3D4E-…, snapshotIDs: […])],
    …)) == nil
```

## What changed

`previewPurgeSession(set:destinations:)` is now the only public way to obtain a purge token. It resolves the executable **before the first query**, pins every preview command to it, and mints the token against that same identity. `previewPurge` and `issuePurgeToken` are internal, so a future caller cannot generate plans and attach an unrelated identity later — the same move `922f3a8` made for `purgeChild`, applied one level up.

Apply's `currentPurgePlan` snapshot query is pinned too.

## Where I disagree with the review on severity

The review rates the apply-time variant alongside the preview one. It isn't equivalent: the destructive launch was **already** pinned, so `ResticRunner.execute` rechecks the identity and refuses. That path failed *closed*.

The real residual defect is narrower — a substituted binary answering the revalidation query could make the *staleness* check pass when the repository had actually changed. It could never widen the purge, because the rewritten ids must equal the token's exactly. But it did cost something concrete: the single-use token was **consumed** on that answer. Red-checking that test gives `alreadyUsed` — the operator's preview is spent and they are told it is stale, when the truth is that a binary changed underneath them. That is why it is fixed here rather than deferred.

## Second instance of the classification bug

The review found `PurgePreview` never calling `classifyPurgeApply`, so a missing restic binary rendered as `internal_error`. Renamed to `classifyPurgeOperation` — preview mints the capability and raises the same errors, and the narrower name is what made it look inapplicable.

There is a more reachable sibling the review did not reach: `issuePurgeToken` let a bare `PreviewTokenError` escape where `runPurgeLocked` wraps its own. So an unusable confirmation store also fell to the generic mapper, losing the specific "check the permissions on the data directory" advice #117 added — on the one path that *writes* that store, and so is likeliest to hit it. Now wrapped, and the test asserts the rendered message, not just the error case.

## A test-integrity fix in #109's own suite

`Env.resticArgvs` filtered on the static fixture path. The executable-swap tests deliberately point the engine at a binary they may modify, so in exactly those tests the filter matched nothing and every `!env.resticArgvs.contains { $0.contains("rewrite") }` — each commented as "the decisive assertion" — was vacuously true. It now filters on the path the env configured. Those assertions were correct all along; they were simply not being evaluated.

## Verification

Every new test was red-checked against the old behavior, and each red is the finding itself rather than an incidental failure. The first draft of the multi-destination test went red only because the fake process script ran out — it was rewritten to script both destinations fully, so the refusal now comes from the pin.

`scripts/local-ci.sh`: root/Core/App tests, xcodegen, app build, integration, secret CLI, headless CLI — all pass. Linux cross-compile skipped locally (no static SDK); CI covers it.

## Not covered end to end

The CLI-level assertion the review asked for — `purge preview --json` emitting `restic_not_found` — is not here, and not because it was skipped. To reach that error the binary must resolve at `HelperContext.make()` (which *executes* `restic version --json`) and then fail to hash. The only thing that discriminates those is an execute-but-not-read binary, which root ignores — and the `linux` CI job runs as root, so it would pass there for the wrong reason. The mapping is covered in `CLIErrorTests`, and the store-unusable test asserts the rendered envelope; the command-to-classifier wiring itself rests on the `do`/`catch` being present.

## Left open deliberately

Hashing is still not atomic with execution: the runner resolves and hashes a path, then hands the *pathname* to `Foundation.Process`. A symlink retarget in that window still executes unhashed bytes. A complete fix needs an `fexecve`-style launch or an owner-only staged copy. The retention analogue in `AppModel+Maintenance` has the correct ordering already but its `forget --dry-run` queries are still unpinned; an X→Y→X change survives helper-side fingerprint validation. Both are noted in #118.

