### PR TITLE
Add a fault-injection crash matrix for run-record durability, fix a tail-repair bug it found

### DIFF
--- a/Core/Sources/ResticStationCore/Runs/RunStore.swift
+++ b/Core/Sources/ResticStationCore/Runs/RunStore.swift
@@ -949,10 +949,15 @@ public struct RunStore: Sendable {
 
         let runsDirectoryFD = try openDirectory(paths.runsDir)
         defer { closeFileDescriptor(runsDirectoryFD) }
+        // `O_APPEND` is load-bearing: the tail repair reads only with
+        // `pread`, which leaves the file offset at 0, so the terminating
+        // newline written for a complete newline-less final record would
+        // otherwise land on the first byte of the index — destroying the
+        // oldest record instead of finishing the newest one.
         let fd = fileOperations.openAt(
             runsDirectoryFD,
             paths.runsIndexFile.lastPathComponent,
-            O_RDWR | O_CLOEXEC | O_NOFOLLOW,
+            O_RDWR | O_APPEND | O_CLOEXEC | O_NOFOLLOW,
             0
         )
         guard fd >= 0 else {

--- a/Core/Tests/ResticStationCoreTests/Runs/RunStoreCrashDurabilityTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Runs/RunStoreCrashDurabilityTests.swift
@@ -410,10 +410,12 @@ import Musl
         }
 
         // `lineLength - 1` keeps the whole JSON record and tears only the
-        // newline — the complete-newline-less tail covered by
-        // `recoveryTerminatesNewlinelessTailAtTheEnd`; excluded here so the
-        // torn-fragment matrix stays focused on strict prefixes.
-        for offset in stride(from: 1, to: lineLength, by: 3) where offset != lineLength - 1 {
+        // newline — the complete-newline-less repair path also pinned by
+        // `recoveryTerminatesNewlinelessTailAtTheEnd`. Every other offset
+        // leaves a strict, undecodable prefix for truncation.
+        var offsets = Array(stride(from: 1, to: lineLength, by: 3))
+        if !offsets.contains(lineLength - 1) { offsets.append(lineLength - 1) }
+        for offset in offsets {
             let paths = makePaths()
             defer { cleanup(paths) }
             let (firstRunId, secondRunId) = try runFlow(paths: paths, tearAt: offset)
@@ -438,6 +440,50 @@ import Musl
             #expect(try recoveryStore.unresolvedAuditFailures().isEmpty)
             #expect(try recoveryStore.recoverInterrupted().isEmpty, "offset \(offset): not idempotent")
         }
+    }
+
+    /// A write torn one byte short of the end leaves a complete JSON record
+    /// with no trailing newline. Recovery must terminate that record *at
+    /// the end of the file* — before the `O_APPEND` fix in
+    /// `readIndexEntriesRepairingTail`, the terminating newline was written
+    /// through a descriptor whose offset was still 0 (the repair reads only
+    /// with `pread`), overwriting the first byte of `index.jsonl`:
+    /// destroying the oldest record while leaving the tail unterminated.
+    /// (The same repair through `appendIndexEntry` was safe all along: its
+    /// descriptor carries `O_APPEND`.)
+    @Test("recovery terminates a complete newline-less index tail at the end, not at byte 0")
+    func recoveryTerminatesNewlinelessTailAtTheEnd() throws {
+        let paths = makePaths()
+        defer { cleanup(paths) }
+        let tick = TickBox()
+        let store = RunStore(paths: paths, now: {
+            Self.start.addingTimeInterval(TimeInterval(tick.next()))
+        })
+        let first = try store.begin(
+            kind: .backup, setId: Self.setId, destId: Self.destId, trigger: .manual
+        )
+        try store.finish(first, status: .success, resticExitCode: 0)
+        let second = try store.begin(
+            kind: .backup, setId: Self.setId, destId: Self.destId, trigger: .manual
+        )
+        try store.finish(second, status: .success, resticExitCode: 0)
+
+        var indexBytes = try Data(contentsOf: paths.runsIndexFile)
+        try #require(indexBytes.last == 0x0A)
+        indexBytes.removeLast()
+        try indexBytes.write(to: paths.runsIndexFile)
+
+        #expect(try store.recoverInterrupted().isEmpty)
+
+        let repaired = try Data(contentsOf: paths.runsIndexFile)
+        #expect(repaired.first == UInt8(ascii: "{"), "recovery overwrote the head of the index")
+        #expect(repaired.last == 0x0A, "the newline-less tail was never terminated")
+        #expect(repaired.split(separator: 0x0A, omittingEmptySubsequences: true).count == 2)
+        let history = try store.recentRuns(limit: 10)
+        #expect(history.map(\.runId) == [second.runId, first.runId])
+        #expect(try store.unresolvedAuditFailures().isEmpty)
+        #expect(try store.recoverInterrupted().isEmpty)
+        #expect(try Data(contentsOf: paths.runsIndexFile) == repaired)
     }
 
     // MARK: - EINTR at every fsync site

--- a/Core/Tests/ResticStationCoreTests/Runs/RunStoreCrashDurabilityTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Runs/RunStoreCrashDurabilityTests.swift
@@ -1,0 +1,709 @@
+import Foundation
+import Testing
+@testable import ResticStationCore
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
+
+/// Crash-durability fault-injection tests for `RunStore` (and the
+/// `StateStore` atomic-write convention), driven through
+/// `FaultInjectingFileOperations` — see `docs/testing.md` §RunStore fault
+/// injection.
+///
+/// The ordering contracts under test (docs/data-model.md §runs/index.jsonl,
+/// §runs/<runId>/metadata.json):
+///
+/// 1. `begin`: newly created history ancestors and `runs/` are fsynced
+///    bottom-up, then `metadata.json` is written via temp → fsync(file) →
+///    `renameat` → fsync(run dir), and the new directory entry is made
+///    durable in `runs/` before `begin` returns.
+/// 2. `finish`: a durable two-phase transaction — terminal metadata with
+///    `indexPublicationPending: true` commits first (same atomic cycle),
+///    the index line is appended and fsynced (file, then directory) under
+///    `index.jsonl.lock`, and only then is the marker cleared.
+/// 3. `markDestructiveLaunchAuthorized`: the launch marker commits through
+///    the same atomic cycle before any destructive argv may run.
+/// 4. `recoverInterrupted`: repairs a torn index tail and fsyncs the
+///    snapshot before decoding it, republishes with marker-before-append,
+///    and is idempotent.
+///
+/// Each crash matrix simulates dying at EVERY seam-operation boundary of a
+/// flow, then "remounts" (fresh live `RunStore` over the same directory,
+/// with the dead process's pid marked unreachable where the on-disk record
+/// still claims `.running`) and asserts the recovered view is consistent:
+/// no acknowledged record lost, no phantom or divergent projection, no
+/// stuck pending marker, recovery idempotent.
+@Suite struct RunStoreCrashDurabilityTests {
+    private static let setId = UUID(uuidString: "6F9619FF-8B86-D011-B42D-00C04FC964FF")!
+    private static let destId = UUID(uuidString: "0B36BB67-4E34-4A34-9A9E-3B2C1D0E4F55")!
+    private static let start = Date(timeIntervalSince1970: 1_755_000_000)
+
+    private func makePaths() -> AppPaths {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("restic-station-crash-durability-\(UUID().uuidString)")
+        return AppPaths(root: root)
+    }
+
+    private func cleanup(_ paths: AppPaths) {
+        try? FileManager.default.removeItem(at: paths.root)
+    }
+
+    private func makeCrashStore(
+        paths: AppPaths,
+        crashAfter operations: Int
+    ) -> (RunStore, FaultInjectingFileOperations) {
+        let faults = FaultInjectingFileOperations()
+        faults.crashAfter(operations: operations)
+        let store = RunStore(
+            paths: paths,
+            now: { Self.start },
+            initialPublicationHook: { _ in },
+            fileOperations: faults.operations
+        )
+        return (store, faults)
+    }
+
+    /// The dead process's `.running` record still carries the test's own
+    /// live pid. A remount happens after that process is gone; make the
+    /// on-disk evidence agree before running recovery.
+    private func markRecordedProcessDead(runId: String, paths: AppPaths) throws {
+        let store = RunStore(paths: paths)
+        guard var metadata = try? store.metadata(runId: runId), metadata.status == .running else {
+            return
+        }
+        metadata.pid = 999_999
+        try writeRaw(metadata, paths: paths)
+    }
+
+    /// Asserts the invariant shared by every crash point once recovery has
+    /// run: a terminal canonical record, no pending marker, exactly one
+    /// logical projection agreeing with it, and idempotent recovery.
+    private func assertRecoveredHistoryIsConsistent(
+        paths: AppPaths,
+        runId: String,
+        crashPoint: Int
+    ) throws {
+        let store = RunStore(paths: paths)
+        let final = try store.metadata(runId: runId)
+        #expect(
+            final.status != .running,
+            "metadata still .running after recovery at crash point \(crashPoint)"
+        )
+        #expect(
+            final.indexPublicationPending == nil,
+            "pending marker survived recovery at crash point \(crashPoint)"
+        )
+        let history = try store.recentRuns(limit: 10)
+        #expect(
+            history.map(\.runId) == [runId],
+            "phantom or lost record at crash point \(crashPoint): \(history.map(\.runId))"
+        )
+        #expect(history.first?.status == final.status)
+
+        let indexBytes = try Data(contentsOf: paths.runsIndexFile)
+        let metadataBytes = try Data(contentsOf: paths.runMetadataFile(runId: runId))
+        #expect(try store.recoverInterrupted().isEmpty)
+        #expect(
+            try Data(contentsOf: paths.runsIndexFile) == indexBytes,
+            "second recovery rewrote the index at crash point \(crashPoint)"
+        )
+        #expect(try Data(contentsOf: paths.runMetadataFile(runId: runId)) == metadataBytes)
+    }
+
+    // MARK: - Contract 2: finish (non-destructive)
+
+    /// The largest argument doubles as the coverage check: the flow must
+    /// complete without reaching the crash point there, proving the range
+    /// still spans every step boundary.
+    @Test(
+        "a backup finish crashed at every step boundary recovers to a consistent history",
+        arguments: 0...24
+    )
+    func finishBackupCrashAtEveryStep(crashPoint: Int) throws {
+        let paths = makePaths()
+        defer { cleanup(paths) }
+        let liveStore = RunStore(paths: paths, now: { Self.start })
+        var run = try liveStore.begin(
+            kind: .backup, setId: Self.setId, destId: Self.destId, trigger: .manual
+        )
+        run.argvRedacted = ["restic", "backup", "/src", "--json"]
+
+        let (crashStore, faults) = makeCrashStore(paths: paths, crashAfter: crashPoint)
+        try? crashStore.finish(run, status: .success, resticExitCode: 0)
+        if crashPoint == 24 {
+            #expect(!faults.didCrash, "raise the crash-point upper bound: finish grew past it")
+        }
+        let acknowledged = !faults.didCrash
+
+        try markRecordedProcessDead(runId: run.runId, paths: paths)
+        let recoveryStore = RunStore(paths: paths)
+        _ = try recoveryStore.recoverInterrupted()
+
+        let final = try recoveryStore.metadata(runId: run.runId)
+        if acknowledged {
+            #expect(final.status == .success, "acknowledged finish lost at crash point \(crashPoint)")
+        } else {
+            #expect(final.status == .success || final.status == .failed)
+        }
+        #expect(try recoveryStore.unresolvedAuditFailures().isEmpty)
+        try assertRecoveredHistoryIsConsistent(paths: paths, runId: run.runId, crashPoint: crashPoint)
+    }
+
+    // MARK: - Contract 2 + destructive audit: finish (destructive)
+
+    @Test(
+        "a destructive finish crashed at every step boundary either publishes exactly once or fails closed",
+        arguments: 0...24
+    )
+    func finishDestructiveCrashAtEveryStep(crashPoint: Int) throws {
+        let paths = makePaths()
+        defer { cleanup(paths) }
+        let liveStore = RunStore(paths: paths, now: { Self.start })
+        var run = try liveStore.begin(
+            kind: .prune, setId: Self.setId, destId: Self.destId, trigger: .manual
+        )
+        run.argvRedacted = ["restic", "forget", "--keep-last", "3", "--prune"]
+        try liveStore.markDestructiveLaunchAuthorized(run)
+
+        let (crashStore, faults) = makeCrashStore(paths: paths, crashAfter: crashPoint)
+        try? crashStore.finish(run, status: .success, resticExitCode: 0)
+        if crashPoint == 24 {
+            #expect(!faults.didCrash, "raise the crash-point upper bound: finish grew past it")
+        }
+        let terminalLanded = try liveStore.metadata(runId: run.runId).status == .success
+
+        try markRecordedProcessDead(runId: run.runId, paths: paths)
+        let recoveryStore = RunStore(paths: paths)
+        _ = try recoveryStore.recoverInterrupted()
+
+        let final = try recoveryStore.metadata(runId: run.runId)
+        let failures = try recoveryStore.unresolvedAuditFailures()
+        if terminalLanded {
+            // The repository outcome was recorded before the crash; recovery
+            // must complete the projection and verification must go green.
+            #expect(final.status == .success)
+            #expect(failures.isEmpty, "crash point \(crashPoint): \(failures)")
+        } else {
+            // The process died after launch authorization with no terminal
+            // record: an unknown repository outcome must stay an explicit,
+            // unresolved audit failure — never a quiet success.
+            #expect(final.status == .failed)
+            #expect(final.auditFailureReason == .launchedWithoutTerminalMetadata)
+            #expect(final.errorSummary?.contains("operation_completed_audit_failed") == true)
+            #expect(failures.map(\.reason) == [.launchedWithoutTerminalMetadata])
+            #expect(failures.first?.runId == run.runId)
+        }
+        // Whatever else, the derived index must never diverge from or
+        // duplicate the canonical destructive record.
+        #expect(!failures.contains { $0.reason == .terminalMetadataIndexMismatch })
+        #expect(!failures.contains { $0.reason == .canonicalMetadataMissing })
+        try assertRecoveredHistoryIsConsistent(paths: paths, runId: run.runId, crashPoint: crashPoint)
+    }
+
+    // MARK: - Contract 1: begin
+
+    @Test(
+        "a begin crashed at every step boundary leaves no phantom history and recovers or fails closed",
+        arguments: 0...16
+    )
+    func beginCrashAtEveryStep(crashPoint: Int) throws {
+        let paths = makePaths()
+        defer { cleanup(paths) }
+        let (crashStore, faults) = makeCrashStore(paths: paths, crashAfter: crashPoint)
+        _ = try? crashStore.begin(
+            kind: .backup, setId: Self.setId, destId: Self.destId, trigger: .manual
+        )
+        if crashPoint == 16 {
+            #expect(!faults.didCrash, "raise the crash-point upper bound: begin grew past it")
+        }
+        let runId = RunStore.formatRunId(kind: .backup, setId: Self.setId, date: Self.start)
+
+        try markRecordedProcessDead(runId: runId, paths: paths)
+        let recoveryStore = RunStore(paths: paths)
+        _ = try recoveryStore.recoverInterrupted()
+
+        if (try? recoveryStore.metadata(runId: runId)) != nil {
+            // The initial commit reached the disk: the dead run must be
+            // reported as failed/interrupted history, exactly once.
+            let final = try recoveryStore.metadata(runId: runId)
+            #expect(final.status == .failed)
+            #expect(final.errorSummary == "interrupted")
+            #expect(try recoveryStore.unresolvedAuditFailures().isEmpty)
+            try assertRecoveredHistoryIsConsistent(paths: paths, runId: runId, crashPoint: crashPoint)
+        } else {
+            // The crash fell in the mkdir → first-metadata-commit window:
+            // an orphan run directory with no readable canonical record.
+            // History stays consistent (nothing was acknowledged, nothing
+            // is projected), recovery skips it, and destructive audit
+            // verification fails closed by refusing to read the unreadable
+            // canonical evidence (docs/data-model.md; there is currently no
+            // automated cleanup for this wreckage — deliberate posture).
+            #expect(FileManager.default.fileExists(atPath: paths.runDir(runId: runId).path))
+            #expect(try recoveryStore.recentRuns(limit: 10).isEmpty)
+            #expect(try recoveryStore.recoverInterrupted().isEmpty)
+            #expect(throws: (any Error).self) {
+                try recoveryStore.unresolvedAuditFailures()
+            }
+        }
+    }
+
+    // MARK: - Contract 3: markDestructiveLaunchAuthorized
+
+    @Test(
+        "a launch-marker write crashed at every step boundary is either fully durable or provably unstarted",
+        arguments: 0...10
+    )
+    func launchMarkerCrashAtEveryStep(crashPoint: Int) throws {
+        let paths = makePaths()
+        defer { cleanup(paths) }
+        let liveStore = RunStore(paths: paths, now: { Self.start })
+        var run = try liveStore.begin(
+            kind: .prune, setId: Self.setId, destId: Self.destId, trigger: .manual
+        )
+        run.argvRedacted = ["restic", "forget", "--keep-last", "3"]
+
+        let (crashStore, faults) = makeCrashStore(paths: paths, crashAfter: crashPoint)
+        try? crashStore.markDestructiveLaunchAuthorized(run)
+        if crashPoint == 10 {
+            #expect(!faults.didCrash, "raise the crash-point upper bound: the marker write grew past it")
+        }
+        let markerLanded = try liveStore.metadata(runId: run.runId).destructiveLaunchAuthorizedAt != nil
+
+        try markRecordedProcessDead(runId: run.runId, paths: paths)
+        let recoveryStore = RunStore(paths: paths)
+        _ = try recoveryStore.recoverInterrupted()
+
+        let final = try recoveryStore.metadata(runId: run.runId)
+        #expect(final.status == .failed)
+        let failures = try recoveryStore.unresolvedAuditFailures()
+        if markerLanded {
+            // The marker may have preceded an actual launch: unknown
+            // repository outcome, so recovery must fail closed.
+            #expect(final.auditFailureReason == .launchedWithoutTerminalMetadata)
+            #expect(failures.map(\.reason) == [.launchedWithoutTerminalMetadata])
+        } else {
+            // No durable marker under the current contract is affirmative
+            // evidence the destructive argv never ran: plain interruption.
+            #expect(final.errorSummary == "interrupted")
+            #expect(failures.isEmpty)
+        }
+        try assertRecoveredHistoryIsConsistent(paths: paths, runId: run.runId, crashPoint: crashPoint)
+    }
+
+    // MARK: - Contract 4: recovery itself crashing
+
+    @Test(
+        "recovery of a dead running record crashed at every step boundary completes on the next attempt",
+        arguments: 0...24
+    )
+    func recoveryOfDeadRunCrashAtEveryStep(crashPoint: Int) throws {
+        let paths = makePaths()
+        defer { cleanup(paths) }
+        let liveStore = RunStore(paths: paths, now: { Self.start })
+        let run = try liveStore.begin(
+            kind: .backup, setId: Self.setId, destId: Self.destId, trigger: .manual
+        )
+        var stuck = try liveStore.metadata(runId: run.runId)
+        stuck.pid = 999_999
+        try writeRaw(stuck, paths: paths)
+
+        let (crashStore, faults) = makeCrashStore(paths: paths, crashAfter: crashPoint)
+        _ = try? crashStore.recoverInterrupted()
+        if crashPoint == 24 {
+            #expect(!faults.didCrash, "raise the crash-point upper bound: recovery grew past it")
+        }
+
+        let recoveryStore = RunStore(paths: paths)
+        _ = try recoveryStore.recoverInterrupted()
+
+        let final = try recoveryStore.metadata(runId: run.runId)
+        #expect(final.status == .failed)
+        #expect(final.errorSummary == "interrupted")
+        #expect(try recoveryStore.unresolvedAuditFailures().isEmpty)
+        try assertRecoveredHistoryIsConsistent(paths: paths, runId: run.runId, crashPoint: crashPoint)
+    }
+
+    @Test(
+        "recovery of a pending destructive publication crashed at every step boundary still converges",
+        arguments: 0...16
+    )
+    func recoveryOfPendingPublicationCrashAtEveryStep(crashPoint: Int) throws {
+        let paths = makePaths()
+        defer { cleanup(paths) }
+        let run = try makePendingDestructivePublication(paths: paths)
+
+        let (crashStore, faults) = makeCrashStore(paths: paths, crashAfter: crashPoint)
+        _ = try? crashStore.recoverInterrupted()
+        if crashPoint == 16 {
+            #expect(!faults.didCrash, "raise the crash-point upper bound: recovery grew past it")
+        }
+
+        let recoveryStore = RunStore(paths: paths)
+        _ = try recoveryStore.recoverInterrupted()
+
+        let final = try recoveryStore.metadata(runId: run.runId)
+        #expect(final.status == .success)
+        #expect(try recoveryStore.unresolvedAuditFailures().isEmpty)
+        try assertRecoveredHistoryIsConsistent(paths: paths, runId: run.runId, crashPoint: crashPoint)
+    }
+
+    // MARK: - Torn index appends
+
+    /// Tears the physical index append of a second run at (nearly) every
+    /// byte offset — including inside the multibyte UTF-8 scalars its
+    /// `errorSummary` deliberately contains — then crashes and remounts.
+    /// Recovery must truncate the torn fragment without harming the valid
+    /// first record, republish the second run's projection, and leave a
+    /// newline-terminated index.
+    ///
+    /// One internal loop rather than `@Test(arguments:)`: the line length
+    /// (and so the offset range) is only known from the flow itself.
+    @Test func tornIndexAppendIsRepairedAtEveryOffset() throws {
+        let summary = "café 🚀 données — enregistrement déchiré"
+
+        func runFlow(paths: AppPaths, tearAt offset: Int?) throws -> (first: String, second: String) {
+            let tick = TickBox()
+            let store = RunStore(paths: paths, now: {
+                Self.start.addingTimeInterval(TimeInterval(tick.next()))
+            })
+            let first = try store.begin(
+                kind: .backup, setId: Self.setId, destId: Self.destId, trigger: .manual
+            )
+            try store.finish(first, status: .success, resticExitCode: 0)
+            let second = try store.begin(
+                kind: .backup, setId: Self.setId, destId: Self.destId, trigger: .manual
+            )
+            if let offset {
+                let faults = FaultInjectingFileOperations()
+                faults.tearWrite(toFileNamed: "index.jsonl", keepingBytes: offset)
+                let crashStore = RunStore(
+                    paths: paths,
+                    now: { Self.start.addingTimeInterval(TimeInterval(tick.next())) },
+                    initialPublicationHook: { _ in },
+                    fileOperations: faults.operations
+                )
+                try? crashStore.finish(
+                    second, status: .failed, errorSummary: summary, resticExitCode: 1
+                )
+                #expect(faults.didCrash, "the tear at offset \(offset) never engaged")
+            } else {
+                try store.finish(second, status: .failed, errorSummary: summary, resticExitCode: 1)
+            }
+            return (first.runId, second.runId)
+        }
+
+        // Measure the exact appended line once, with no faults.
+        let measured = makePaths()
+        let lineLength: Int
+        do {
+            defer { cleanup(measured) }
+            _ = try runFlow(paths: measured, tearAt: nil)
+            let lines = try Data(contentsOf: measured.runsIndexFile)
+                .split(separator: 0x0A, omittingEmptySubsequences: true)
+            try #require(lines.count == 2)
+            lineLength = lines[1].count + 1 // + trailing newline
+        }
+
+        // `lineLength - 1` keeps the whole JSON record and tears only the
+        // newline — the complete-newline-less tail covered by
+        // `recoveryTerminatesNewlinelessTailAtTheEnd`; excluded here so the
+        // torn-fragment matrix stays focused on strict prefixes.
+        for offset in stride(from: 1, to: lineLength, by: 3) where offset != lineLength - 1 {
+            let paths = makePaths()
+            defer { cleanup(paths) }
+            let (firstRunId, secondRunId) = try runFlow(paths: paths, tearAt: offset)
+
+            let recoveryStore = RunStore(paths: paths)
+            _ = try recoveryStore.recoverInterrupted()
+
+            let indexBytes = try Data(contentsOf: paths.runsIndexFile)
+            #expect(indexBytes.last == 0x0A, "offset \(offset): index not newline-terminated")
+            let lines = indexBytes.split(separator: 0x0A, omittingEmptySubsequences: true)
+            #expect(lines.count == 2, "offset \(offset): expected 2 physical lines, got \(lines.count)")
+
+            let history = try recoveryStore.recentRuns(limit: 10)
+            #expect(
+                history.map(\.runId) == [secondRunId, firstRunId],
+                "offset \(offset): lost or phantom record: \(history.map(\.runId))"
+            )
+            #expect(history.first?.status == .failed)
+            #expect(history.first?.errorSummary == summary, "offset \(offset): summary damaged")
+            #expect(history.last?.status == .success)
+            #expect(try recoveryStore.metadata(runId: secondRunId).indexPublicationPending == nil)
+            #expect(try recoveryStore.unresolvedAuditFailures().isEmpty)
+            #expect(try recoveryStore.recoverInterrupted().isEmpty, "offset \(offset): not idempotent")
+        }
+    }
+
+    // MARK: - EINTR at every fsync site
+
+    @Test func everyFsyncSiteInThePublicationFlowRetriesEINTR() throws {
+        func runFlow(_ faults: FaultInjectingFileOperations, paths: AppPaths) throws {
+            let store = RunStore(
+                paths: paths,
+                now: { Self.start },
+                initialPublicationHook: { _ in },
+                fileOperations: faults.operations
+            )
+            var run = try store.begin(
+                kind: .prune, setId: Self.setId, destId: Self.destId, trigger: .manual
+            )
+            run.argvRedacted = ["restic", "forget", "--keep-last", "3"]
+            try store.markDestructiveLaunchAuthorized(run)
+            try store.finish(run, status: .success, resticExitCode: 0)
+            #expect(try store.metadata(runId: run.runId).indexPublicationPending == nil)
+            #expect(try store.recentRuns(limit: 5).map(\.runId) == [run.runId])
+            #expect(try store.unresolvedAuditFailures().isEmpty)
+        }
+
+        let totalSyncCalls: Int
+        do {
+            let paths = makePaths()
+            defer { cleanup(paths) }
+            let counting = FaultInjectingFileOperations()
+            try runFlow(counting, paths: paths)
+            totalSyncCalls = counting.syncCallCount
+        }
+        try #require(totalSyncCalls >= 8, "expected the flow to fsync at several sites")
+
+        for call in 1...totalSyncCalls {
+            let paths = makePaths()
+            defer { cleanup(paths) }
+            let faults = FaultInjectingFileOperations()
+            faults.failSync(atCall: call, errno: EINTR)
+            do {
+                try runFlow(faults, paths: paths)
+            } catch {
+                Issue.record("EINTR at fsync call \(call) was treated as fatal: \(error)")
+            }
+            #expect(faults.syncCallCount > call, "fsync call \(call) was not retried")
+        }
+    }
+
+    @Test func everyFsyncSiteInRecoveryRetriesEINTR() throws {
+        func recover(_ faults: FaultInjectingFileOperations, paths: AppPaths, runId: String) throws {
+            let store = RunStore(
+                paths: paths,
+                now: { Self.start },
+                initialPublicationHook: { _ in },
+                fileOperations: faults.operations
+            )
+            _ = try store.recoverInterrupted()
+            #expect(try store.metadata(runId: runId).indexPublicationPending == nil)
+            #expect(try store.unresolvedAuditFailures().isEmpty)
+        }
+
+        let totalSyncCalls: Int
+        do {
+            let paths = makePaths()
+            defer { cleanup(paths) }
+            let run = try makePendingDestructivePublication(paths: paths)
+            let counting = FaultInjectingFileOperations()
+            try recover(counting, paths: paths, runId: run.runId)
+            totalSyncCalls = counting.syncCallCount
+        }
+        try #require(totalSyncCalls >= 4, "expected recovery to fsync at several sites")
+
+        for call in 1...totalSyncCalls {
+            let paths = makePaths()
+            defer { cleanup(paths) }
+            let run = try makePendingDestructivePublication(paths: paths)
+            let faults = FaultInjectingFileOperations()
+            faults.failSync(atCall: call, errno: EINTR)
+            do {
+                try recover(faults, paths: paths, runId: run.runId)
+            } catch {
+                Issue.record("EINTR at recovery fsync call \(call) was treated as fatal: \(error)")
+            }
+            #expect(faults.syncCallCount > call, "recovery fsync call \(call) was not retried")
+        }
+    }
+
+    // MARK: - Ordering traces
+
+    @Test("finish orders marker, append, and clear per the two-phase contract")
+    func finishTraceOrdersTwoPhasePublication() throws {
+        let paths = makePaths()
+        defer { cleanup(paths) }
+        let liveStore = RunStore(paths: paths, now: { Self.start })
+        let run = try liveStore.begin(
+            kind: .backup, setId: Self.setId, destId: Self.destId, trigger: .manual
+        )
+
+        let faults = FaultInjectingFileOperations()
+        let store = RunStore(
+            paths: paths,
+            now: { Self.start },
+            initialPublicationHook: { _ in },
+            fileOperations: faults.operations
+        )
+        try store.finish(run, status: .success, resticExitCode: 0)
+
+        let trace = faults.trace
+        let tempWrites = indices(of: trace) { $0 == .write(.file("metadata.json.tmp")) }
+        let tempSyncs = indices(of: trace) { $0 == .sync(.file("metadata.json.tmp")) }
+        let metadataRenames = indices(of: trace) {
+            if case .rename(_, let to) = $0 { return to == "metadata.json" }
+            return false
+        }
+        let indexWrites = indices(of: trace) { $0 == .write(.file("index.jsonl")) }
+        let indexSyncs = indices(of: trace) { $0 == .sync(.file("index.jsonl")) }
+        let directorySyncs = indices(of: trace) { $0 == .sync(.directory) }
+
+        try #require(tempWrites.count == 2, "expected exactly two metadata rewrites, got \(trace)")
+        try #require(tempSyncs.count == 2)
+        try #require(metadataRenames.count == 2)
+        try #require(indexWrites.count == 1)
+        try #require(indexSyncs.count >= 1)
+
+        // Phase 1 — terminal metadata (pending marker set): fully written
+        // and fsynced before the rename, directory entry fsynced after.
+        #expect(tempWrites[0] < tempSyncs[0])
+        #expect(tempSyncs[0] < metadataRenames[0])
+        #expect(directorySyncs.contains { $0 > metadataRenames[0] && $0 < indexWrites[0] })
+
+        // The marker commits strictly before the append it guards.
+        #expect(metadataRenames[0] < indexWrites[0])
+
+        // Phase 2 — the index line, then its file and directory fsyncs.
+        #expect(indexWrites[0] < indexSyncs[0])
+        #expect(directorySyncs.contains { $0 > indexSyncs[0] && $0 < tempWrites[1] })
+
+        // Phase 3 — the marker is cleared only after the projection is
+        // durable, through the same atomic cycle.
+        #expect(indexSyncs[0] < tempWrites[1])
+        #expect(tempWrites[1] < tempSyncs[1])
+        #expect(tempSyncs[1] < metadataRenames[1])
+        #expect(directorySyncs.contains { $0 > metadataRenames[1] })
+    }
+
+    @Test("begin syncs the history hierarchy before publication and the new entry after it")
+    func beginTraceOrdersHierarchyDurability() throws {
+        let paths = makePaths()
+        defer { cleanup(paths) }
+        let faults = FaultInjectingFileOperations()
+        let store = RunStore(
+            paths: paths,
+            now: { Self.start },
+            initialPublicationHook: { _ in },
+            fileOperations: faults.operations
+        )
+        _ = try store.begin(kind: .backup, setId: Self.setId, destId: Self.destId, trigger: .manual)
+
+        let trace = faults.trace
+        let firstTempOpen = try #require(
+            indices(of: trace) { $0 == .openAt("metadata.json.tmp") }.first
+        )
+        let tempWrites = indices(of: trace) { $0 == .write(.file("metadata.json.tmp")) }
+        let tempSyncs = indices(of: trace) { $0 == .sync(.file("metadata.json.tmp")) }
+        let metadataRenames = indices(of: trace) {
+            if case .rename(_, let to) = $0 { return to == "metadata.json" }
+            return false
+        }
+        let directorySyncs = indices(of: trace) { $0 == .sync(.directory) }
+
+        // runs/, the data root, and its first existing ancestor are all
+        // confirmed durable before the initial record is even opened.
+        #expect(directorySyncs.filter { $0 < firstTempOpen }.count >= 3)
+
+        try #require(tempWrites.count == 1 && tempSyncs.count == 1 && metadataRenames.count == 1)
+        #expect(tempWrites[0] < tempSyncs[0])
+        #expect(tempSyncs[0] < metadataRenames[0])
+        // After the rename: the run directory's own fsync, then the new
+        // directory entry made durable in runs/ before begin returns.
+        #expect(directorySyncs.filter { $0 > metadataRenames[0] }.count >= 2)
+    }
+
+    // MARK: - StateStore atomic-write convention
+
+    /// `state/` files promise atomic replacement (temp + rename), not
+    /// fsync durability — they are regenerable caches, with schedule
+    /// state's corruption handling covered by its own fail-closed tests.
+    /// A temp file abandoned by a crashed writer must neither block the
+    /// next write nor ever be visible to readers.
+    @Test func scheduleStateAtomicWriteSurvivesAStaleCrashTemp() throws {
+        let paths = makePaths()
+        defer { cleanup(paths) }
+        try paths.ensureDirectories()
+        let temp = paths.scheduleStateFile.deletingLastPathComponent()
+            .appendingPathComponent(
+                paths.scheduleStateFile.lastPathComponent + ".tmp", isDirectory: false
+            )
+        try Data("{\"sets\":{\"torn".utf8).write(to: temp)
+
+        let store = StateStore(paths: paths)
+        let setId = UUID()
+        try store.updateScheduleState(setId: setId) { $0.checkCount = 7 }
+        #expect(store.readScheduleStateResult().state?.sets[setId]?.checkCount == 7)
+
+        // A fresh torn temp (a writer dying right now) is invisible to the
+        // read path, which only ever opens the canonical file.
+        try Data("{\"sets\":{\"torn again".utf8).write(to: temp)
+        #expect(store.readScheduleStateResult().state?.sets[setId]?.checkCount == 7)
+    }
+
+    // MARK: - Helpers
+
+    /// A terminal destructive record whose index projection never happened:
+    /// `metadata.json` says `.success` with `indexPublicationPending: true`
+    /// and `index.jsonl` does not exist — exactly what a crash (or the
+    /// surfaced lock failure used to produce it here) leaves behind between
+    /// the two phases of `finish`.
+    private func makePendingDestructivePublication(paths: AppPaths) throws -> ActiveRun {
+        let store = RunStore(paths: paths, now: { Self.start })
+        var run = try store.begin(
+            kind: .prune, setId: Self.setId, destId: Self.destId, trigger: .manual
+        )
+        run.argvRedacted = ["restic", "forget", "--keep-last", "3"]
+        try store.markDestructiveLaunchAuthorized(run)
+        try FileManager.default.createDirectory(
+            at: paths.runsIndexLockFile, withIntermediateDirectories: true
+        )
+        do {
+            try store.finish(run, status: .success, resticExitCode: 0)
+            Issue.record("finish unexpectedly succeeded with an unusable index lock")
+        } catch {}
+        try FileManager.default.removeItem(at: paths.runsIndexLockFile)
+
+        let metadata = try store.metadata(runId: run.runId)
+        try #require(metadata.status == .success && metadata.indexPublicationPending == true)
+        return run
+    }
+
+    private func indices(
+        of trace: [FaultInjectingFileOperations.Operation],
+        where predicate: (FaultInjectingFileOperations.Operation) -> Bool
+    ) -> [Int] {
+        trace.enumerated().compactMap { predicate($0.element) ? $0.offset : nil }
+    }
+
+    /// Writes `metadata` directly, bypassing the store's atomic-write
+    /// machinery, purely to adjust an existing on-disk record (same
+    /// convention as `RunStoreTests.writeRawMetadata`).
+    private func writeRaw(_ metadata: RunMetadata, paths: AppPaths) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
+        encoder.dateEncodingStrategy = .custom { date, encoder in
+            var container = encoder.singleValueContainer()
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            try container.encode(formatter.string(from: date))
+        }
+        let data = try encoder.encode(metadata)
+        try data.write(to: paths.runMetadataFile(runId: metadata.runId))
+    }
+}
+
+/// Single-threaded monotonic tick for deterministic, distinct run starts.
+private final class TickBox: @unchecked Sendable {
+    private var value = 0
+    func next() -> Int {
+        value += 1
+        return value
+    }
+}

--- a/Core/Tests/ResticStationCoreTests/Support/FaultInjectingFileOperations.swift
+++ b/Core/Tests/ResticStationCoreTests/Support/FaultInjectingFileOperations.swift
@@ -1,0 +1,234 @@
+import Foundation
+@testable import ResticStationCore
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
+
+/// Programmable fault injector for `RunStoreFileOperations`, RunStore's
+/// narrow POSIX seam (see `docs/testing.md` §RunStore fault injection).
+///
+/// Three fault programs, plus an operation trace:
+///
+/// - ``crashAfter(operations:)`` — every seam call whose 1-based ordinal
+///   exceeds the given count silently does nothing while *reporting
+///   success*. That is the in-process analog of the process dying at that
+///   step boundary: nothing later reaches the disk, and no error path runs
+///   (a dead process has no error path). A test then "remounts" by building
+///   a fresh live `RunStore` over the same directory and running the
+///   recovery scan against whatever the crash left behind.
+/// - ``failSync(atCall:errno:)`` — one-shot fsync failures (`EINTR`,
+///   `EIO`, ...) at an exact fsync ordinal, counted across all descriptors.
+/// - ``tearWrite(toFileNamed:keepingBytes:)`` — the first write to the
+///   named file persists only a prefix, then the "process" crashes.
+///
+/// The ``trace`` labels each write/fsync by target — the file name it was
+/// opened under through the seam, or `.directory` (detected by `fstat`,
+/// because RunStore opens directory descriptors outside the seam) — so
+/// tests can assert the documented ordering contracts directly.
+///
+/// Model limits, deliberately: crashes replay at *seam-call* boundaries
+/// against the real filesystem. Losing un-fsynced page cache is not
+/// simulated, and `FileManager` calls (mkdir/remove) are not part of the
+/// seam, so a crash "between" one of those and a seam call is not
+/// representable.
+final class FaultInjectingFileOperations: @unchecked Sendable {
+    enum Target: Equatable {
+        case file(String)
+        case directory
+        case unknown
+    }
+
+    enum Operation: Equatable {
+        case openAt(String)
+        case write(Target)
+        case sync(Target)
+        case rename(from: String, to: String)
+        case unlink(String)
+    }
+
+    private let live = RunStoreFileOperations.live
+    private let lock = NSLock()
+    private var fdNames: [Int32: String] = [:]
+    private var operationOrdinal = 0
+    private var syncOrdinal = 0
+    private var recordedTrace: [Operation] = []
+    private var crashAfterOperationCount: Int?
+    private var oneShotSyncErrno: [Int: Int32] = [:]
+    private var pendingTear: (fileName: String, keepBytes: Int)?
+    private var crashed = false
+
+    // MARK: - Programming
+
+    func crashAfter(operations: Int) {
+        withLock { crashAfterOperationCount = operations }
+    }
+
+    /// The `call`-th fsync (1-based) fails once with `errno`; a retry of
+    /// the same fsync is the next ordinal and proceeds normally.
+    func failSync(atCall call: Int, errno code: Int32) {
+        withLock { oneShotSyncErrno[call] = code }
+    }
+
+    func tearWrite(toFileNamed fileName: String, keepingBytes keepBytes: Int) {
+        withLock { pendingTear = (fileName, keepBytes) }
+    }
+
+    // MARK: - Observation
+
+    /// Whether the programmed crash point was actually reached. A crash
+    /// matrix's largest argument asserts this is `false`, proving the
+    /// parameter range still covers the whole flow.
+    var didCrash: Bool { withLock { crashed } }
+    var operationCount: Int { withLock { operationOrdinal } }
+    var syncCallCount: Int { withLock { syncOrdinal } }
+    var trace: [Operation] { withLock { recordedTrace } }
+
+    // MARK: - The seam
+
+    var operations: RunStoreFileOperations {
+        RunStoreFileOperations(
+            openAt: { [self] directory, name, flags, mode in
+                handleOpenAt(directory, name, flags, mode)
+            },
+            write: { [self] fd, buffer, count in
+                handleWrite(fd, buffer, count)
+            },
+            sync: { [self] fd in
+                handleSync(fd)
+            },
+            renameAt: { [self] oldDirectory, oldName, newDirectory, newName in
+                handleRenameAt(oldDirectory, oldName, newDirectory, newName)
+            },
+            unlinkAt: { [self] directory, name in
+                handleUnlinkAt(directory, name)
+            }
+        )
+    }
+
+    // MARK: - Handlers
+
+    private func handleOpenAt(
+        _ directory: Int32, _ name: String, _ flags: Int32, _ mode: mode_t
+    ) -> Int32 {
+        let dead = advanceOperation(recording: .openAt(name))
+        let fd: Int32
+        if dead {
+            // The caller needs a descriptor it can close; writes and syncs
+            // against it are already no-ops via the crash flag.
+            fd = "/dev/null".withCString { open($0, O_RDWR) }
+        } else {
+            fd = live.openAt(directory, name, flags, mode)
+        }
+        if fd >= 0 {
+            withLock { fdNames[fd] = name }
+        }
+        return fd
+    }
+
+    private func handleWrite(_ fd: Int32, _ buffer: UnsafeRawPointer, _ count: Int) -> Int {
+        let target = classify(fd)
+        let dead = advanceOperation(recording: .write(target))
+        if dead { return count }
+        if let tear = withLock({ pendingTear }), target == .file(tear.fileName) {
+            let keep = min(max(tear.keepBytes, 0), count)
+            var written = 0
+            while written < keep {
+                let result = live.write(fd, buffer.advanced(by: written), keep - written)
+                if result <= 0 { break }
+                written += result
+            }
+            withLock {
+                pendingTear = nil
+                // Everything after the torn write is the dead process.
+                crashAfterOperationCount = operationOrdinal
+                crashed = true
+            }
+            return count
+        }
+        return live.write(fd, buffer, count)
+    }
+
+    private func handleSync(_ fd: Int32) -> Int32 {
+        let target = classify(fd)
+        let dead = advanceOperation(recording: .sync(target))
+        let injected: Int32? = withLock {
+            syncOrdinal += 1
+            return oneShotSyncErrno.removeValue(forKey: syncOrdinal)
+        }
+        if let code = injected {
+            setInjectedErrno(code)
+            return -1
+        }
+        if dead { return 0 }
+        return live.sync(fd)
+    }
+
+    private func handleRenameAt(
+        _ oldDirectory: Int32, _ oldName: String, _ newDirectory: Int32, _ newName: String
+    ) -> Int32 {
+        let dead = advanceOperation(recording: .rename(from: oldName, to: newName))
+        if dead { return 0 }
+        return live.renameAt(oldDirectory, oldName, newDirectory, newName)
+    }
+
+    private func handleUnlinkAt(_ directory: Int32, _ name: String) -> Int32 {
+        let dead = advanceOperation(recording: .unlink(name))
+        if dead { return 0 }
+        return live.unlinkAt(directory, name)
+    }
+
+    // MARK: - Internals
+
+    /// Records the operation, advances the ordinal, and reports whether the
+    /// operation lies beyond the programmed crash point.
+    private func advanceOperation(recording operation: Operation) -> Bool {
+        withLock {
+            operationOrdinal += 1
+            recordedTrace.append(operation)
+            if let crashPoint = crashAfterOperationCount, operationOrdinal > crashPoint {
+                crashed = true
+                return true
+            }
+            return false
+        }
+    }
+
+    private func classify(_ fd: Int32) -> Target {
+        if Self.isDirectory(fd) { return .directory }
+        if let name = withLock({ fdNames[fd] }) { return .file(name) }
+        return .unknown
+    }
+
+    private static func isDirectory(_ fd: Int32) -> Bool {
+        var info = stat()
+        #if canImport(Darwin)
+        guard Darwin.fstat(fd, &info) == 0 else { return false }
+        #elseif canImport(Glibc)
+        guard Glibc.fstat(fd, &info) == 0 else { return false }
+        #elseif canImport(Musl)
+        guard Musl.fstat(fd, &info) == 0 else { return false }
+        #endif
+        return (info.st_mode & S_IFMT) == S_IFDIR
+    }
+
+    private func setInjectedErrno(_ value: Int32) {
+        #if canImport(Darwin)
+        __error().pointee = value
+        #elseif canImport(Glibc)
+        __errno_location().pointee = value
+        #elseif canImport(Musl)
+        __errno_location().pointee = value
+        #endif
+    }
+
+    private func withLock<T>(_ body: () -> T) -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return body()
+    }
+}

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -62,6 +62,19 @@ ScheduleMath: table-driven tests per rule in scheduling.md — incl. DST spring-
 
 RunStore: temp-dir AppPaths; crash-recovery test (write `running` metadata with dead pid → recover marks `failed`); index append under contention (two FileLocks, in-process; flock is per-open-file-description — take care to open separately).
 
+### RunStore fault injection (crash-durability harness)
+
+`RunStoreFileOperations` is `RunStore`'s narrow POSIX seam — `openat`/`write`/`fsync`/`renameat`/`unlinkat`; directory fsyncs go through the same `sync` closure against descriptors RunStore opens with `O_DIRECTORY`. Production always uses `.live`; the internal `RunStore` initializer accepts a replacement, and behavior with `.live` is byte-identical to having no seam. `FaultInjectingFileOperations` (Core test support) is the programmable double on top of it:
+
+- `crashAfter(operations:)` — every seam call past the given 1-based ordinal silently no-ops while *reporting success*: the in-process analog of dying at that step boundary (nothing later reaches the disk, and no error path runs, because a dead process has no error path). The test then "remounts" — a fresh live `RunStore` over the same directory, the dead process's recorded pid rewritten to an unreachable one where the on-disk record still claims `.running` — and asserts the recovered view is consistent.
+- `failSync(atCall:errno:)` — one-shot fsync failures (`EINTR`, `EIO`, `ENOSPC`, …) at an exact fsync ordinal, counted across all descriptors.
+- `tearWrite(toFileNamed:keepingBytes:)` — the first write to the named file persists only a prefix, then the process "crashes".
+- an operation **trace**, each write/fsync labeled with the file name it was opened under through the seam or `.directory` (detected by `fstat`), used to assert the documented ordering contracts (write → fsync file → rename → fsync directory; pending marker before the index append it guards; marker cleared only after the projection's fsyncs) directly rather than inferring them from end states.
+
+`RunStoreCrashDurabilityTests` runs the crash matrix: every step boundary of `begin`, `markDestructiveLaunchAuthorized`, `finish` (destructive and not), and `recoverInterrupted` itself (each matrix's largest crash point asserts the flow completed, so a flow that grows new steps fails the coverage check loudly rather than silently shrinking the matrix); torn index appends at byte offsets including mid-UTF-8-scalar; and `EINTR` injected at every fsync site of both the publication and recovery flows.
+
+Model limits, deliberately: crashes replay at seam-call boundaries against the real filesystem — losing un-fsynced page cache is not simulated, and `FileManager` calls (mkdir/remove) are outside the seam, so a crash "between" one of those and a seam call is not representable. `ConfigStore`/`AppPaths` durability is tested separately (their own seams); `StateStore` promises only atomic replacement (temp + rename), covered by the stale-temp test in the same suite.
+
 ## Layer 2 — integration script (`scripts/integration-test.sh`)
 
 Real restic (from PATH; CI: `brew install restic` on macOS, and the **official 0.18.1 release binary** on Linux — deliberately *not* `apt-get install restic`, because Ubuntu 24.04 ships 0.16.4, below the 0.17.0 minimum `ResticDiscovery` enforces, so any scenario that relies on discovery rather than a pinned `resticPath` fails — since issue #50 with an explicit "restic 0.16.4 … is too old", previously with a flatly misleading "restic not found"). Runs on **both platforms** (extended for Linux by T29 / issue #31 — one script, so the two platforms cannot silently drift in what they cover). Contract:


### PR DESCRIPTION
## What changed

Two commits. **Commit 1** adds a fault-injection harness over the `RunStoreFileOperations` seam #129 introduced: `FaultInjectingFileOperations` can crash at any seam-call boundary (subsequent operations no-op — the in-process analog of process death), fail or EINTR any fsync by ordinal, tear a write at a byte offset, and record an ordering trace. `RunStoreCrashDurabilityTests` runs parameterized crash matrices over every step boundary of `begin`, `markDestructiveLaunchAuthorized`, `finish` (destructive and non-destructive), and `recoverInterrupted` itself, remounting a fresh store each time and asserting the recovered view is consistent; plus torn appends at offsets including mid-UTF-8-scalar, EINTR at every fsync site, and direct trace assertions of the documented write→fsync→rename→dir-fsync and marker-before-append orderings. Each matrix's largest crash point asserts flow completion, so a flow that grows steps fails coverage loudly. Documented in `docs/testing.md` with the model's limits (page-cache loss and mkdir/remove boundaries not representable). Production behavior untouched by this commit.

**Commit 2** fixes a real bug the matrix found: `readIndexEntriesRepairingTail` reads only with `pread`, so its descriptor's offset was still 0 when it wrote the terminating newline for a complete newline-less final record — the newline overwrote the first byte of `index.jsonl`, **destroying the oldest run record** while leaving the tail unterminated. Fix: `O_APPEND` on the repair descriptor. (`appendIndexEntry`'s descriptor already carried `O_APPEND` and was safe.)

Motivation: #129 drew 16 review findings because fsync-ordering/torn-write bugs were visible only to reviewers, never to tests (the ancestor-fsync gap was re-flagged three times). This harness makes that class locally testable — and found a live data-loss bug on its first run.

Per the in-flight-#130 conflict constraint, `ConfigStore` shares none of these seams and is untouched; seaming it is a follow-up after #130 lands.

## Review anchor

An independent review applies to an exact `(base SHA, head SHA)` pair. Changing
the base can change the diff even when the head commit is identical, so these
must be filled in and **re-stated after any rebase, force-push, or retarget** —
a review against a superseded pair does not carry forward.

- Base SHA: `213da09f4229f7bdbf2a5df462ea9e45079999e8`
- Head SHA: `e490c911afa9aa9cd68fbaf11a934203f4072933`
- Reviewed at this pair: Codex clean pass (thumbs-up), zero findings

## Checklist

- [x] Spec docs in `docs/` updated in this PR if behavior changed (they are normative) — `docs/testing.md` documents the harness; the tail-repair fix restores the behavior `data-model.md` already specifies (repair terminates the tail; no record loss)
- [x] `project.yml` edited rather than `ResticStation.xcodeproj` (it is generated) — neither touched
- [x] `Core/` and `Helper/` still build and test on Linux — no Darwin-only API unguarded (Musl import guards in tests); local `swift build`/`swift test` root 115/21 + Core 816/91 green
- [x] Invariants preserved — no acknowledged run record may be lost: previously violated by the repair path, now enforced and pinned by test
- [x] Destructive-path change? The run index feeds the destructive audit. Failure direction if the fix is wrong: recovery refuses/fails loudly under the crash matrix (fails closed); the *old* code silently destroyed the oldest record (failed open) — this PR moves the failure to the recoverable side.
- [x] Behavior change? Only the bug fix; blast radius swept — no doc, envelope, or copy describes the corrupted-head behavior
- [x] New/changed assertions red-checked — `recoveryTerminatesNewlinelessTailAtTheEnd` fails against the pre-fix flags (2 issues: head overwritten, tail unterminated); matrix coverage checks fail when a flow grows steps
- [x] New or extended safety invariant? Threat model stated: crash at every seam-call boundary of every publication flow, torn writes at arbitrary offsets (incl. mid-scalar), EINTR at every fsync, recovery-during-recovery idempotence, dead-pid `.running` records

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KtczdRBghL2e9CxbXbrNMC