### PR TITLE
Correct the disposition for a mirror the peer cannot purge

### DIFF
--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -316,8 +316,28 @@ permanently and mirrors read as stale forever.
 **What this deliberately does not chase.** A peer host still on an older
 config can write a snapshot containing the pattern after this host's watermark
 is set. That snapshot is attributable here only when the set names the peer in
-`machines`, and either way the peer heals it from its own watermark when it
-picks up the shared config. Under-purging is recoverable; over-purging is not.
+`machines`. On any destination the peer itself owns, it heals the snapshot from
+its own watermark once it picks up the shared config. Under-purging is
+recoverable; over-purging is not.
+
+**One case the peer cannot heal, and neither can this host.** A mirror scoped
+away from the peer by `machines` is reachable by the peer's *snapshots* but not
+by its *purge*. Host A applies rule R everywhere it owns and satisfies its
+watermark. Peer B, still stale, writes matching snapshot S to the shared
+primary. A's next run has no pending patterns, so its copy is unbounded —
+plain `restic copy --from-repo`, no explicit ids — and ferries S to A's mirror
+M. B then upgrades and rewrites S on the primary, but B has M disabled and
+never purges it; A will not either, because its watermark records R as applied
+and manual apply narrows by that same watermark and refuses a token with no
+pending pair. S stays on M until ordinary retention forgets it.
+
+This is still the under-purge direction and violates none of the invariants
+below, so it is accepted rather than chased: closing it means either an
+unbounded rewrite scan per tick (the cost this gating exists to avoid) or
+letting a host purge a destination it was configured not to touch. The remedy
+is manual and external — `restic forget` against the mirror, or briefly
+enabling M for a host that can purge it. Keeping the fleet's config in lockstep
+avoids the window entirely.
 
 A lost watermark is likewise recoverable by construction: the pattern reads as
 pending again, the next run re-runs the rewrite, restic reports a no-op (see


### PR DESCRIPTION
Follow-up #140 from the #139 pre-merge review. **Docs only** — no code, no
tests.

## What was wrong

`docs/scheduling.md` said a snapshot a stale peer writes after this host's
watermark is set is healed *"either way"*, because the peer purges it from its
own watermark once it picks up the shared config.

That holds only for destinations **the peer owns**. A mirror scoped away from
the peer by `machines` is reachable by the peer's *snapshots* but not by its
*purge*:

1. A satisfies its watermark for rule R.
2. Stale peer B writes matching snapshot S to the shared primary.
3. A has no pending patterns, so its copy is **unbounded** — `copySnapshotIDs`
   empty yields a bare `restic copy --from-repo`, which ferries every snapshot
   the mirror lacks, S included.
4. B upgrades and rewrites S on the primary — but has the mirror disabled, so
   never purges it.
5. A does not either: its watermark records R as applied, and manual apply
   narrows by that same watermark and refuses a token with no pending pair.

S stays on the mirror until ordinary retention forgets it.

## What is *not* changing

The disposition. This is the under-purge direction and violates none of the
§Purge safety invariants, so it stays accepted rather than chased — closing it
properly means either an unbounded rewrite scan per tick (exactly the cost this
gating exists to avoid) or letting a host purge a destination it was configured
not to touch.

What needed fixing was claiming a heal that cannot happen, and leaving a state
with no in-product exit without a remedy. Both are stated now, including the
manual one (`restic forget` against the mirror, or briefly enabling it for a
host that can purge it) and the fact that a lockstep fleet config avoids the
window entirely.

## Verification

Prose change to a normative doc; the mechanism was verified by reading the code
rather than taken from the review report — `BackupEngine.swift` step 7/8 gating
on `primaryPurgeSnapshotPrefixes.isEmpty`, and `ResticCommand.copy` appending
no ids when `snapshotIDs` is empty. No behavior change, so no test moves.

## Review anchor

- Base: `f61abdc04fee43a4047ad079b8e33ec39db11d9c`
- Head: `74ab47f49f2bb3d450f8deb3ecad9a0ce4194cef`

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EstNhm3JVkixiiJEQtxLtB