### PR TITLE
Reject "." and ".." components in configured source paths

### DIFF
--- a/App/Sources/Views/Sets/SetsCopy.swift
+++ b/App/Sources/Views/Sets/SetsCopy.swift
@@ -207,6 +207,13 @@ enum SetsCopy {
             return (.sources, "Add at least one folder or file to back up.")
         case .relativeSourcePath(_, let path):
             return (.sources, "Sources must be absolute paths — “\(path)” is not.")
+        case .nonCanonicalSourcePath(_, let path):
+            return (
+                .sources,
+                "“\(path)” contains “.” or “..”. Use the folder's real path instead — restic "
+                    + "stores the resolved path, so backups from this source could not be matched "
+                    + "back to it."
+            )
         case .emptyPurgeExcludePattern:
             return (
                 .purgeExcludes,
@@ -235,6 +242,13 @@ enum SetsCopy {
             return (
                 .sources,
                 "Sources must be absolute paths — “\(path)”, set for machine “\(machineId)” in config.json, is not."
+            )
+        case .nonCanonicalOverrideSourcePath(_, let machineId, let path):
+            return (
+                .sources,
+                "“\(path)”, set for machine “\(machineId)” in config.json, contains “.” or “..”. "
+                    + "Use the folder's real path instead — restic stores the resolved path, so "
+                    + "backups from this source could not be matched back to it."
             )
         case .notExactlyOnePrimaryDestinationForMachine(_, let machineId, let count):
             if count == 0 {

--- a/Core/Sources/ResticStationCore/Config/Models.swift
+++ b/Core/Sources/ResticStationCore/Config/Models.swift
@@ -614,6 +614,9 @@ public enum ConfigError: Error, Equatable, Sendable, CustomStringConvertible {
     case emptySources(setId: UUID)
     /// Invariant 3: a set has a non-absolute source path.
     case relativeSourcePath(setId: UUID, path: String)
+    /// Invariant 3: a set has a source path containing a `.` or `..`
+    /// component.
+    case nonCanonicalSourcePath(setId: UUID, path: String)
     /// Invariant 3: a set has an empty `purgeExcludes` pattern.
     case emptyPurgeExcludePattern(setId: UUID, index: Int)
     /// Invariant 4: a `Schedule` field is out of range.
@@ -626,6 +629,9 @@ public enum ConfigError: Error, Equatable, Sendable, CustomStringConvertible {
     case invalidMachineIdKey(setId: UUID, machineId: String)
     /// Invariant 6: an override `sources` entry is not an absolute path.
     case relativeOverrideSourcePath(setId: UUID, machineId: String, path: String)
+    /// Invariant 6: an override `sources` entry contains a `.` or `..`
+    /// component.
+    case nonCanonicalOverrideSourcePath(setId: UUID, machineId: String, path: String)
     /// Invariant 7: after resolving for `machineId`, a set that still runs
     /// there does not have exactly one primary destination — e.g. a config
     /// that disables the primary on some machine without disabling the set.
@@ -645,6 +651,10 @@ public enum ConfigError: Error, Equatable, Sendable, CustomStringConvertible {
             return "backup set \(setId) has no sources"
         case .relativeSourcePath(let setId, let path):
             return "backup set \(setId) has a non-absolute source path: \(path)"
+        case .nonCanonicalSourcePath(let setId, let path):
+            return "backup set \(setId) has a source path containing a \".\" or \"..\" component: \(path)"
+                + " — restic records the cleaned path in its snapshots, so snapshots from this source "
+                + "cannot be attributed to it and purge would refuse. Write the resolved path instead."
         case .emptyPurgeExcludePattern(let setId, let index):
             return "backup set \(setId) has an empty purgeExcludes pattern at position \(index) — "
                 + "remove the blank row; an empty pattern would be passed to restic as --exclude \"\""
@@ -659,6 +669,11 @@ public enum ConfigError: Error, Equatable, Sendable, CustomStringConvertible {
                 + "non-empty and use only lowercase letters, digits and '-'"
         case .relativeOverrideSourcePath(let setId, let machineId, let path):
             return "backup set \(setId) has a non-absolute source path for machine \"\(machineId)\": \(path)"
+        case .nonCanonicalOverrideSourcePath(let setId, let machineId, let path):
+            return "backup set \(setId) has a source path containing a \".\" or \"..\" component "
+                + "for machine \"\(machineId)\": \(path) — restic records the cleaned path in its "
+                + "snapshots, so snapshots from this source cannot be attributed to it and purge "
+                + "would refuse. Write the resolved path instead."
         case .notExactlyOnePrimaryDestinationForMachine(let setId, let machineId, let count):
             return "backup set \(setId) must have exactly one primary destination on machine \"\(machineId)\", "
                 + "found \(count) — disable the whole set for that machine instead of its primary destination"
@@ -708,6 +723,9 @@ extension AppConfig {
             for source in set.sources where !source.hasPrefix("/") {
                 throw ConfigError.relativeSourcePath(setId: set.id, path: source)
             }
+            for source in set.sources where Self.hasNonCanonicalComponent(source) {
+                throw ConfigError.nonCanonicalSourcePath(setId: set.id, path: source)
+            }
 
             // Invariant 3: no blank purge pattern. `excludes` is deliberately
             // left unvalidated — a stray blank row there is harmless noise —
@@ -737,6 +755,23 @@ extension AppConfig {
         try validateResolutions()
     }
 
+    /// Whether a configured source path carries a `.` or `..` component.
+    ///
+    /// restic lexically cleans the paths it records in a snapshot, while
+    /// `PurgePlan` deliberately does not resolve them — it has no filesystem
+    /// access, and resolving `..` lexically is wrong across a symlink. The
+    /// configured path and the recorded path therefore never compare equal,
+    /// so every snapshot from such a source is unattributable: purge finds a
+    /// plan that matches nothing while snapshots were declined, and fails
+    /// closed. Safe, but diagnosed at purge time from a message about
+    /// attribution. Refusing here makes it an obvious configuration error.
+    ///
+    /// Empty components are *not* refused: `//` and a trailing `/` already
+    /// compare equal, because `PurgePlan` normalizes both sides for those.
+    static func hasNonCanonicalComponent(_ path: String) -> Bool {
+        path.split(separator: "/").contains { $0 == "." || $0 == ".." }
+    }
+
     // MARK: Invariant 6 — override shape
 
     /// Every `machines` key on a set or on one of its destinations must be a
@@ -754,6 +789,13 @@ extension AppConfig {
             // reason rather than running a sourceless backup.
             for source in override.sources ?? [] where !source.hasPrefix("/") {
                 throw ConfigError.relativeOverrideSourcePath(setId: set.id, machineId: machineId, path: source)
+            }
+            for source in override.sources ?? [] where hasNonCanonicalComponent(source) {
+                throw ConfigError.nonCanonicalOverrideSourcePath(
+                    setId: set.id,
+                    machineId: machineId,
+                    path: source
+                )
             }
             // Same rule as invariant 4 for the schedule it replaces.
             if let schedule = override.schedule {

--- a/Core/Sources/ResticStationCore/Support/CLIError.swift
+++ b/Core/Sources/ResticStationCore/Support/CLIError.swift
@@ -761,6 +761,7 @@ extension CLIFailure {
              .emptyPurgeExcludePattern, .invalidSchedule,
              .invalidStalenessWarningDays, .invalidReadDataSubsetSlices,
              .invalidMachineIdKey, .relativeOverrideSourcePath,
+             .nonCanonicalSourcePath, .nonCanonicalOverrideSourcePath,
              .notExactlyOnePrimaryDestinationForMachine:
             // Every other case is a validation failure of a config this
             // build *can* read. They are one code on purpose: a caller

--- a/Core/Tests/ResticStationCoreTests/Config/ValidateTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Config/ValidateTests.swift
@@ -124,6 +124,42 @@ private func makeValidConfig() -> AppConfig {
         }
     }
 
+    /// restic records the lexically cleaned path in a snapshot, while
+    /// `PurgePlan` deliberately does not resolve `.`/`..`. The two never
+    /// compare equal, so snapshots from such a source are unattributable and
+    /// purge fails closed at run time with a message about attribution.
+    /// Refusing here makes it a configuration error instead.
+    @Test func nonCanonicalSourcePathThrows() {
+        for path in ["/srv/./data", "/srv/../srv/data", "/srv/data/..", "/."] {
+            var config = makeValidConfig()
+            config.sets[0].sources = [path]
+            #expect(throws: ConfigError.nonCanonicalSourcePath(setId: config.sets[0].id, path: path)) {
+                try config.validate()
+            }
+        }
+    }
+
+    /// Empty components stay legal: `PurgePlan` normalizes repeated and
+    /// trailing separators on both sides, so these already attribute
+    /// correctly. Refusing them would reject working configurations.
+    @Test func repeatedAndTrailingSeparatorsAreAccepted() throws {
+        for path in ["/srv//data", "/srv/data/", "/srv///data//"] {
+            var config = makeValidConfig()
+            config.sets[0].sources = [path]
+            try config.validate()
+        }
+    }
+
+    /// A dotfile is not a `.` component — the rule must not reject
+    /// `/home/me/.config`, which is an ordinary thing to back up.
+    @Test func dotfileSourcePathsAreAccepted() throws {
+        for path in ["/home/me/.config", "/srv/..data", "/srv/data.", "/srv/...."] {
+            var config = makeValidConfig()
+            config.sets[0].sources = [path]
+            try config.validate()
+        }
+    }
+
     // Invariant 4: Schedule fields in range.
 
     @Test func minute60Throws() {
@@ -289,6 +325,20 @@ private func makeValidConfig() -> AppConfig {
         config.sets[0].machines = ["linux-nas": BackupSetMachineOverride(sources: ["srv/data"])]
         #expect(throws: ConfigError.relativeOverrideSourcePath(
             setId: config.sets[0].id, machineId: "linux-nas", path: "srv/data"
+        )) {
+            try config.validate()
+        }
+    }
+
+    /// The override path re-validates what it replaces, so the `.`/`..` rule
+    /// must apply here too — otherwise a machine override is a way around it.
+    @Test func nonCanonicalOverrideSourcePathThrows() {
+        var config = makeValidConfig()
+        config.sets[0].machines = [
+            "linux-nas": BackupSetMachineOverride(sources: ["/srv/../srv/data"])
+        ]
+        #expect(throws: ConfigError.nonCanonicalOverrideSourcePath(
+            setId: config.sets[0].id, machineId: "linux-nas", path: "/srv/../srv/data"
         )) {
             try config.validate()
         }

--- a/Core/Tests/ResticStationCoreTests/Support/FailureClassificationTableTests.swift
+++ b/Core/Tests/ResticStationCoreTests/Support/FailureClassificationTableTests.swift
@@ -305,6 +305,7 @@ struct ConfigErrorTableTests {
              .emptyPurgeExcludePattern, .invalidSchedule,
              .invalidStalenessWarningDays, .invalidReadDataSubsetSlices,
              .invalidMachineIdKey, .relativeOverrideSourcePath,
+             .nonCanonicalSourcePath, .nonCanonicalOverrideSourcePath,
              .notExactlyOnePrimaryDestinationForMachine:
             return (.configInvalid, false)
         }
@@ -323,6 +324,8 @@ struct ConfigErrorTableTests {
         .invalidReadDataSubsetSlices(setId: setId, value: 1),
         .invalidMachineIdKey(setId: setId, machineId: "Bad_Slug"),
         .relativeOverrideSourcePath(setId: setId, machineId: "linux-nas", path: "Documents"),
+        .nonCanonicalSourcePath(setId: setId, path: "/srv/../srv/data"),
+        .nonCanonicalOverrideSourcePath(setId: setId, machineId: "linux-nas", path: "/srv/./data"),
         .notExactlyOnePrimaryDestinationForMachine(setId: setId, machineId: "linux-nas", count: 0),
     ]
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -160,11 +160,11 @@ public struct CheckPolicy: Codable, Equatable {
 
 1. Each set has **exactly one** destination with `isPrimary == true`.
 2. Set and destination UUIDs are unique across the whole config.
-3. `sources` non-empty for every set; every source is an absolute path.
+3. `sources` non-empty for every set; every source is an absolute path, and carries no `.` or `..` component. restic records the lexically cleaned path in a snapshot while `PurgePlan` deliberately does not resolve those components — it has no filesystem access, and resolving `..` lexically is wrong across a symlink — so a source written that way makes its own snapshots unattributable, and purge fails closed at run time. Repeated and trailing separators stay legal: both sides are normalized for those.
 4. `Schedule` fields in range (minute 0–59, hour 0–23, weekday 1–7, everyMinutes ≥ 5).
 5. Every `purgeExcludes` pattern is non-empty. A blank plain `excludes` entry is harmless noise, but a blank pattern must never become a history-changing purge rule.
 6. `stalenessWarningDays ≥ 1`; `readDataSubsetSlices` in 2...100.
-7. Every `machines` key is a valid `machineId` (see §machine.json for the charset), and every value an override supplies gets the same check as the field it replaces: override `sources` entries must be absolute, an override `schedule` must be in range. **Exception:** an override `sources` of `[]` is legal where a top-level `[]` is not — it is how a machine says "nothing to back up here", and resolution drops the set with a recorded reason rather than running a source-less backup.
+7. Every `machines` key is a valid `machineId` (see §machine.json for the charset), and every value an override supplies gets the same check as the field it replaces: override `sources` entries get the whole of invariant 3's path rule (absolute, no `.`/`..`), an override `schedule` must be in range. **Exception:** an override `sources` of `[]` is legal where a top-level `[]` is not — it is how a machine says "nothing to back up here", and resolution drops the set with a recorded reason rather than running a source-less backup.
 8. **Per machine:** if a set runs on a machine, exactly one of its destinations must be a primary that is enabled there. Disabling the primary is never a valid way to say "do not run here" — disable the whole set for that machine instead. Checked for every `machineId` the config mentions; machines with no overrides see the shared values, which invariant 1 already covers.
 
 A `machines` key that no `machine.json` in the fleet claims is **not** an error — machines come and go, and the config is shared. It is a warning surfaced by `config validate` (T27).


### PR DESCRIPTION
Follow-up #143 from the #139 pre-merge review.

## Why

restic records the lexically cleaned path in a snapshot. `PurgePlan`
deliberately does **not** resolve `.`/`..` — it has no filesystem access, and
resolving `..` lexically is wrong across a symlink. So the configured path and
the recorded path never compare equal, and every snapshot from such a source is
unattributable: the plan matches nothing while snapshots were declined, which
#139 made an explicit apply failure.

The behavior is already **safe** — it fails closed, loudly. It is just
diagnosed at purge time, from a message about attribution, for what is plainly
a configuration error. This moves the diagnosis to `config validate`.

## Scope

- Applied to **override** sources too. The override path re-validates what it
  replaces, so leaving it out would make a machine override a way around the
  rule.
- **Empty components stay legal.** `PurgePlan` normalizes repeated and trailing
  separators on both sides, so `/srv//data` and `/srv/data/` already attribute
  correctly; refusing them would reject working configurations.
- **Dotfiles are not `.` components.** `/home/me/.config`, `/srv/..data`,
  `/srv/data.` are all accepted — asserted, because that is the obvious way to
  get this rule wrong.

## Blast radius

`ConfigError`'s classification switches are exhaustive on purpose, so three
places failed to compile until each was given the new cases — the mechanism
from #134 doing its job:

| Site | Given |
|---|---|
| `CLIError.classify` | collapsed to `config_invalid`, like every sibling |
| `FailureClassificationTableTests` | table rows |
| `SetsCopy.fieldMessage` | inline messages in that screen's voice |

Note the GUI's source picker returns resolved paths, so this rule only bites a
hand-edited `config.json`.

## Verification

Red-checked — removing either check fails the new tests with *"an error was
expected but none was thrown"*, across all four path shapes and the override.

`./scripts/local-ci.sh` green, including the Linux musl cross-compile. **One
run reported a `Core package tests` failure** that did not reproduce in two
subsequent full runs or a standalone 911-test run; that is consistent with the
known intermittent in #116, not with this change. Flagging it rather than
quietly re-running until green.

## Review anchor

- Base: `f61abdc04fee43a4047ad079b8e33ec39db11d9c`
- Head: `fc32dff0ca5a518811cb02869743c59bade4845a`

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EstNhm3JVkixiiJEQtxLtB