### PR TITLE
Make failure classification exhaustive at the type level

### DIFF
--- a/Core/Sources/ResticStationCore/Engine/BackupEngine.swift
+++ b/Core/Sources/ResticStationCore/Engine/BackupEngine.swift
@@ -1147,7 +1147,10 @@ public final class BackupEngine: Sendable {
                     return .completed(.success)
                 case .warningIncompleteRead:
                     return .completed(.warning)
-                default:
+                case .fatal, .repoDoesNotExist, .repoLocked, .wrongPassword, .other:
+                    // Every failing exit class keeps its own identity in the
+                    // typed result; enumerated (no `default`) so a new
+                    // `ResticExitClass` case must choose a lane here.
                     return .failed(.restic(outcome.status))
                 }
             case .didNotRun:
@@ -2449,7 +2452,10 @@ public final class BackupEngine: Sendable {
             case .warningIncompleteRead:
                 status = .warning
                 errorSummary = outcome.status.userFacingMessage
-            default:
+            case .fatal, .repoDoesNotExist, .repoLocked, .wrongPassword, .other:
+                // Enumerated (no `default`) so a new `ResticExitClass` case
+                // must decide its run status here rather than silently
+                // recording `.failed`.
                 status = .failed
                 errorSummary = outcome.status.userFacingMessage
             }
@@ -2812,7 +2818,13 @@ public final class BackupEngine: Sendable {
             return reason
         case .token(.storeUnusable(let detail)):
             return "preview-token store unusable — \(detail)"
-        default:
+        case .token(.unavailable), .token(.unknown), .token(.expired),
+             .token(.alreadyUsed), .tokenDoesNotMatchCurrentPlan, .busy,
+             .destinationOffline, .unavailable, .resticUnavailable:
+            // Refusals and transient conditions, not broken infrastructure.
+            // Enumerated (no `default`) so a new `PurgeApplyError` or
+            // `PreviewTokenError` case must decide whether it is an
+            // infrastructure fault instead of silently reading as "not one".
             return nil
         }
     }

--- a/Core/Sources/ResticStationCore/Support/CLIError.swift
+++ b/Core/Sources/ResticStationCore/Support/CLIError.swift
@@ -433,7 +433,14 @@ extension CLIFailure {
                 ),
                 details: CLIErrorDetails(setId: setId)
             )
-        case .token, .tokenDoesNotMatchCurrentPlan:
+        case .token(.unavailable), .token(.unknown), .token(.alreadyUsed),
+             .tokenDoesNotMatchCurrentPlan:
+            // Deliberately one opaque refusal for all four: a caller must not
+            // be able to probe the token store for whether a value is
+            // unknown, spent, or merely stale. Spelled case-by-case (no
+            // `.token` catch-all) so a new `PreviewTokenError` case is a
+            // compile error here instead of silently inheriting this
+            // fail-closed wording.
             return CLIFailure(
                 code: .operationNotAllowed,
                 message: "The purge preview does not match the current plan. Run purge preview again.",
@@ -749,12 +756,19 @@ extension CLIFailure {
                     versionSupported: String(supported)
                 )
             )
-        default:
+        case .remoteMaintenanceRequiresSFTP, .notExactlyOnePrimaryDestination,
+             .duplicateIdentifier, .emptySources, .relativeSourcePath,
+             .emptyPurgeExcludePattern, .invalidSchedule,
+             .invalidStalenessWarningDays, .invalidReadDataSubsetSlices,
+             .invalidMachineIdKey, .relativeOverrideSourcePath,
+             .notExactlyOnePrimaryDestinationForMachine:
             // Every other case is a validation failure of a config this
             // build *can* read. They are one code on purpose: a caller
             // fixes them all the same way — edit config.json — and the
             // per-field detail is in `message`, which is where a human
-            // needs it.
+            // needs it. Enumerated (no `default`) so a future `ConfigError`
+            // case must be classified here deliberately rather than
+            // inheriting this collapse by omission.
             return CLIFailure(code: .configInvalid, message: bounded(error.description))
         }
     }

--- a/Core/Tests/ResticStationCoreTests/Locking/LockingHealthClassificationTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Locking/LockingHealthClassificationTests.swift
@@ -1,0 +1,91 @@
+import Foundation
+import Testing
+@testable import ResticStationCore
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
+
+// The lock-health contention-vs-breakage taxonomy, pinned as a table.
+//
+// `LockingHealth.classifyHealthArtifactFailure` decides whether damage found
+// on a *health-only* artifact proves a machine-wide production outage or is
+// merely diagnostic failure. Unlike the other classification taxonomies,
+// `LockFailure.operation` is a string (it names the failing syscall or
+// policy check), so this classifier cannot be made compile-time exhaustive
+// without retyping every `LockFailure` construction site — which PR-conflict
+// constraints rule out for now. This table is the runtime substitute: it
+// enumerates **every operation string the health-artifact probes can
+// produce** and pins each one's scope, so a new or renamed operation that
+// silently changes classification fails a named row here.
+
+@Suite("classification table: lock-health artifact failures")
+struct LockingHealthClassificationTests {
+
+    /// The capabilities the health artifacts exist to exercise. A failure of
+    /// one of these is a production outage even when it happens on a
+    /// health-only inode: the filesystem refused a lock, an inode
+    /// allocation, or a directory creation it would also refuse production.
+    private static let machineWideOperations: [String] = [
+        "flock",
+        "create lock probe",
+        "create protected directory",
+    ]
+
+    /// Every other operation string the health-artifact code paths
+    /// (`FileLock.probeLocking`, `FileLock.ensureDirectory` on the scratch
+    /// directory, `FileLock.probeActualCreation`) can put in a
+    /// `LockFailure`. Damage to the artifact itself is inconclusive about
+    /// production locks, so these classify as `.diagnostic`.
+    private static let diagnosticOperations: [String] = [
+        // open/verify of the health lock file itself
+        "open",
+        "fstat",
+        "file type",
+        "ownership",
+        "fchmod",
+        "fstat after fchmod",
+        "permissions",
+        // scratch-directory creation and repair
+        "fchmod created protected directory",
+        "open protected directory",
+        "fstat protected directory",
+        "protected directory type",
+        "protected directory ownership",
+        "fchmod protected directory",
+        "fstat after protected directory fchmod",
+        "protected directory permissions",
+        "trusted directory boundary",
+        // probe-file lifecycle
+        "remove lock probe",
+    ]
+
+    @Test("capability failures on health artifacts are machine-wide outages")
+    func machineWideRows() {
+        for operation in Self.machineWideOperations {
+            let classified = LockingHealth.classifyHealthArtifactFailure(
+                LockFailure(path: "/data/locks/health.lock", operation: operation, errnoValue: ENOSPC)
+            )
+            #expect(classified.scope == .machine, "\(operation)")
+        }
+    }
+
+    @Test("artifact-integrity failures stay diagnostic")
+    func diagnosticRows() {
+        for operation in Self.diagnosticOperations {
+            let classified = LockingHealth.classifyHealthArtifactFailure(
+                LockFailure(path: "/data/locks/health.lock", operation: operation, errnoValue: 0)
+            )
+            #expect(classified.scope == .diagnostic, "\(operation)")
+        }
+    }
+
+    @Test("the two tables never overlap or drift into each other")
+    func tablesAreDisjoint() {
+        #expect(Set(Self.machineWideOperations).isDisjoint(with: Set(Self.diagnosticOperations)))
+    }
+}

--- a/Core/Tests/ResticStationCoreTests/Locking/LockingHealthClassificationTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Locking/LockingHealthClassificationTests.swift
@@ -88,4 +88,81 @@ struct LockingHealthClassificationTests {
     func tablesAreDisjoint() {
         #expect(Set(Self.machineWideOperations).isDisjoint(with: Set(Self.diagnosticOperations)))
     }
+
+    // MARK: - Producer binding
+
+    // The rows above pin the classifier against synthetic `LockFailure`s;
+    // these bind the rows to the *producers*, by driving the real probe code
+    // paths into failure and classifying what they actually emit. A renamed
+    // operation string in `FileLock` now fails here instead of silently
+    // falling through `classifyHealthArtifactFailure` to `.diagnostic`
+    // while the synthetic table keeps passing on the old spelling.
+    //
+    // "flock" is the one machine-wide row with no portably drivable
+    // producer: its failure arm needs the syscall itself to fail (an
+    // flock-less filesystem), which no temp-directory setup can simulate.
+    // It stays table-only, pinned additionally by the contention tests in
+    // FileLockTests exercising the surrounding switch.
+
+    private func makeTempDirectory() throws -> URL {
+        let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("lh-producer-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: directory, withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        return directory
+    }
+
+    @Test(
+        "probeActualCreation's real failure classifies machine-wide",
+        .enabled(if: canInjectPermissionFaults, "root can create in mode-0500 directories")
+    )
+    func actualCreationProbeFailureIsBoundToItsRow() throws {
+        let directory = try makeTempDirectory()
+        defer {
+            chmod(directory.path, 0o700)
+            try? FileManager.default.removeItem(at: directory)
+        }
+        try #require(chmod(directory.path, 0o500) == 0)
+
+        let failure = try #require(
+            FileLock.probeActualCreation(in: directory),
+            "an unwritable directory must fail the creation probe"
+        )
+        #expect(Self.machineWideOperations.contains(failure.operation),
+                "producer emitted \(failure.operation), which has no machine-wide row")
+        #expect(LockingHealth.classifyHealthArtifactFailure(failure).scope == .machine)
+    }
+
+    @Test(
+        "ensureDirectory's real creation failure classifies machine-wide",
+        .enabled(if: canInjectPermissionFaults, "root can create in mode-0500 directories")
+    )
+    func ensureDirectoryCreateFailureIsBoundToItsRow() throws {
+        let root = try makeTempDirectory()
+        defer {
+            chmod(root.appendingPathComponent("parent").path, 0o700)
+            try? FileManager.default.removeItem(at: root)
+        }
+        let parent = root.appendingPathComponent("parent")
+        try FileManager.default.createDirectory(
+            at: parent, withIntermediateDirectories: false,
+            attributes: [.posixPermissions: 0o700]
+        )
+        try #require(chmod(parent.path, 0o500) == 0)
+
+        let failure = try #require(
+            FileLock.ensureDirectory(
+                parent.appendingPathComponent("locks"),
+                parent: parent,
+                trustedRoot: root,
+                mode: 0o700
+            ),
+            "creation under an unwritable parent must fail"
+        )
+        #expect(Self.machineWideOperations.contains(failure.operation),
+                "producer emitted \(failure.operation), which has no machine-wide row")
+        #expect(LockingHealth.classifyHealthArtifactFailure(failure).scope == .machine)
+    }
 }

--- a/Core/Tests/ResticStationCoreTests/Support/FailureClassificationTableTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Support/FailureClassificationTableTests.swift
@@ -1,0 +1,345 @@
+import Foundation
+import Testing
+@testable import ResticStationCore
+
+// Exhaustive, table-driven pins for every failure-classification mapping —
+// one table per taxonomy, one row per enum case.
+//
+// The companion change in the classifiers themselves removed every
+// `default:` arm and every `.token`-style catch-all sub-pattern, so **adding
+// an enum case now fails compilation at each classifier**. These tables are
+// the runtime half of that guarantee: each `expected…` function below is
+// itself an exhaustive `switch` (no `default`), so a new case also fails
+// compilation *here*, in the file whose whole job is to make the author
+// write down the intended mapping — and each `cases` list is checked for
+// completeness where `CaseIterable` exists.
+//
+// Motivation: PR #117 fixed ~17 call sites that collapsed typed failures to
+// generic `.failed`/`internal_error`/wrong-retryable codes, one review round
+// at a time. This file is what turns the next instance of that bug shape
+// into a compile error plus a single failing row.
+
+private let setId = UUID(uuidString: "6B29FC40-CA47-1067-B31D-00DD010662DA")!
+private let destId = UUID(uuidString: "0A1B2C3D-4E5F-4A1B-8C1D-000000000001")!
+
+// MARK: - CLIErrorCode (the published envelope codes)
+
+@Suite("classification table: CLIErrorCode")
+struct CLIErrorCodeTableTests {
+
+    /// Every published code → (wire name, process exit code, retryable).
+    /// `CLIErrorCode` is `CaseIterable`, so a case added without a row makes
+    /// the completeness test below fail by itself.
+    private static let rows: [(code: CLIErrorCode, raw: String, exit: HelperExitCode, retryable: Bool)] = [
+        (.invalidArguments, "invalid_arguments", .error, false),
+        (.configInvalid, "config_invalid", .error, false),
+        (.setNotFound, "set_not_found", .error, false),
+        (.setDisabledHere, "set_disabled_here", .error, false),
+        (.destinationNotFound, "destination_not_found", .error, false),
+        (.destinationDisabledHere, "destination_disabled_here", .error, false),
+        (.runNotFound, "run_not_found", .error, false),
+        (.setBusy, "set_busy", .busy, true),
+        (.repositoryOffline, "repository_offline", .offline, true),
+        (.repositoryLocked, "repository_locked", .error, true),
+        (.secretUnavailable, "secret_unavailable", .error, true),
+        (.secretRejected, "secret_rejected", .error, false),
+        (.secretNotConfigured, "secret_not_configured", .error, false),
+        (.repositoryNotInitialized, "repository_not_initialized", .error, false),
+        (.resticNotFound, "restic_not_found", .error, false),
+        (.resticUnsupported, "restic_unsupported", .error, false),
+        (.resticFailed, "restic_failed", .error, false),
+        (.operationTimedOut, "operation_timed_out", .error, true),
+        (.previewExpired, "preview_expired", .error, false),
+        (.operationNotAllowed, "operation_not_allowed", .error, false),
+        (.operationCompletedAuditFailed, "operation_completed_audit_failed", .error, false),
+        (.internalError, "internal_error", .error, false),
+    ]
+
+    @Test("every case has exactly one row")
+    func tableIsComplete() {
+        #expect(Set(Self.rows.map(\.code)) == Set(CLIErrorCode.allCases))
+        #expect(Self.rows.count == CLIErrorCode.allCases.count)
+    }
+
+    @Test("each row pins wire name, exit code, and retryable bit")
+    func rowsMatchImplementation() {
+        for row in Self.rows {
+            #expect(row.code.rawValue == row.raw, "\(row.raw)")
+            #expect(row.code.exitCode == row.exit, "\(row.raw)")
+            #expect(row.code.retryable == row.retryable, "\(row.raw)")
+        }
+    }
+}
+
+// MARK: - PurgeApplyError (including every PreviewTokenError sub-case)
+
+@Suite("classification table: PurgeApplyError / PreviewTokenError")
+struct PurgeApplyErrorTableTests {
+
+    /// The intended envelope classification for every case, written as an
+    /// exhaustive switch: a new `PurgeApplyError` or `PreviewTokenError`
+    /// case fails compilation on this function until a mapping is chosen.
+    private static func expected(_ error: PurgeApplyError) -> (code: CLIErrorCode, retryable: Bool) {
+        switch error {
+        case .token(let tokenError):
+            switch tokenError {
+            case .expired:
+                return (.previewExpired, false)
+            case .storeUnusable:
+                return (.internalError, false)
+            case .unavailable, .unknown, .alreadyUsed:
+                // Deliberately opaque: a caller must not learn whether a
+                // token value is unknown, spent, or merely stale.
+                return (.operationNotAllowed, false)
+            }
+        case .tokenDoesNotMatchCurrentPlan:
+            return (.operationNotAllowed, false)
+        case .busy:
+            return (.setBusy, true)
+        case .lockUnusable:
+            return (.internalError, false)
+        case .infrastructureFailure(let reason, _):
+            return (reason.hasPrefix("operation_completed_audit_failed")
+                ? (.operationCompletedAuditFailed, false)
+                : (.internalError, false))
+        case .auditFailure:
+            return (.operationCompletedAuditFailed, false)
+        case .destinationOffline:
+            return (.repositoryOffline, true)
+        case .unavailable:
+            return (.secretUnavailable, true)
+        case .resticUnavailable:
+            return (.resticNotFound, false)
+        }
+    }
+
+    /// One concrete value per case (and per meaningful payload variant).
+    private static let cases: [PurgeApplyError] = [
+        .token(.unavailable),
+        .token(.storeUnusable("lock file owned by another user")),
+        .token(.unknown),
+        .token(.expired),
+        .token(.alreadyUsed),
+        .tokenDoesNotMatchCurrentPlan,
+        .busy,
+        .lockUnusable("open lock directory failed"),
+        .infrastructureFailure(reason: "run history unusable", operationMayHaveRun: false),
+        .infrastructureFailure(reason: "run history unusable", operationMayHaveRun: true),
+        .infrastructureFailure(
+            reason: "operation_completed_audit_failed — terminal audit persistence failed",
+            operationMayHaveRun: true
+        ),
+        .auditFailure(
+            reason: "operation_completed_audit_failed — prior destructive run needs inspection",
+            operationMayHaveRun: false,
+            runId: "20260825T210000Z-purge-deadbeef"
+        ),
+        .destinationOffline(destinationId: destId),
+        .unavailable,
+        .resticUnavailable,
+    ]
+
+    @Test("every case maps to its pinned envelope code, exit code, and retryable bit")
+    func rowsMatchClassifier() {
+        for error in Self.cases {
+            let failure = CLIFailure.classifyPurgeOperation(error, setId: setId)
+            let want = Self.expected(error)
+            #expect(failure.code == want.code, "\(error)")
+            #expect(failure.retryable == want.retryable, "\(error)")
+            #expect(failure.exitCode == want.code.exitCode, "\(error)")
+            #expect(failure.details.setId == setId, "\(error)")
+        }
+    }
+
+    @Test("no purge classification can leak token material")
+    func messagesNeverCarryTokens() {
+        for error in Self.cases {
+            let failure = CLIFailure.classifyPurgeOperation(error, setId: setId)
+            #expect(!failure.message.lowercased().contains("token value"), "\(error)")
+        }
+    }
+}
+
+// MARK: - ResticExitClass
+
+@Suite("classification table: ResticExitClass")
+struct ResticExitClassTableTests {
+
+    /// Exhaustive: (envelope code, published restic exit code, run-record
+    /// category). A new exit class fails compilation here.
+    private static func expected(
+        _ exitClass: ResticExitClass
+    ) -> (code: CLIErrorCode, resticExit: Int32?, category: ResticErrorCategory) {
+        switch exitClass {
+        case .success:
+            return (.internalError, nil, .success)
+        case .warningIncompleteRead:
+            return (.internalError, nil, .warning)
+        case .fatal:
+            return (.resticFailed, 1, .terminal)
+        case .repoDoesNotExist:
+            return (.repositoryNotInitialized, 10, .terminal)
+        case .repoLocked:
+            return (.repositoryLocked, 11, .retryable)
+        case .wrongPassword:
+            return (.secretRejected, 12, .terminal)
+        case .other(let raw):
+            return (.resticFailed, raw, .terminal)
+        }
+    }
+
+    private static let cases: [ResticExitClass] = [
+        .success,
+        .warningIncompleteRead,
+        .fatal(stderrSummary: "repository is damaged"),
+        .repoDoesNotExist,
+        .repoLocked,
+        .wrongPassword,
+        .other(130),
+    ]
+
+    @Test("every exit class maps to its pinned envelope code, restic exit, and category")
+    func rowsMatchClassifier() {
+        for exitClass in Self.cases {
+            let failure = CLIFailure.classify(exitClass: exitClass, setId: setId, destinationId: destId)
+            let want = Self.expected(exitClass)
+            #expect(failure.code == want.code, "\(exitClass)")
+            #expect(failure.details.resticExitCode == want.resticExit, "\(exitClass)")
+            #expect(failure.details.resticCategory == want.category, "\(exitClass)")
+            #expect(exitClass.category == want.category, "\(exitClass)")
+            #expect(failure.retryable == want.code.retryable, "\(exitClass)")
+        }
+    }
+}
+
+// MARK: - ResticRunnerError
+
+@Suite("classification table: ResticRunnerError")
+struct ResticRunnerErrorTableTests {
+
+    /// Exhaustive: (envelope code, retryable, run-record category).
+    private static func expected(
+        _ error: ResticRunnerError
+    ) -> (code: CLIErrorCode, retryable: Bool, category: ResticErrorCategory) {
+        switch error {
+        case .secretsUnavailable:
+            return (.secretUnavailable, true, .retryable)
+        case .secretsNotConfigured:
+            return (.secretNotConfigured, false, .terminal)
+        case .launchFailed:
+            return (.resticNotFound, false, .terminal)
+        case .timedOut:
+            return (.operationTimedOut, true, .terminal)
+        }
+    }
+
+    private static let cases: [ResticRunnerError] = [
+        .secretsUnavailable(destinationId: destId),
+        .secretsNotConfigured(destinationId: destId),
+        .launchFailed("no such file"),
+        .timedOut,
+    ]
+
+    @Test("every runner error maps to its pinned envelope code, retryable bit, and category")
+    func rowsMatchClassifier() {
+        for error in Self.cases {
+            let failure = CLIFailure.classify(error)
+            let want = Self.expected(error)
+            #expect(failure.code == want.code, "\(error)")
+            #expect(failure.retryable == want.retryable, "\(error)")
+            #expect(error.category == want.category, "\(error)")
+        }
+    }
+}
+
+// MARK: - SecretStoreError
+
+@Suite("classification table: SecretStoreError")
+struct SecretStoreErrorTableTests {
+
+    /// Exhaustive: envelope code and retryable bit per case.
+    private static func expected(_ error: SecretStoreError) -> (code: CLIErrorCode, retryable: Bool) {
+        switch error {
+        case .itemNotFound:
+            return (.secretNotConfigured, false)
+        case .lockUnusable:
+            return (.internalError, false)
+        case .backendFailed:
+            return (.secretUnavailable, true)
+        }
+    }
+
+    private static let cases: [SecretStoreError] = [
+        .itemNotFound,
+        .lockUnusable(LockFailure(path: "/data/locks/secrets.lock", operation: "ownership", errnoValue: 0)),
+        .backendFailed("security: exit 44"),
+    ]
+
+    @Test("every secret-store error maps to its pinned envelope code and retryable bit")
+    func rowsMatchClassifier() {
+        for error in Self.cases {
+            let failure = CLIFailure.classify(error)
+            let want = Self.expected(error)
+            #expect(failure.code == want.code, "\(error)")
+            #expect(failure.retryable == want.retryable, "\(error)")
+        }
+    }
+}
+
+// MARK: - ConfigError
+
+@Suite("classification table: ConfigError")
+struct ConfigErrorTableTests {
+
+    /// Every `ConfigError` case classifies as `config_invalid`; only
+    /// `newerVersion` additionally publishes the version pair in `details`.
+    /// The switch is exhaustive so a new case fails compilation here — the
+    /// classifier's own switch (`CLIFailure.classify(_: ConfigError)`) is now
+    /// case-exhaustive too, so both break together.
+    private static func expected(_ error: ConfigError) -> (code: CLIErrorCode, carriesVersions: Bool) {
+        switch error {
+        case .newerVersion:
+            return (.configInvalid, true)
+        case .remoteMaintenanceRequiresSFTP, .notExactlyOnePrimaryDestination,
+             .duplicateIdentifier, .emptySources, .relativeSourcePath,
+             .emptyPurgeExcludePattern, .invalidSchedule,
+             .invalidStalenessWarningDays, .invalidReadDataSubsetSlices,
+             .invalidMachineIdKey, .relativeOverrideSourcePath,
+             .notExactlyOnePrimaryDestinationForMachine:
+            return (.configInvalid, false)
+        }
+    }
+
+    private static let cases: [ConfigError] = [
+        .remoteMaintenanceRequiresSFTP(destinationId: destId),
+        .newerVersion(found: 4, supported: 3),
+        .notExactlyOnePrimaryDestination(setId: setId, count: 2),
+        .duplicateIdentifier(setId),
+        .emptySources(setId: setId),
+        .relativeSourcePath(setId: setId, path: "Documents"),
+        .emptyPurgeExcludePattern(setId: setId, index: 0),
+        .invalidSchedule(setId: setId, reason: "minute out of range"),
+        .invalidStalenessWarningDays(setId: setId, value: 0),
+        .invalidReadDataSubsetSlices(setId: setId, value: 1),
+        .invalidMachineIdKey(setId: setId, machineId: "Bad_Slug"),
+        .relativeOverrideSourcePath(setId: setId, machineId: "linux-nas", path: "Documents"),
+        .notExactlyOnePrimaryDestinationForMachine(setId: setId, machineId: "linux-nas", count: 0),
+    ]
+
+    @Test("every config error is config_invalid, non-retryable, exit 1")
+    func rowsMatchClassifier() {
+        for error in Self.cases {
+            let failure = CLIFailure.classify(error)
+            let want = Self.expected(error)
+            #expect(failure.code == want.code, "\(error)")
+            #expect(!failure.retryable, "\(error)")
+            #expect(failure.exitCode == .error, "\(error)")
+            if want.carriesVersions {
+                #expect(failure.details.versionFound == "4", "\(error)")
+                #expect(failure.details.versionSupported == "3", "\(error)")
+            } else {
+                #expect(failure.details.versionFound == nil, "\(error)")
+            }
+        }
+    }
+}

--- a/Helper/Sources/Commands/Maintenance.swift
+++ b/Helper/Sources/Commands/Maintenance.swift
@@ -178,23 +178,34 @@ struct MaintenancePrune: AsyncParsableCommand, JSONRenderable {
                 destinationId: destinationId,
                 effectiveDestinationFingerprint: fingerprint
             )
-        } catch PreviewTokenError.unavailable {
-            throw CLIFailure(
-                code: .setBusy,
-                message: "The reclaim confirmation is temporarily unavailable. Run the dry run again.",
-                details: CLIErrorDetails(setId: setId, destinationId: destinationId)
-            )
-        } catch PreviewTokenError.storeUnusable(let detail) {
-            // Not `set_busy`: "run the dry run again" is the wrong advice
-            // for a token store that no retry will fix (#110).
-            throw CLIFailure(
-                code: .internalError,
-                message: CLIFailure.bounded(
-                    "The confirmation store could not be used: \(detail). "
-                        + "Check the permissions on the Restic Station data directory."
-                ),
-                details: CLIErrorDetails(setId: setId, destinationId: destinationId)
-            )
+        } catch let error as PreviewTokenError {
+            // An exhaustive switch (no `default`, no partial catch list) so a
+            // new `PreviewTokenError` case must be classified here rather
+            // than falling through to whatever the generic mapper guesses.
+            switch error {
+            case .unavailable:
+                throw CLIFailure(
+                    code: .setBusy,
+                    message: "The reclaim confirmation is temporarily unavailable. Run the dry run again.",
+                    details: CLIErrorDetails(setId: setId, destinationId: destinationId)
+                )
+            case .storeUnusable(let detail):
+                // Not `set_busy`: "run the dry run again" is the wrong advice
+                // for a token store that no retry will fix (#110).
+                throw CLIFailure(
+                    code: .internalError,
+                    message: CLIFailure.bounded(
+                        "The confirmation store could not be used: \(detail). "
+                            + "Check the permissions on the Restic Station data directory."
+                    ),
+                    details: CLIErrorDetails(setId: setId, destinationId: destinationId)
+                )
+            case .unknown, .expired, .alreadyUsed:
+                // Consume-side refusals that issuing never raises. Rethrown
+                // unchanged — exactly what the previous partial catch list
+                // did — so behavior is identical if they ever appear.
+                throw error
+            }
         }
     }
 

--- a/Helper/Sources/Commands/RunSet.swift
+++ b/Helper/Sources/Commands/RunSet.swift
@@ -141,7 +141,9 @@ struct RunSet: AsyncParsableCommand {
             switch status {
             case .failed:
                 HelperExit.fail("backup failed — see the run log")
-            default:
+            case .success, .warning, .skipped, .running:
+                // Enumerated (no `default`) so a new `RunStatus` case must
+                // choose an exit here rather than silently printing success.
                 print("backup \(status.rawValue) (\(children.count) run\(children.count == 1 ? "" : "s"))")
             }
         case .skipped:


### PR DESCRIPTION
## What changed

No observable behavior changes. Every classifier that converts typed failures (`PurgeApplyError`/`PreviewTokenError`, `ConfigError`, `ResticExitClass`, `RunStatus`) into CLI codes, run statuses, or infrastructure-failure reasons now switches exhaustively — catch-all `default:` arms and partial catch lists are spelled out case-by-case, so adding a new failure case is a compile error at each decision point instead of a silent collapse (the #117 review pattern: the same typed-failure collapse re-found call site by call site across ~10 rounds). Two new table-driven test suites (11 tests) pin every case's current mapping — code, retryable bit, message identity — and the tables' own `expected()` switches are exhaustive, so an unclassified new case breaks both compile and test.

Deliberate collapses (the opaque token refusal that prevents probing the token store; the single `config_invalid` code) are preserved and now documented as deliberate at the match site.

**Candidate follow-ups found while auditing (not changed here, since this PR locks current behavior):**
1. `classifyPurgeOperation(.token(.unavailable))` maps transient store-lock contention to non-retryable `operation_not_allowed` with a "preview does not match" message, while the same condition is retryable `set_busy` in `MaintenancePrune.issueBinding` — wrong retry advice, wrong message.
2. `PreviewTokenStore.readIndex`/`writeIndex` map every failure — including a corrupt or wrong-mode index file — to retryable `.unavailable`; permanent damage reads as transient (the #110 shape).
3. Group purge reports any non-success child as `restic_failed` even when the child failed pre-restic (offline, secret unavailable).

Also noted: `LockingHealth.classifyHealthArtifactFailure` switches on the stringly `operation` field; it is pinned by an operation-string table test for now because retyping ~40 construction sites would collide with in-flight #130.

## Review anchor

An independent review applies to an exact `(base SHA, head SHA)` pair. Changing
the base can change the diff even when the head commit is identical, so these
must be filled in and **re-stated after any rebase, force-push, or retarget** —
a review against a superseded pair does not carry forward.

- Base SHA: `213da09f4229f7bdbf2a5df462ea9e45079999e8`
- Head SHA: `8731033b7da1b30271c715f18c10e5409732843a`
- Reviewed at this pair: Codex clean pass (thumbs-up) after the P2 fix in `8731033`

## Checklist

- [x] Spec docs in `docs/` updated in this PR if behavior changed (they are normative) — no behavior change; envelope codes/messages unchanged per the new table tests
- [x] `project.yml` edited rather than `ResticStation.xcodeproj` (it is generated) — neither touched
- [x] `Core/` and `Helper/` still build and test on Linux — no Darwin-only API added; local `swift build`/`swift test` (root + Core) green
- [x] Invariants preserved — classification-only refactor; the fail-closed opaque token refusal is preserved and documented
- [x] Destructive-path change? Touches purge/maintenance *classifiers* only; if a new failure case is added unclassified the code now fails to compile (fails closed) rather than inheriting a generic mapping (fails open).
- [x] Behavior change? No — blast radius swept anyway: no doc, UI copy, or envelope describes the removed `default:` arms
- [x] New/changed assertions red-checked — 7 mutations (retryable flips, code remaps, allowlist removal) each observed failing exactly the new table, then restored; dummy enum case produced exhaustiveness errors at all four classifiers
- [x] New or extended safety invariant? No new runtime invariant; compile-time enforcement of an existing convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KtczdRBghL2e9CxbXbrNMC
